### PR TITLE
fixing dump/load to not do everything in memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*.pyc
+.*.swp
+*.log
+*~
+pynamodb.egg-info
+build/
+dist/
+MANIFEST
+.DS_Store
+.idea
+.tox
+.coverage
+*flymake.py

--- a/docs/backup_restore.rst
+++ b/docs/backup_restore.rst
@@ -26,11 +26,16 @@ To back up a table, you can simply use the provided `dump` method and write the 
 
     Thread.dump("thread_backup.json")
 
-Alternatively, you can write the contents to a string.
+Alternatively, you can write the contents to a list of strings or stdout:
 
 .. code-block:: python
 
-    content = Thread.dumps()
+    content = [item for item in Thread.dumps()]
+   
+    ...
+
+    for item in Thread.dumps():
+        print(item)
 
 
 Restoring from a backup
@@ -59,8 +64,12 @@ To restore items from a backup file, simply use the provided `load` method.
 
     Thread.load("thread_backup.json")
 
-Alternatively, you can also load the contents from a string.
+Alternatively, you can also load the contents from a JSON string or from a list of JSON strings:
 
 .. code-block:: python
 
     Thread.loads(content)
+   
+    ...
+
+    threads = [Thread.loads(item) for item in content]

--- a/pynamodb/tests/data.py
+++ b/pynamodb/tests/data.py
@@ -477,6 +477,7 @@ SERIALIZED_TABLE_DATA = [
                 "picture": {
                     "B": "aGVsbG8sIHdvcmxk"
                 },
+                "user_name": {"S": "foo"},
                 "zip_code": {"N": "88030"}
             }
         }
@@ -491,6 +492,7 @@ SERIALIZED_TABLE_DATA = [
                 "picture": {
                     "B": "aGVsbG8sIHdvcmxk"
                 },
+                "user_name": {"S": "foo"},
                 "zip_code": {"N": "88030"}
             }
         }

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ envlist = py26,py27,py33,py34,pypy
 
 [testenv]
 deps = -rrequirements.txt
-commands = nosetests
+commands = nosetests --exe {posargs}


### PR DESCRIPTION
As-is, the model load/dump functions will run out of memory for large tables, which makes it not very useful for non-trivial tables.
