### PR TITLE
Update setup.py so we only require ordereddict for Python2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,15 @@ if sys.argv[-1] == 'publish':
     print("  git push --tags")
     sys.exit()
 
+install_requires = [
+    'Delorean',
+    'six',
+    'botocore>=0.42.0'
+]
+
+if sys.version_info.major < 3:
+    install_requires.append('ordereddict')
+
 setup(
     name='pynamodb',
     version=__import__('pynamodb').__version__,
@@ -23,12 +32,7 @@ setup(
     zip_safe=False,
     license='MIT',
     keywords='python dynamodb amazon',
-    install_requires=[
-        'Delorean',
-        'six',
-        'ordereddict',
-        'botocore>=0.42.0',
-    ],
+    install_requires=install_requires,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
There's a requirement now on ordereddict, but ordereddict is only relevant for Python2 according to the PyPy page. If it's an install requirement for Python3 in setup.py it messes up making Debian / Ubuntu packages using the standard packaging tools.

This is just a very simple patch so that ordereddict is only required for Python with major version < 3.
