### PR TITLE
ListAttribute & MapAttribute serialize use correct class like deserialize

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -471,9 +471,12 @@ class MapAttribute(AttributeContainer, Attribute):
         for k in values:
             v = values[k]
             attr_class = self._get_serialize_class(k, v)
-            attr_key = _get_key_for_serialize(v)
             if attr_class is None:
                 continue
+            if attr_class.attr_type:
+                attr_key = ATTR_TYPE_MAP[attr_class.attr_type]
+            else:
+                attr_key = _get_key_for_serialize(v)
 
             # If this is a subclassed MapAttribute, there may be an alternate attr name
             attr = self._get_attributes().get(k)
@@ -577,11 +580,14 @@ class ListAttribute(Attribute):
         """
         rval = []
         for v in values:
-            class_for_serialize = (self.element_type()
-                                   if self.element_type
-                                   else _get_class_for_serialize(v))
-            attr_key = _get_key_for_serialize(v)
-            rval.append({attr_key: class_for_serialize.serialize(v)})
+            attr_class = (self.element_type()
+                          if self.element_type
+                          else _get_class_for_serialize(v))
+            if attr_class.attr_type:
+                attr_key = ATTR_TYPE_MAP[attr_class.attr_type]
+            else:
+                attr_key = _get_key_for_serialize(v)
+            rval.append({attr_key: attr_class.serialize(v)})
         return rval
 
     def deserialize(self, values):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -470,7 +470,7 @@ class MapAttribute(AttributeContainer, Attribute):
         rval = {}
         for k in values:
             v = values[k]
-            attr_class = _get_class_for_serialize(v)
+            attr_class = self._get_serialize_class(k, v)
             attr_key = _get_key_for_serialize(v)
             if attr_class is None:
                 continue
@@ -510,6 +510,12 @@ class MapAttribute(AttributeContainer, Attribute):
         for key, value in six.iteritems(self.attribute_values):
             result[key] = value.as_dict() if isinstance(value, MapAttribute) else value
         return result
+
+    @classmethod
+    def _get_serialize_class(cls, key, value):
+        if not cls.is_raw():
+            return cls._get_attributes().get(key)
+        return _get_class_for_serialize(value)
 
     @classmethod
     def _get_deserialize_class(cls, key, value):
@@ -571,9 +577,11 @@ class ListAttribute(Attribute):
         """
         rval = []
         for v in values:
-            attr_class = _get_class_for_serialize(v)
+            class_for_serialize = (self.element_type()
+                                   if self.element_type
+                                   else _get_class_for_serialize(v))
             attr_key = _get_key_for_serialize(v)
-            rval.append({attr_key: attr_class.serialize(v)})
+            rval.append({attr_key: class_for_serialize.serialize(v)})
         return rval
 
     def deserialize(self, values):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -696,6 +696,7 @@ class MapAndListAttributeTestCase(TestCase):
         class Person(MapAttribute):
             name = UnicodeAttribute()
             age = NumberAttribute()
+            extra_arbitrary_data = JSONAttribute()
 
             def __lt__(self, other):
                 return self.name < other.name
@@ -707,10 +708,14 @@ class MapAndListAttributeTestCase(TestCase):
         person1 = Person()
         person1.name = 'john'
         person1.age = 40
+        person1.extra_arbitrary_data = {'married': True}
 
         person2 = Person()
         person2.name = 'Dana'
         person2.age = 41
+        person2.extra_arbitrary_data = {'net_income': 200000,
+                                        'dog': 'Fido'}
+
         inp = [person1, person2]
 
         list_attribute = ListAttribute(default=[], of=Person)

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -641,6 +641,20 @@ class MapAttributeTestCase(TestCase):
         self.assertEqual(json.dumps({'map_attr': {'foo': 'bar'}}),
                          json.dumps(item.typed_map.as_dict()))
 
+    def test_serialize_datetime(self):
+
+        class CustomMapAttribute(MapAttribute):
+            date_attr = UTCDateTimeAttribute()
+
+        cm = CustomMapAttribute(date_attr=datetime(2017, 1, 1))
+        serialized_datetime = cm.serialize(cm)
+        expected_serialized_value = {
+            'date_attr': {
+                'S': u'2017-01-01T00:00:00.000000+0000'
+            }
+        }
+        self.assertEquals(serialized_datetime, expected_serialized_value)
+
 
 class MapAndListAttributeTestCase(TestCase):
 


### PR DESCRIPTION
This PR updates `ListAttribute` so that it uses the `serialize` method from its type (if provided) and updates `MapAttribute` so that it uses the `serialize` methods of its attributes. This mirros the behavior in the `deserialize` methods.

This means using a `ListAttribute` with an `of` with a custom `Attribute` caused an unexpected behavior. For example:

``` python
from pynamodb.attributes import Attribute, UnicodeAttribute, MapAttribute, ListAttribute
from pynamodb.constants import STRING


class CustomAttribute(Attribute):
    attr_type = STRING

    def serialize(self, value):
        print('CustomAttribute.serialize')
        return value

    def deserialize(self, value):
        print('CustomAttribute.deserialize')
        return value


class DogAttribute(MapAttribute):
    name = UnicodeAttribute()
    custom = CustomAttribute()


if __name__ == '__main__':
    list_of_dogs = [
        DogAttribute(name='Fido', custom='test'),
        DogAttribute(name='Spot', custom='other-test'),
    ]
    list_attribute = ListAttribute(of=DogAttribute)
    ser = list_attribute.serialize(list_of_dogs)
    list_attribute.deserialize(ser)
```

Without this PR `CustomAttribute.serialize` is never called. The output is:

```
CustomAttribute.deserialize
CustomAttribute.deserialize
```

With this PR the output is:

```
CustomAttribute.serialize
CustomAttribute.serialize
CustomAttribute.deserialize
CustomAttribute.deserialize
```
