### PR TITLE
Starting point for issue #132: update_item@action='delete' with value

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -360,7 +360,7 @@ class Model(AttributeContainer):
                 ACTION: action.upper() if action else None,
             }
         }
-        if action is not None and action.upper() != DELETE:
+        if action is not None and (action.upper() != DELETE or (value is not None and not(isinstance(value, str) and value.upper() == 'NULL'))):
             kwargs[pythonic(ATTR_UPDATES)][attribute_cls.attr_name][VALUE] = {ATTR_TYPE_MAP[attribute_cls.attr_type]: value}
         kwargs[pythonic(RETURN_VALUES)] = ALL_NEW
         kwargs.update(conditional_operator=conditional_operator)

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -410,8 +410,9 @@ class Model(AttributeContainer):
             attribute_cls = attrs[attr]
             action = params['action'] and params['action'].upper()
             attr_values = {ACTION: action}
-            if action != DELETE:
-                attr_values[VALUE] = self._serialize_value(attribute_cls, params['value'])
+            update_value = params.get('value')
+            if action != DELETE or (update_value is not None and not(isinstance(update_value, str))):
+                attr_values[VALUE] = self._serialize_value(attribute_cls, update_value)
 
             kwargs[pythonic(ATTR_UPDATES)][attribute_cls.attr_name] = attr_values
 

--- a/pynamodb/tests/data.py
+++ b/pynamodb/tests/data.py
@@ -19,6 +19,10 @@ SIMPLE_MODEL_TABLE_DATA = {
                 "AttributeName": "email",
                 "AttributeType": "S"
             },
+            {
+                "AttributeName": "numbers",
+                "AttributeType": "NS"
+            },
         ],
         "CreationDateTime": 1.363729002358E9,
         "ItemCount": 0,

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -1516,6 +1516,40 @@ class ModelTestCase(TestCase):
             deep_eq(args, params, _assert=True)
 
 
+    def test_update_item_delete_from_set(self):
+        with patch(PATCH_METHOD) as req:
+            req.return_value = SIMPLE_MODEL_TABLE_DATA
+            item = SimpleUserModel('bar', email='bar', numbers=set([1, 2, 3]))
+
+        with patch(PATCH_METHOD) as req:
+            req.return_value = {}
+            item.save()
+
+        with patch(PATCH_METHOD) as req:
+            req.return_value = {
+                ATTRIBUTES: {
+                    'numbers': {
+                        'NS': ['1', '3']
+                    }
+                }
+            }
+            item.update_item('numbers', value=[2], action='delete')
+            args = req.call_args[0][1]
+            params = {
+                'TableName': 'SimpleModel',
+                'ReturnValues': 'ALL_NEW',
+                'Key': {
+                    'user_name': {
+                        'S': 'bar'
+                    },
+                },
+                'ExpressionAttributeNames': {'#0': 'numbers'},
+                'ExpressionAttributeValues': {':0': {'NS': ['2']}},
+                'UpdateExpression': 'DELETE #0 :0',
+                'ReturnConsumedCapacity': 'TOTAL'
+            }
+            deep_eq(args, params, _assert=True)
+
     def test_save(self):
         """
         Model.save

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -1550,6 +1550,45 @@ class ModelTestCase(TestCase):
             }
             deep_eq(args, params, _assert=True)
 
+    def test_update_delete_from_set(self):
+        with patch(PATCH_METHOD) as req:
+            req.return_value = SIMPLE_MODEL_TABLE_DATA
+            item = SimpleUserModel('bar', email='bar', numbers=set([1, 2, 3]))
+
+        with patch(PATCH_METHOD) as req:
+            req.return_value = {}
+            item.save()
+
+        with patch(PATCH_METHOD) as req:
+            req.return_value = {
+                ATTRIBUTES: {
+                    'numbers': {
+                        'NS': ['1', '3']
+                    }
+                }
+            }
+            item.update({
+                'numbers': {
+                    'action': 'delete',
+                    'value': [2],
+                }
+            })
+            args = req.call_args[0][1]
+            params = {
+                'TableName': 'SimpleModel',
+                'ReturnValues': 'ALL_NEW',
+                'Key': {
+                    'user_name': {
+                        'S': 'bar'
+                    },
+                },
+                'ExpressionAttributeNames': {'#0': 'numbers'},
+                'ExpressionAttributeValues': {':0': {'NS': ['2']}},
+                'UpdateExpression': 'DELETE #0 :0',
+                'ReturnConsumedCapacity': 'TOTAL'
+            }
+            deep_eq(args, params, _assert=True)
+
     def test_save(self):
         """
         Model.save


### PR DESCRIPTION
Changes to update_item on both the model and connection, as well as a unit test, to restore the correct behavior of allowing deletion of items from a set while still preserving the ability to delete without having to specify a value when the entire set should be removed.

This fixes a bug since 1.4.4 where if you had a user with a set-valued attribute like:

```
user = UserModel(1, nicknames={'nick1',  'nick2', 'DELETEME'})
user.save()
```

Then if you tried to remove a nickname from the set, with:

```
user.update_item('nicknames', value=['DELETEME'], action='delete')
```

The query sent to DynamoDB is as if no value were provided, and DynamoDB removes the nicknames attribute rather than just removing the item from the set.
