### PR TITLE
making Set Attribute serialization optional

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -25,7 +25,8 @@ class Attribute(object):
                  range_key=False,
                  null=None,
                  default=None,
-                 attr_name=None
+                 attr_name=None,
+                 serialized=True
                  ):
         self.default = default
         if null is not None:
@@ -34,6 +35,7 @@ class Attribute(object):
         self.is_range_key = range_key
         if attr_name is not None:
             self.attr_name = attr_name
+        self.serialized = serialized
 
     def __set__(self, instance, value):
         if isinstance(value, Attribute):
@@ -77,7 +79,10 @@ class SetMixin(object):
             except TypeError:
                 value = [value]
             if len(value):
-                return [json.dumps(val) for val in sorted(value)]
+                if self.serialized:
+                    return [json.dumps(val) for val in sorted(value)]
+                else:
+                    return value
         return None
 
     def deserialize(self, value):
@@ -85,7 +90,10 @@ class SetMixin(object):
         Deserializes a set
         """
         if value and len(value):
-            return set([json.loads(val) for val in value])
+            if self.serialized:
+                return set([json.loads(val) for val in value])
+            else:
+                return set(value)
 
 
 class BinaryAttribute(Attribute):


### PR DESCRIPTION
Leaves default of JSON serialization of objects as-is.
