### PR TITLE
Skip null check when deletion

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1076,7 +1076,7 @@ class Model(with_metaclass(MetaModel)):
         """
         Returns the proper arguments for deleting
         """
-        serialized = self._serialize()
+        serialized = self._serialize(null_check=False)
         hash_key = serialized.get(HASH)
         range_key = serialized.get(RANGE, None)
         hash_keyname = self._get_meta_data().hash_keyname


### PR DESCRIPTION
Not needed null check in deletion.

```
class Foo(GlobalSecondaryIndex):
   foo = attributes.UnicodeAttribute(hash_key=True)
   created = attributes.UTCDateTimeAttribute(range_key=True)

class Bar(Model):
    id = attributes.UnicodeAttribute(hash_key=True)
    buzz = attributes.UnicodeAttribute()

    foo = attributes.UnicodeAttribute()
    created = attributes.UTCDateTimeAttribute()   
    foo_index = Foo()

with Bar.batch_write() as batch:
    for bar in Bar.foo_index.query('foo', created_lt=datetime.now() - timedelta(days=365)):
        batch.delete(bar)
```

Following error occurred

```
ValueError: Attribute 'buzz' cannot be None
```
