### PR TITLE
Remove ListAttribute.element_type restriction

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -585,8 +585,6 @@ class ListAttribute(Attribute):
                                             default=default,
                                             attr_name=attr_name)
         if of:
-            if not issubclass(of, MapAttribute):
-                raise ValueError("'of' must be subclass of MapAttribute")
             self.element_type = of
 
     def serialize(self, values):


### PR DESCRIPTION
From this article <http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html>

At List Section,
>A list type attribute can store an ordered collection of values. Lists are enclosed in square brackets: [ ... ]
>
>A list is similar to a JSON array. There are no restrictions on the data types that can be stored in a >list element, and the elements in a list element do not have to be of the same type.

So I think the ListAttribute.element_type restriction should be removed.

#261 