### PR TITLE
Attribute List and Map support UTCDateTimeAttribute

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -11,6 +11,7 @@ from pynamodb.constants import (
     MAP, MAP_SHORT, LIST, LIST_SHORT, DEFAULT_ENCODING, BOOLEAN, ATTR_TYPE_MAP, NUMBER_SHORT, NULL
 )
 import collections
+from datetime import datetime
 
 
 class Attribute(object):
@@ -601,6 +602,7 @@ SERIALIZE_CLASS_MAP = {
     float: NumberAttribute(),
     int: NumberAttribute(),
     str: UnicodeAttribute(),
+    datetime: UTCDateTimeAttribute(),
 }
 
 
@@ -612,6 +614,7 @@ SERIALIZE_KEY_MAP = {
     float: NUMBER_SHORT,
     int: NUMBER_SHORT,
     str: STRING_SHORT,
+    datetime: STRING_SHORT,
 }
 
 


### PR DESCRIPTION
I've used UTCDateTimeAttribute in MapAttribute and got this error.
Error: Unknown value: <type 'datetime.datetime'>

I've figure out that there is no datetime support in SERIALIZE_CLASS_MAP when serialize in Map or List.

Example
```python
from pynamodb.models import Model
from pynamodb.attributes import ListAttribute, NumberAttribute, UnicodeAttribute, MapAttribute, UTCDateTimeAttribute
from datetime import datetime

# define table
class SiteLDevice(MapAttribute):
	name = UnicodeAttribute(null=True)
	created = UTCDateTimeAttribute(null=False)

class Site(Model):
	"""
	A Site
	"""
	class Meta:
		table_name = "Site3"
		region = 'ap-southeast-1'
	
	name = UnicodeAttribute(range_key=True)
	server = UnicodeAttribute(hash_key=True)
	devices = ListAttribute(of=SiteLDevice)

# create table
Site.create_table(read_capacity_units=1, write_capacity_units=1)

# create new site
site = Site()
site.name = 'test'
site.server = 'testserver.abc.com'
site.devices = [ SiteLDevice(name='device 1', created= datetime.now()) ]
site.save()
```