### PR TITLE
	modified:   pynamodb/connection/base.py

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -299,7 +299,7 @@ class Connection(object):
             for index in global_secondary_indexes:
                 global_secondary_indexes_list.append({
                     INDEX_NAME: index.get(pythonic(INDEX_NAME)),
-                    KEY_SCHEMA: index.get(pythonic(KEY_SCHEMA)),
+                    KEY_SCHEMA: sorted(index.get(pythonic(KEY_SCHEMA)), key=lambda x: x.get(KEY_TYPE)),
                     PROJECTION: index.get(pythonic(PROJECTION)),
                     PROVISIONED_THROUGHPUT: index.get(pythonic(PROVISIONED_THROUGHPUT))
                 })
@@ -320,7 +320,7 @@ class Connection(object):
             for index in local_secondary_indexes:
                 local_secondary_indexes_list.append({
                     INDEX_NAME: index.get(pythonic(INDEX_NAME)),
-                    KEY_SCHEMA: index.get(pythonic(KEY_SCHEMA)),
+                    KEY_SCHEMA: sorted(index.get(pythonic(KEY_SCHEMA)), key=lambda x: x.get(KEY_TYPE)), 
                     PROJECTION: index.get(pythonic(PROJECTION)),
                 })
             operation_kwargs[pythonic(LOCAL_SECONDARY_INDEXES)] = local_secondary_indexes_list


### PR DESCRIPTION
The following ensures the key_schema in indexes is sorted appropriately because AWS's API requires the HASH key to come first. Depending on how the stars align, you may or may not end up with your local or global index key_schema out of order resulting in the following error when creating your table:

<code>pynamodb.exceptions.TableError: Failed to create table: {"__type":"com.amazon.coral.validate#ValidationException","message":"Invalid KeySchema: The first KeySchemaElement is not a HASH key type"</code>
