### PR TITLE
Enforce attr access through field name instead of attr_name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - AWS_SECRET_ACCESS_KEY=fake_key AWS_ACCESS_KEY_ID=fake_id
 
 before_install:
-  - pip install six==1.8.0
+  - pip install six==1.9.0
 
 install:
   - pip install -r requirements-dev.txt

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -40,11 +40,13 @@ class Attribute(object):
 
     def __set__(self, instance, value):
         if instance:
-            instance.attribute_values[self.attr_name] = value
+            attr_name = instance._dynamo_to_python_attrs.get(self.attr_name, self.attr_name)
+            instance.attribute_values[attr_name] = value
 
     def __get__(self, instance, owner):
         if instance:
-            return instance.attribute_values.get(self.attr_name, None)
+            attr_name = instance._dynamo_to_python_attrs.get(self.attr_name, self.attr_name)
+            return instance.attribute_values.get(attr_name, None)
         else:
             return self
 
@@ -451,7 +453,12 @@ class MapAttribute(AttributeContainer, Attribute):
         return self.attribute_values[item]
 
     def __getattr__(self, attr):
-        return self.attribute_values[attr]
+        # Should only be called for raw, otherwise we would go through
+        # the descriptor instead.
+        try:
+            return self.attribute_values[attr]
+        except KeyError:
+            raise AttributeError("'{0}' has no attribute '{1}'".format(self.__class__.__name__, attr))
 
     def __set__(self, instance, value):
         if isinstance(value, collections.Mapping):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -681,6 +681,39 @@ class TestMapAttribute:
         }
         assert serialized_datetime == expected_serialized_value
 
+    def test_complex_map_accessors(self):
+        class NestedThing(MapAttribute):
+            double_nested = MapAttribute()
+            double_nested_renamed = MapAttribute(attr_name='something_else')
+
+        class ThingModel(Model):
+            nested = NestedThing()
+
+        t = ThingModel(nested=NestedThing(
+            double_nested={'hello': 'world'},
+            double_nested_renamed={'foo': 'bar'})
+        )
+
+        assert t.nested.double_nested.as_dict() == {'hello': 'world'}
+        assert t.nested.double_nested_renamed.as_dict() == {'foo': 'bar'}
+        assert t.nested.double_nested.hello == 'world'
+        assert t.nested.double_nested_renamed.foo == 'bar'
+        assert t.nested['double_nested'].as_dict() == {'hello': 'world'}
+        assert t.nested['double_nested_renamed'].as_dict() == {'foo': 'bar'}
+        assert t.nested['double_nested']['hello'] == 'world'
+        assert t.nested['double_nested_renamed']['foo'] == 'bar'
+
+        with pytest.raises(AttributeError):
+            bad = t.nested.double_nested.bad
+        with pytest.raises(AttributeError):
+            bad = t.nested.bad
+        with pytest.raises(AttributeError):
+            bad = t.nested.something_else
+        with pytest.raises(KeyError):
+            bad = t.nested.double_nested['bad']
+        with pytest.raises(KeyError):
+            bad = t.nested['something_else']
+
 
 class TestValueDeserialize:
     def test__get_value_for_deserialize(self):

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import six
 from botocore.client import ClientError
 from botocore.vendored import requests
+import pytest
 
 from pynamodb.compat import CompatTestCase as TestCase
 from pynamodb.tests.deep_eq import deep_eq
@@ -3178,7 +3179,23 @@ class ModelTestCase(TestCase):
                 GET_OFFICE_EMPLOYEE_ITEM_DATA_WITH_NULL.get(ITEM).get('person').get(
                     MAP_SHORT).get('firstName').get(STRING_SHORT))
             self.assertIsNone(item.person.age)
-            self.assertIsNone(item.person.is_dude)
+            self.assertIsNone(item.person.is_male)
+
+    def test_model_with_maps_with_pythonic_attributes(self):
+        fake_db = self.database_mocker(OfficeEmployee, OFFICE_EMPLOYEE_MODEL_TABLE_DATA,
+                                       GET_OFFICE_EMPLOYEE_ITEM_DATA, 'office_employee_id', 'N',
+                                 '123')
+
+        with patch(PATCH_METHOD, new=fake_db) as req:
+            req.return_value = GET_OFFICE_EMPLOYEE_ITEM_DATA
+            item = OfficeEmployee.get(123)
+            self.assertEqual(
+                item.person.fname,
+                GET_OFFICE_EMPLOYEE_ITEM_DATA.get(ITEM).get('person').get(
+                    MAP_SHORT).get('firstName').get(STRING_SHORT))
+            assert item.person.is_male
+            with pytest.raises(AttributeError):
+                item.person.is_dude
 
     def test_model_with_list_retrieve_from_db(self):
         fake_db = self.database_mocker(GroceryList, GROCERY_LIST_MODEL_TABLE_DATA,


### PR DESCRIPTION
Alternate approach to #292.

Note that this will break any existing code which relies on accessing via `attr_name`s instead of python field names.