### PR TITLE
Replace AttributesToGet with ProjectionExpression / ExpressionAttributeNames

### DIFF
--- a/pynamodb/constants.py
+++ b/pynamodb/constants.py
@@ -33,7 +33,6 @@ CONSISTENT_READ = 'ConsistentRead'
 DELETE_REQUEST = 'DeleteRequest'
 RETURN_VALUES = 'ReturnValues'
 REQUEST_ITEMS = 'RequestItems'
-ATTRS_TO_GET = 'AttributesToGet'
 ATTR_UPDATES = 'AttributeUpdates'
 TABLE_STATUS = 'TableStatus'
 SCAN_FILTER = 'ScanFilter'
@@ -61,6 +60,10 @@ ITEM = 'Item'
 KEYS = 'Keys'
 UTC = 'UTC'
 KEY = 'Key'
+
+# Expression Parameters
+EXPRESSION_ATTRIBUTE_NAMES = 'ExpressionAttributeNames'
+PROJECTION_EXPRESSION = 'ProjectionExpression'
 
 # Defaults
 DEFAULT_ENCODING = 'utf-8'

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -2381,7 +2381,10 @@ class ModelTestCase(TestCase):
                             {'user_name': {'S': 'hash-1'}},
                             {'user_name': {'S': 'hash-0'}}
                         ],
-                        'AttributesToGet': ['numbers']
+                        'ProjectionExpression': '#0',
+                        'ExpressionAttributeNames': {
+                            '#0': 'numbers'
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR is a first step towards moving off of the legacy conditional parameters (#219).

As part of this change, the `attributes_to_get` keyword arguments now support Document Paths:
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.Attributes.html

Note that in order to not need special handling for reserved words,
all attributes are replaced with expression attribute name placeholders:
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html

Breaking Changes:

Neither `[` nor `]` are allowed characters for attribute names; however, `.` is.
Any attribute names that include a `.` (defined using the `attr_name` keyword argument)
are no longer able to be requested since the name is interpreted as a nested path.
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html

Invalid document paths (e.g. empty paths or non-integer array indexes) now throw a `ValueError`
during request construction instead of a `ClientError` during response processing.