### PR TITLE
Replace Delorean with dateutil, as dateutil is brought in by botocore

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -5,7 +5,8 @@ import six
 from six import with_metaclass
 import json
 from base64 import b64encode, b64decode
-from delorean import Delorean, parse
+from dateutil.parser import parse
+from dateutil.tz import tzutc
 from pynamodb.constants import (
     STRING, STRING_SHORT, NUMBER, BINARY, UTC, DATETIME_FORMAT, BINARY_SET, STRING_SET, NUMBER_SET,
     MAP, MAP_SHORT, LIST, LIST_SHORT, DEFAULT_ENCODING, BOOLEAN, ATTR_TYPE_MAP, NUMBER_SHORT, NULL
@@ -329,14 +330,16 @@ class UTCDateTimeAttribute(Attribute):
         """
         Takes a datetime object and returns a string
         """
-        fmt = Delorean(value, timezone=UTC).datetime.strftime(DATETIME_FORMAT)
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=tzutc())
+        fmt = value.astimezone(tzutc()).strftime(DATETIME_FORMAT)
         return six.u(fmt)
 
     def deserialize(self, value):
         """
         Takes a UTC datetime string and returns a datetime object
         """
-        return parse(value, dayfirst=False).datetime
+        return parse(value)
 
 
 class NullAttribute(Attribute):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -159,7 +159,7 @@ class UTCDateTimeAttributeTestCase(TestCase):
         """
         tstamp = datetime.now()
         attr = UTCDateTimeAttribute()
-        self.assertEqual(attr.serialize(tstamp), tstamp.strftime(DATETIME_FORMAT))
+        self.assertEqual(attr.serialize(tstamp), tstamp.replace(tzinfo=UTC).strftime(DATETIME_FORMAT))
 
 
 class BinaryAttributeTestCase(TestCase):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -1,21 +1,29 @@
 """
 pynamodb attributes tests
 """
-import six
 import json
+import six
+
 from base64 import b64encode
 from datetime import datetime
-from delorean import Delorean
+
+from dateutil.parser import parse
+from dateutil.tz import tzutc
+
 from mock import patch
+
 from pynamodb.compat import CompatTestCase as TestCase
 from pynamodb.constants import UTC, DATETIME_FORMAT
 from pynamodb.models import Model
+
 from pynamodb.attributes import (
     BinarySetAttribute, BinaryAttribute, NumberSetAttribute, NumberAttribute,
     UnicodeAttribute, UnicodeSetAttribute, UTCDateTimeAttribute, BooleanAttribute, LegacyBooleanAttribute,
     MapAttribute, ListAttribute,
     JSONAttribute, DEFAULT_ENCODING, NUMBER, STRING, STRING_SET, NUMBER_SET, BINARY_SET,
     BINARY, MAP, LIST, BOOLEAN)
+
+UTC = tzutc()
 
 
 class AttributeTestModel(Model):
@@ -126,22 +134,22 @@ class UTCDateTimeAttributeTestCase(TestCase):
         """
         UTCDateTimeAttribute.deserialize
         """
-        tstamp = Delorean(timezone=UTC).datetime
+        tstamp = datetime.now(UTC)
         attr = UTCDateTimeAttribute()
         self.assertEqual(
             tstamp,
-            attr.deserialize(Delorean(tstamp, timezone=UTC).datetime.strftime(DATETIME_FORMAT)),
+            attr.deserialize(tstamp.strftime(DATETIME_FORMAT)),
         )
 
     def test_utc_date_time_deserialize_parse_args(self):
         """
         UTCDateTimeAttribute.deserialize
         """
-        tstamp = Delorean(timezone=UTC).datetime
+        tstamp = datetime.now(UTC)
         attr = UTCDateTimeAttribute()
 
         with patch('pynamodb.attributes.parse') as parse:
-            attr.deserialize(Delorean(tstamp, timezone=UTC).datetime.strftime(DATETIME_FORMAT))
+            attr.deserialize(tstamp.strftime(DATETIME_FORMAT))
 
             parse.assert_called_with(tstamp.strftime(DATETIME_FORMAT))
 
@@ -151,7 +159,7 @@ class UTCDateTimeAttributeTestCase(TestCase):
         """
         tstamp = datetime.now()
         attr = UTCDateTimeAttribute()
-        self.assertEqual(attr.serialize(tstamp), Delorean(tstamp, timezone=UTC).datetime.strftime(DATETIME_FORMAT))
+        self.assertEqual(attr.serialize(tstamp), tstamp.strftime(DATETIME_FORMAT))
 
 
 class BinaryAttributeTestCase(TestCase):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -143,7 +143,7 @@ class UTCDateTimeAttributeTestCase(TestCase):
         with patch('pynamodb.attributes.parse') as parse:
             attr.deserialize(Delorean(tstamp, timezone=UTC).datetime.strftime(DATETIME_FORMAT))
 
-            parse.assert_called_with(tstamp.strftime(DATETIME_FORMAT), dayfirst=False)
+            parse.assert_called_with(tstamp.strftime(DATETIME_FORMAT))
 
     def test_utc_date_time_serialize(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 sphinx-rtd-theme==0.1.8
 mock==1.0.1
-Delorean==0.4.5
 botocore==1.1.2
 flake8==2.4.1
 nose==1.3.7

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.argv[-1] == 'publish':
 install_requires = [
     'six',
     'botocore>=1.0.0',
-    'python-dateutil>=2.6.0',
+    'python-dateutil>=2.1,<3.0.0',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ if sys.argv[-1] == 'publish':
     sys.exit()
 
 install_requires = [
-    'Delorean',
     'six',
     'botocore>=1.0.0'
 ]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ if sys.argv[-1] == 'publish':
 
 install_requires = [
     'six',
-    'botocore>=1.0.0'
+    'botocore>=1.0.0',
+    'python-dateutil>=2.6.0',
 ]
 
 setup(


### PR DESCRIPTION
No point depending on two libs that provide the same services.