### PR TITLE
Error on refresh with UTCAttribute in python 2.7

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -255,6 +255,9 @@ class UTCDateTimeAttribute(Attribute):
         """
         Takes a datetime object and returns a string
         """
+        if isinstance(value, unicode):
+            #already serialized
+            return value
         fmt = Delorean(value, timezone=UTC).datetime.strftime(DATETIME_FORMAT)
         return six.u(fmt)
 


### PR DESCRIPTION
A model that has a UTCDatetime attribute, if you do a model.refresh() you get the following error.

The problem is the attribute is a unicode object after being read and the function expects a datetime object.  I doubt this is the right way to fix this bug, but it should give a place to start.

My setup
Python 2.7.3
delorean and six I believe were installed when Pynamodb was.

You have any trouble reproducing this, let me know.
something like

```
class myModel(Model):
    table_name = 'sometabel'                                                                           
    name = UnicodeAttribute( hash_key=True )                            
    date_created = UTCDateTimeAttribute( range_key=True, default=datetime.utcnow() )
    avar = UnicodeAttribute()

myModel.create_table( read_capacity_units=2, write_capacity_units=1, wait=True)
m = myModel('bar')
m.save()
models = [m for m in myModel.scan(name__eq='bar')]
models[0].refresh()
```

oughta reproduce it.

 self._model.refresh()
  File "/usr/local/lib/python2.7/dist-packages/pynamodb/models.py", line 360, in refresh
    args, kwargs = self._get_save_args(attributes=False)
  File "/usr/local/lib/python2.7/dist-packages/pynamodb/models.py", line 346, in _get_save_args
    serialized = self.serialize(null_check=null_check)
  File "/usr/local/lib/python2.7/dist-packages/pynamodb/models.py", line 391, in serialize
    serialized = attr.serialize(value)
  File "/usr/local/lib/python2.7/dist-packages/pynamodb/attributes.py", line 258, in serialize
    fmt = Delorean(value, timezone=UTC).datetime.strftime(DATETIME_FORMAT)
  File "/usr/local/lib/python2.7/dist-packages/delorean/dates.py", line 175, in __init__
    if not is_datetime_naive(datetime):
  File "/usr/local/lib/python2.7/dist-packages/delorean/dates.py", line 30, in is_datetime_naive
    if dt.tzinfo is None:
AttributeError: 'unicode' object has no attribute 'tzinfo'

BTW, thanks for writing this.  Been looking for something like this for a while now.
