### PR TITLE
Speedup UTCDateTimeAttribute deserialization

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -395,7 +395,9 @@ class UTCDateTimeAttribute(Attribute):
         """
         Takes a UTC datetime string and returns a datetime object
         """
-        #  First attempt to parse the datetime with the
+        # First attempt to parse the datetime with the datetime format used
+        # by default when storing UTCDateTimeAttributes.  This is signifantly
+        # faster than always going through dateutil.
         try:
             return datetime.strptime(value, DATETIME_FORMAT)
         except ValueError:

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -5,6 +5,7 @@ import six
 from six import add_metaclass
 import json
 from base64 import b64encode, b64decode
+from datetime import datetime
 from dateutil.parser import parse
 from dateutil.tz import tzutc
 from pynamodb.constants import (
@@ -394,7 +395,11 @@ class UTCDateTimeAttribute(Attribute):
         """
         Takes a UTC datetime string and returns a datetime object
         """
-        return parse(value)
+        #  First attempt to parse the datetime with the
+        try:
+            return datetime.strptime(value, DATETIME_FORMAT)
+        except ValueError:
+            return parse(value)
 
 
 class NullAttribute(Attribute):


### PR DESCRIPTION
`UTCDateTimeAttribute.deserialize` spends most of it's time inside of dateutil which attempts to first
guess the format.  In most cases PynamoDB will have written the data to begin with, so we can first
optimistically assume the data is stored in DATETIME_FORMAT before falling back to dateutil.

This ~4.5 times faster than always going through dateutil.

```python
from dateutil.parser import parse
import datetime
from dateutil.tz import tzutc

DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f%z'
now_str = datetime.datetime.now().replace(tzinfo=tzutc()).strftime(DATETIME_FORMAT)

%timeit parse(now_str) # 116 µs ± 9.46 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
%timeit datetime.datetime.strptime(now_str, DATETIME_FORMAT) # 26 µs ± 7.53 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```