### PR TITLE
add a provision to get LastEvaluatedKey from last executed query, 

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -205,6 +205,7 @@ class Model(AttributeContainer):
     _index_classes = None
     _throttle = NoThrottle()
     DoesNotExist = DoesNotExist
+    _last_query_evaluated_key = None
 
     def __init__(self, hash_key=None, range_key=None, **attrs):
         """
@@ -618,6 +619,7 @@ class Model(AttributeContainer):
         cls._throttle.add_record(data.get(CONSUMED_CAPACITY))
 
         last_evaluated_key = data.get(LAST_EVALUATED_KEY, None)
+        cls._set_last_query_evaluated_key(last_evaluated_key)
 
         for item in data.get(ITEMS):
             if limit is not None:
@@ -638,6 +640,7 @@ class Model(AttributeContainer):
                     limit -= 1
                 yield cls.from_raw_data(item)
             last_evaluated_key = data.get(LAST_EVALUATED_KEY, None)
+            cls._set_last_query_evaluated_key(last_evaluated_key)
 
     @classmethod
     def rate_limited_scan(cls,
@@ -1235,6 +1238,22 @@ class Model(AttributeContainer):
                 if record.get(TABLE_NAME) == cls.Meta.table_name:
                     cls._throttle.add_record(record.get(CAPACITY_UNITS))
                     break
+
+    @classmethod
+    def _set_last_query_evaluated_key(cls, key):
+        """
+        Sets _last_query_evaluated_key attribute value.
+        :param key: _last_evaluated_key string from last execution data
+        """
+        cls._last_query_evaluated_key = key
+
+    @classmethod
+    def get_last_query_evaluated_key(cls):
+        """
+        Returns the _last_query_evaluated_key from last query() on this
+        model
+        """
+        return cls._last_query_evaluated_key
 
     @classmethod
     def get_throttle(cls):


### PR DESCRIPTION
so we can paginate manually. We are building an api where we would like to send the limit and page_no in and would like to return a chunk of data. 
eg: 
GET /posts/user1?limit=5
```{
items : [...],
"pagination": {
   "type": "standard",
  "nextPageKey": "abc",
  "limit": 5,
  "total_records": 7
 } }
```
GET /posts/user1?nextPageKey=abc&limit=5
```{
items : [...],
"pagination": {
   "type": "standard",
  "nextPageKey": "",
  "limit": 5,
  "total_records": 2
 } }
```
In order to make 2 queries() that can continue data set, we need a way to get the last querie's `LastEvaluatedKey` value.