### PR TITLE
Add the ability to treat Model instances as dictionaries

### DIFF
--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -2548,3 +2548,46 @@ class ModelTestCase(TestCase):
         for k in rs:
             self.assertTrue(k in results)
 
+    def test_model_as_dict(self):
+        with patch(PATCH_METHOD) as req:
+            req.return_value = MODEL_TABLE_DATA
+            item = UserModel('foo', 'bar')
+
+            # Test keys that should not be considered "in" the model.
+            self.assertFalse('garbage' in item)
+            self.assertFalse('zip_code' in item)
+            self.assertFalse('user_name' in item)
+
+            # Test keys that should be considered "in" the model.
+            item.zip_code = 0
+            self.assertTrue('zip_code' in item)
+            self.assertTrue('custom_user_name' in item)
+
+            # Test dictionary-style lookup.
+            self.assertEquals(item['custom_user_name'], 'foo')
+            self.assertEquals(item['user_id'], 'bar')
+            with self.assertRaises(KeyError):
+                value = item['garbage']
+
+            with self.assertRaises(KeyError):
+                value = item['user_name']
+
+            # Test dictionary-style setting.
+            item['custom_user_name'] = 'faz'
+            item['user_id'] = 'baz'
+            self.assertEquals(item.custom_user_name, 'faz')
+            self.assertEquals(item.user_id, 'baz')
+            with self.assertRaises(KeyError):
+                item['garbage'] = 'garbage'
+
+            with self.assertRaises(KeyError):
+                item['user_name'] = 'faz'
+
+            # Test conversion to a dictionary.
+            item_dict = dict(item)
+            self.assertEquals(item_dict,
+                              {'custom_user_name': 'faz',
+                               'user_id': 'baz',
+                               'zip_code': 0,
+                               'email': 'needs_email',
+                               'callable_field': 42})


### PR DESCRIPTION
This change allows Model instances to be treated as dictionaries mapping attribute names to values. There are two motivations for this change:
1. Make it easier to replace or mix boto3 with PynamoDB.
2. Make it easy to convert a model to a language-agnostic format (probably JSON).

Regarding the first motivation, boto3 operations that get table entries return the entries as dictionaries mapping attribute names to values. The following is a simplified code snippet from the product that I'm working on. It originally used boto3, but it now uses PynamoDB. Its continued use of "in" to check whether "optionalAttribute" has been set and its continued use of dictionary-style lookups of the "firstName," "lastName," and "email" attributes demonstrate how this change can make switching from boto3 to PynamoDB easier.

```
def set_optional_attribute_in_user(user_id, new_attribute_value):
    user = User.get(caller_id)  # This used to be the 'Item' from a boto3 'get_item' operation.
    if 'optionalAttribute' in user:
        raise ValueError('The user already has this attribute.')

    x = user['firstName']
    y = user['lastName']
    z = user['email']
    . . . do some other work . . .
    return dict(user)  # This used to be "return user"
```

Regarding the second motivation, I'm using Lambda and DynamoDB as the backend for an iOS app. The app, written in Swift, asks a Lambda function, written in Python, to get data from DynamoDB, and the Lambda function responds with JSON dictionaries mapping models' attributes to values. I believe that the existing functions to convert PynamoDB models to JSON, such as _serialize and _get_json, do not provide what I need. Those functions produce results that match the way models are stored inside DynamoDB, while what I need is an abstraction away from DynamoDB. 

With this change, one can call dict() on a model to get a Python dictionary mapping attribute names to values, and that Python dictionary can easily be converted to JSON. Lambda does it automatically if your function returns a Python dictionary. Any applications that use Python to access a DynamoDB database but need to manipulate the models in other programming languages may find this functionality useful.
