### PR TITLE
Raise a ValueError if count() is invoked with no hash key AND filters

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -123,6 +123,17 @@ Alternatively, you can retrieve the table item count by calling the `count` meth
     print(UserModel.count())
 
 
+Note that the first positional argument to `count()` is a `hash_key`. Although
+this argument can be `None`, filters must not be used when `hash_key` is `None`:
+
+::
+    # raises a ValueError
+    print(UserModel.count(first_name__eq='John'))
+
+    # returns count of only the matching users
+    print(UserModel.count('my_hash_key', first_name__eq='John'))
+
+
 Batch Operations
 ^^^^^^^^^^^^^^^^
 
@@ -156,4 +167,3 @@ Perhaps you want to delete all these users:
         items = [UserModel('user-{0}@example.com'.format(x)) for x in range(100)]
         for item in items:
             batch.delete(item)
-

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -127,6 +127,7 @@ Note that the first positional argument to `count()` is a `hash_key`. Although
 this argument can be `None`, filters must not be used when `hash_key` is `None`:
 
 ::
+
     # raises a ValueError
     print(UserModel.count(first_name__eq='John'))
 

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -525,6 +525,8 @@ class Model(AttributeContainer):
         :param filters: A dictionary of filters to be used in the query
         """
         if hash_key is None:
+            if filters:
+                raise ValueError('A hash_key must be given to use filters')
             return cls.describe_table().get(ITEM_COUNT)
 
         cls._get_indexes()

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -522,7 +522,7 @@ class Model(AttributeContainer):
         :param hash_key: The hash key to query. Can be None.
         :param consistent_read: If True, a consistent read is performed
         :param index_name: If set, then this index is used
-        :param filters: A dictionary of filters to be used in the query
+        :param filters: A dictionary of filters to be used in the query. Requires a hash_key to be passed.
         """
         if hash_key is None:
             if filters:

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -1476,6 +1476,10 @@ class ModelTestCase(TestCase):
             params = {'TableName': 'UserModel'}
             self.assertEqual(args, params)
 
+    def test_count_no_hash_key(self):
+        self.assertRaises(ValueError, lambda: UserModel.count(zip_code__le='94117'))
+
+
     def test_index_count(self):
         """
         Model.index.count()

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -1477,8 +1477,8 @@ class ModelTestCase(TestCase):
             self.assertEqual(args, params)
 
     def test_count_no_hash_key(self):
-        self.assertRaises(ValueError, lambda: UserModel.count(zip_code__le='94117'))
-
+        with pytest.raises(ValueError):
+            UserModel.count(zip_code__le='94117')
 
     def test_index_count(self):
         """


### PR DESCRIPTION
After being confused by [this logic](https://github.com/pynamodb/PynamoDB/blob/master/pynamodb/models.py#L527-L528), @garrettheel and I thought it would be a good idea to:

+ `raise` if a `count()` is invoked without a `hash_key` AND with a `filter` expression.
+ clarify the `count()` documentation
