### PR TITLE
Fix attribute discovery with Model inheritance

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -77,8 +77,18 @@ class AttributeContainer(object):
         """
         cls._attributes = {}
         cls._dynamo_to_python_attrs = {}
-        for item_name, instance in six.iteritems(cls.__dict__):
-            if issubclass(type(instance), (Attribute,)):
+
+        for item_name in dir(cls):
+            try:
+                item_cls = getattr(getattr(cls, item_name), "__class__", None)
+            except AttributeError:
+                continue
+
+            if item_cls is None:
+                continue
+
+            if issubclass(item_cls, (Attribute, )):
+                instance = getattr(cls, item_name)
                 cls._attributes[item_name] = instance
                 if instance.attr_name is not None:
                     cls._dynamo_to_python_attrs[instance.attr_name] = item_name

--- a/pynamodb/tests/data.py
+++ b/pynamodb/tests/data.py
@@ -1326,3 +1326,30 @@ EXPLICIT_RAW_MAP_MODEL_AS_SUB_MAP_IN_TYPED_MAP_ITEM_DATA = {
         }
     }
 }
+
+DOG_TABLE_DATA = {
+    "Table": {
+        "AttributeDefinitions": [
+            {
+                "AttributeName": "name",
+                "AttributeType": "S"
+            }
+        ],
+        "CreationDateTime": 1.363729002358E9,
+        "ItemCount": 42,
+        "KeySchema": [
+            {
+                "AttributeName": "name",
+                "KeyType": "HASH"
+            }
+        ],
+        "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 5,
+            "WriteCapacityUnits": 5
+        },
+        "TableName": "Dog",
+        "TableSizeBytes": 0,
+        "TableStatus": "ACTIVE"
+    }
+}

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -34,7 +34,7 @@ from pynamodb.attributes import (
 from pynamodb.tests.data import (
     MODEL_TABLE_DATA, GET_MODEL_ITEM_DATA, SIMPLE_MODEL_TABLE_DATA,
     BATCH_GET_ITEMS, SIMPLE_BATCH_GET_ITEMS, COMPLEX_TABLE_DATA,
-    COMPLEX_ITEM_DATA, INDEX_TABLE_DATA, LOCAL_INDEX_TABLE_DATA,
+    COMPLEX_ITEM_DATA, INDEX_TABLE_DATA, LOCAL_INDEX_TABLE_DATA, DOG_TABLE_DATA,
     CUSTOM_ATTR_NAME_INDEX_TABLE_DATA, CUSTOM_ATTR_NAME_ITEM_DATA,
     BINARY_ATTR_DATA, SERIALIZED_TABLE_DATA, OFFICE_EMPLOYEE_MODEL_TABLE_DATA,
     GET_OFFICE_EMPLOYEE_ITEM_DATA, GET_OFFICE_EMPLOYEE_ITEM_DATA_WITH_NULL,
@@ -444,6 +444,17 @@ class OverriddenSessionModel(Model):
     random_attr = UnicodeAttribute(attr_name='random_attr_1', null=True)
 
 
+class Animal(Model):
+    name = UnicodeAttribute(hash_key=True)
+
+
+class Dog(Animal):
+    class Meta:
+        table_name = 'Dog'
+
+    breed = UnicodeAttribute()
+
+
 class ModelTestCase(TestCase):
     """
     Tests for the models API
@@ -588,7 +599,7 @@ class ModelTestCase(TestCase):
             self.assertEquals(actual['TableName'], params['TableName'])
             self.assertEquals(actual['ProvisionedThroughput'], params['ProvisionedThroughput'])
             self.assert_dict_lists_equal(sorted(actual['KeySchema'], key=lambda x: x['AttributeName']),
-                                         sorted(actual['KeySchema'], key=lambda x: x['AttributeName']))
+                                         sorted(params['KeySchema'], key=lambda x: x['AttributeName']))
             # These come in random order
             self.assert_dict_lists_equal(sorted(actual['AttributeDefinitions'], key=lambda x: x['AttributeName']),
                                          sorted(params['AttributeDefinitions'], key=lambda x: x['AttributeName']))
@@ -3501,6 +3512,29 @@ class ModelTestCase(TestCase):
                              map_native.get('floaty'))
             self.assertEqual(actual.map_field['mapy']['baz'],
                              map_native.get('mapy').get('baz'))
+
+    def test_model_subclass_attributes_inherited_on_create(self):
+        scope_args = {'count': 0}
+
+        def fake_dynamodb(*args, **kwargs):
+            if scope_args['count'] == 0:
+                scope_args['count'] += 1
+                raise ClientError({'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Not Found'}},
+                                  "DescribeTable")
+            return {}
+
+        fake_db = MagicMock()
+        fake_db.side_effect = fake_dynamodb
+
+        with patch(PATCH_METHOD, new=fake_db) as req:
+            Dog.create_table(read_capacity_units=2, write_capacity_units=2)
+
+            actual = req.call_args_list[1][0][1]
+
+            self.assertEquals(actual['TableName'], DOG_TABLE_DATA['Table']['TableName'])
+            self.assert_dict_lists_equal(actual['KeySchema'], DOG_TABLE_DATA['Table']['KeySchema'])
+            self.assert_dict_lists_equal(actual['AttributeDefinitions'],
+                                         DOG_TABLE_DATA['Table']['AttributeDefinitions'])
 
 
 class ModelInitTestCase(TestCase):


### PR DESCRIPTION
There was a regression with attribute discovery in https://github.com/pynamodb/PynamoDB/pull/22, where we switched from using `dir(cls)` to `cls.__dict__` to discover attributes. Turns out this doesn't include properties from base classes.