### PR TITLE
Improve clarity around count() without a hash_key

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -123,6 +123,17 @@ Alternatively, you can retrieve the table item count by calling the `count` meth
     print(UserModel.count())
 
 
+Note that the first positional argument to `count()` is a `hash_key`. Although
+this argument can be `None`, filters do not apply when `hash_key` is `None`:
+
+::
+    # filters do not apply, returns a count of ALL records in User table
+    print(UserModel.count(first_name__eq='John'))
+
+    # filters DO apply, returns count of only the matching users
+    print(UserModel.count('my_hash_key', first_name__eq='John'))
+
+
 Batch Operations
 ^^^^^^^^^^^^^^^^
 
@@ -156,4 +167,3 @@ Perhaps you want to delete all these users:
         items = [UserModel('user-{0}@example.com'.format(x)) for x in range(100)]
         for item in items:
             batch.delete(item)
-


### PR DESCRIPTION
After being confused by [this logic](https://github.com/pynamodb/PynamoDB/blob/master/pynamodb/models.py#L527-L528), @garrettheel and I thought it would be a good idea to clarify the `count()` documentation.

This elaborates slightly on the somewhat unexpected behavior that happens if you do not pass an explicit `hash_key` position argument to the `count` method -- it returns the count of all rows in the table.