### PR TITLE
Fixed the issue of BOTO_DEFAULT_REGION

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -2,6 +2,7 @@
 Lowest level connection
 """
 import logging
+import os
 
 import six
 from botocore.session import get_session
@@ -178,7 +179,7 @@ class Connection(object):
         self.host = host
         if region:
             self.region = region
-        else:
+        elif 'BOTO_DEFAULT_REGION' not in os.environ:
             self.region = DEFAULT_REGION
 
     def __repr__(self):


### PR DESCRIPTION
Fixed the issue that botocore's BOTO_DEFAULT_REGION is overridden with PynamoDB's DEFAULT_REGION.
