### PR TITLE
Replace KeyConditions with KeyConditionExpression / ExpressionAttributeValues

### DIFF
--- a/pynamodb/constants.py
+++ b/pynamodb/constants.py
@@ -33,6 +33,7 @@ CONSISTENT_READ = 'ConsistentRead'
 DELETE_REQUEST = 'DeleteRequest'
 RETURN_VALUES = 'ReturnValues'
 REQUEST_ITEMS = 'RequestItems'
+ATTRS_TO_GET = 'AttributesToGet'
 ATTR_UPDATES = 'AttributeUpdates'
 TABLE_STATUS = 'TableStatus'
 SCAN_FILTER = 'ScanFilter'
@@ -63,6 +64,8 @@ KEY = 'Key'
 
 # Expression Parameters
 EXPRESSION_ATTRIBUTE_NAMES = 'ExpressionAttributeNames'
+EXPRESSION_ATTRIBUTE_VALUES = 'ExpressionAttributeValues'
+KEY_CONDITION_EXPRESSION = 'KeyConditionExpression'
 PROJECTION_EXPRESSION = 'ProjectionExpression'
 
 # Defaults
@@ -140,8 +143,8 @@ STREAM_OLD_IMAGE = 'OLD_IMAGE'
 STREAM_NEW_AND_OLD_IMAGE = 'NEW_AND_OLD_IMAGES'
 STREAM_KEYS_ONLY = 'KEYS_ONLY'
 
-# These are constants used in the KeyConditions parameter
-# See: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-KeyConditions
+# These are constants used in the KeyConditionExpression parameter
+# http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-KeyConditionExpression
 EXCLUSIVE_START_KEY = 'ExclusiveStartKey'
 LAST_EVALUATED_KEY = 'LastEvaluatedKey'
 QUERY_FILTER = 'QueryFilter'
@@ -164,6 +167,15 @@ QUERY_OPERATOR_MAP = {
     'gt': GT,
     'begins_with': BEGINS_WITH,
     'between': BETWEEN
+}
+KEY_CONDITION_OPERATOR_MAP = {
+    EQ: '__eq__',
+    LE: '__le__',
+    LT: '__lt__',
+    GE: '__ge__',
+    GT: '__gt__',
+    BEGINS_WITH: 'startswith',
+    BETWEEN: 'between'
 }
 
 # These are the valid select values for the Scan operation

--- a/pynamodb/expressions/condition.py
+++ b/pynamodb/expressions/condition.py
@@ -1,0 +1,85 @@
+from pynamodb.expressions.util import get_value_placeholder, substitute_names
+
+
+class Path(object):
+
+    def __init__(self, path):
+        self.path = path
+
+    def __eq__(self, other):
+        return self._compare('=', other)
+
+    def __lt__(self, other):
+        return self._compare('<', other)
+
+    def __le__(self, other):
+        return self._compare('<=', other)
+
+    def __gt__(self, other):
+        return self._compare('>', other)
+
+    def __ge__(self, other):
+        return self._compare('>=', other)
+
+    def _compare(self, operator, value):
+        return Condition(self.path, operator, value)
+
+    def between(self, value1, value2):
+        # This seemed preferable to other options such as merging value1 <= attribute & attribute <= value2
+        # into one condition expression. DynamoDB only allows a single sort key comparison and having this
+        # work but similar expressions like value1 <= attribute & attribute < value2 fail seems too brittle.
+        return Between(self.path, value1, value2)
+
+    def startswith(self, prefix):
+        # A 'pythonic' replacement for begins_with to match string behavior (e.g. "foo".startswith("f"))
+        return BeginsWith(self.path, prefix)
+
+
+class Condition(object):
+    format_string = '{path} {operator} {0}'
+
+    def __init__(self, path, operator, *values):
+        self.path = path
+        self.operator = operator
+        self.values = values
+        self.logical_operator = None
+        self.other_condition = None
+
+    def serialize(self, placeholder_names, expression_attribute_values):
+        path = substitute_names(self.path, placeholder_names)
+        values = [get_value_placeholder(value, expression_attribute_values) for value in self.values]
+        condition = self.format_string.format(*values, path=path, operator=self.operator)
+        if self.logical_operator:
+            other_condition = self.other_condition.serialize(placeholder_names, expression_attribute_values)
+            return '{0} {1} {2}'.format(condition, self.logical_operator, other_condition)
+        return condition
+
+    def __and__(self, other):
+        if not isinstance(other, Condition):
+            raise TypeError("unsupported operand type(s) for &: '{0}' and '{1}'",
+                            self.__class__.__name__, other.__class__.__name__)
+        self.logical_operator = 'AND'
+        self.other_condition = other
+        return self
+
+    def __nonzero__(self):
+        # Prevent users from accidentally comparing the condition object instead of the attribute instance
+        raise TypeError("unsupported operand type(s) for bool: '{0}'".format(self.__class__.__name__))
+
+    def __bool__(self):
+        # Prevent users from accidentally comparing the condition object instead of the attribute instance
+        raise TypeError("unsupported operand type(s) for bool: {0}".format(self.__class__.__name__))
+
+
+class Between(Condition):
+    format_string = '{path} {operator} {0} AND {1}'
+
+    def __init__(self, attribute, value1, value2):
+        super(Between, self).__init__(attribute, 'BETWEEN', value1, value2)
+
+
+class BeginsWith(Condition):
+    format_string = '{operator} ({path}, {0})'
+
+    def __init__(self, attribute, prefix):
+        super(BeginsWith, self).__init__(attribute, 'begins_with', prefix)

--- a/pynamodb/expressions/projection.py
+++ b/pynamodb/expressions/projection.py
@@ -1,0 +1,6 @@
+from pynamodb.expressions.util import substitute_names
+
+
+def create_projection_expression(attributes_to_get, placeholders):
+    expressions = [substitute_names(attribute, placeholders) for attribute in attributes_to_get]
+    return ', '.join(expressions)

--- a/pynamodb/expressions/util.py
+++ b/pynamodb/expressions/util.py
@@ -1,0 +1,29 @@
+import re
+
+PATH_SEGMENT_REGEX = re.compile(r'([^\[\]]+)((?:\[\d+\])*)$')
+
+
+def substitute_names(expression, placeholders):
+    """
+    Replaces names in the given expression with placeholders.
+    Stores the placeholders in the given dictionary.
+    """
+    path_segments = expression.split('.')
+    for idx, segment in enumerate(path_segments):
+        match = PATH_SEGMENT_REGEX.match(segment)
+        if not match:
+            raise ValueError('{0} is not a valid document path'.format(expression))
+        name, indexes = match.groups()
+        if name in placeholders:
+            placeholder = placeholders[name]
+        else:
+            placeholder = '#' + str(len(placeholders))
+            placeholders[name] = placeholder
+        path_segments[idx] = placeholder + indexes
+    return '.'.join(path_segments)
+
+
+def get_value_placeholder(value, expression_attribute_values):
+    placeholder = ':' + str(len(expression_attribute_values))
+    expression_attribute_values[placeholder] = value
+    return placeholder

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -1,0 +1,96 @@
+from pynamodb.attributes import UnicodeAttribute
+from pynamodb.compat import CompatTestCase as TestCase
+from pynamodb.expressions.projection import create_projection_expression
+
+
+class ProjectionExpressionTestCase(TestCase):
+
+    def test_create_projection_expression(self):
+        attributes_to_get = ['Description', 'RelatedItems[0]', 'ProductReviews.FiveStar']
+        placeholders = {}
+        projection_expression = create_projection_expression(attributes_to_get, placeholders)
+        assert projection_expression == "#0, #1[0], #2.#3"
+        assert placeholders == {'Description': '#0', 'RelatedItems': '#1', 'ProductReviews': '#2', 'FiveStar': '#3'}
+
+    def test_create_projection_expression_repeated_names(self):
+        attributes_to_get = ['ProductReviews.FiveStar', 'ProductReviews.ThreeStar', 'ProductReviews.OneStar']
+        placeholders = {}
+        projection_expression = create_projection_expression(attributes_to_get, placeholders)
+        assert projection_expression == "#0.#1, #0.#2, #0.#3"
+        assert placeholders == {'ProductReviews': '#0', 'FiveStar': '#1', 'ThreeStar': '#2', 'OneStar': '#3'}
+
+    def test_create_projection_expression_invalid_attribute_raises(self):
+        invalid_attributes = ['', '[0]', 'foo[bar]', 'MyList[-1]', 'MyList[0.4]']
+        for attribute in invalid_attributes:
+            with self.assertRaises(ValueError):
+                create_projection_expression([attribute], {})
+
+
+class ConditionExpressionTestCase(TestCase):
+
+    def setUp(self):
+        self.attribute = UnicodeAttribute(attr_name='foo')
+
+    def test_equals(self):
+        condition = self.attribute == 'bar'
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0 = :0"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S': 'bar'}}
+
+    def test_less_than(self):
+        condition = self.attribute < 'bar'
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0 < :0"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S': 'bar'}}
+
+    def test_less_than_or_equal(self):
+        condition = self.attribute <= 'bar'
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0 <= :0"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S': 'bar'}}
+
+    def test_greater_than(self):
+        condition = self.attribute > 'bar'
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0 > :0"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S': 'bar'}}
+
+    def test_greater_than_or_equal(self):
+        condition = self.attribute >= 'bar'
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0 >= :0"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S': 'bar'}}
+
+    def test_between(self):
+        condition = self.attribute.between('bar', 'baz')
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0 BETWEEN :0 AND :1"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S': 'bar'}, ':1': {'S': 'baz'}}
+
+    def test_begins_with(self):
+        condition = self.attribute.startswith('bar')
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "begins_with (#0, :0)"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S' : 'bar'}}
+
+    def test_indexing(self):
+        condition = self.attribute[0] == 'bar'
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0[0] = :0"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': 'bar'}  # TODO fix attribute value formatting

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -1446,10 +1446,13 @@ class ModelTestCase(TestCase):
             self.assertEqual(res, 10)
             args = req.call_args[0][1]
             params = {
-                'KeyConditions': {
-                    'user_name': {
-                        'ComparisonOperator': 'EQ',
-                        'AttributeValueList': [{'S': u'foo'}]
+                'KeyConditionExpression': '#0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'user_name'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': u'foo'
                     }
                 },
                 'TableName': 'UserModel',
@@ -1490,14 +1493,17 @@ class ModelTestCase(TestCase):
             self.assertEqual(res, 42)
             args = req.call_args[0][1]
             params = {
-                'KeyConditions': {
-                    'user_name': {
-                        'ComparisonOperator': 'BEGINS_WITH',
-                        'AttributeValueList': [{'S': u'bar'}]
+                'KeyConditionExpression': '#0 = :0 AND begins_with (#1, :1)',
+                'ExpressionAttributeNames': {
+                    '#0': 'user_id',
+                    '#1': 'user_name'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': u'foo'
                     },
-                    'user_id': {
-                        'ComparisonOperator': 'EQ',
-                        'AttributeValueList': [{'S': u'foo'}]
+                    ':1': {
+                        'S': u'bar'
                     }
                 },
                 'Limit': 2,
@@ -1523,10 +1529,13 @@ class ModelTestCase(TestCase):
 
             args_one = req.call_args_list[0][0][1]
             params_one = {
-                'KeyConditions': {
-                    'user_id': {
-                        'ComparisonOperator': 'EQ',
-                        'AttributeValueList': [{'S': u'foo'}]
+                'KeyConditionExpression': '#0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'user_id'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': u'foo'
                     }
                 },
                 'IndexName': 'uid_index',
@@ -1823,18 +1832,17 @@ class ModelTestCase(TestCase):
                     zip_code__between=[2, 3]):
                 queried.append(item._serialize())
             params = {
-                'KeyConditions': {
-                    'user_id': {
-                        'AttributeValueList': [
-                            {'S': 'id'}
-                        ],
-                        'ComparisonOperator': 'BEGINS_WITH'
+                'KeyConditionExpression': '#0 = :0 AND begins_with (#1, :1)',
+                'ExpressionAttributeNames': {
+                    '#0': 'user_name',
+                    '#1': 'user_id'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': u'foo'
                     },
-                    'user_name': {
-                        'AttributeValueList': [
-                            {'S': 'foo'}
-                        ],
-                        'ComparisonOperator': 'EQ'
+                    ':1': {
+                        'S': u'id'
                     }
                 },
                 'QueryFilter': {
@@ -1933,18 +1941,17 @@ class ModelTestCase(TestCase):
                     conditional_operator='AND'):
                 queried.append(item._serialize())
             params = {
-                'KeyConditions': {
-                    'user_id': {
-                        'AttributeValueList': [
-                            {'S': 'id'}
-                        ],
-                        'ComparisonOperator': 'BEGINS_WITH'
+                'KeyConditionExpression': '#0 = :0 AND begins_with (#1, :1)',
+                'ExpressionAttributeNames': {
+                    '#0': 'user_name',
+                    '#1': 'user_id'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': u'foo'
                     },
-                    'user_name': {
-                        'AttributeValueList': [
-                            {'S': 'foo'}
-                        ],
-                        'ComparisonOperator': 'EQ'
+                    ':1': {
+                        'S': u'id'
                     }
                 },
                 'query_filter': {
@@ -1971,11 +1978,8 @@ class ModelTestCase(TestCase):
 
             for key in ('ConditionalOperator', 'ReturnConsumedCapacity', 'TableName'):
                 self.assertEqual(req.call_args[0][1][key], params[key])
-            for key in ('user_id', 'user_name'):
-                self.assertEqual(
-                    req.call_args[0][1]['KeyConditions'][key],
-                    params['KeyConditions'][key]
-                )
+            for key in ('KeyConditionExpression', 'ExpressionAttributeNames', 'ExpressionAttributeValues'):
+                self.assertEqual(req.call_args[0][1][key], params[key])
             for key in ('email', 'zip_code', 'picture'):
                 self.assertEqual(
                     sorted(req.call_args[0][1]['QueryFilter'][key].items(), key=lambda x: x[0]),
@@ -2615,22 +2619,17 @@ class ModelTestCase(TestCase):
                 queried.append(item._serialize())
 
             params = {
-                'KeyConditions': {
-                    'user_name': {
-                        'ComparisonOperator': 'BEGINS_WITH',
-                        'AttributeValueList': [
-                            {
-                                'S': u'bar'
-                            }
-                        ]
+                'KeyConditionExpression': '#0 = :0 AND begins_with (#1, :1)',
+                'ExpressionAttributeNames': {
+                    '#0': 'email',
+                    '#1': 'user_name'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': u'foo'
                     },
-                    'email': {
-                        'ComparisonOperator': 'EQ',
-                        'AttributeValueList': [
-                            {
-                                'S': u'foo'
-                            }
-                        ]
+                    ':1': {
+                        'S': u'bar'
                     }
                 },
                 'IndexName': 'custom_idx_name',
@@ -2658,22 +2657,17 @@ class ModelTestCase(TestCase):
                 queried.append(item._serialize())
 
             params = {
-                'KeyConditions': {
-                    'user_name': {
-                        'ComparisonOperator': 'BEGINS_WITH',
-                        'AttributeValueList': [
-                            {
-                                'S': u'bar'
-                            }
-                        ]
+                'KeyConditionExpression': '#0 = :0 AND begins_with (#1, :1)',
+                'ExpressionAttributeNames': {
+                    '#0': 'email',
+                    '#1': 'user_name'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': u'foo'
                     },
-                    'email': {
-                        'ComparisonOperator': 'EQ',
-                        'AttributeValueList': [
-                            {
-                                'S': u'foo'
-                            }
-                        ]
+                    ':1': {
+                        'S': u'bar'
                     }
                 },
                 'QueryFilter': {
@@ -2706,22 +2700,17 @@ class ModelTestCase(TestCase):
                 queried.append(item._serialize())
 
             params = {
-                'KeyConditions': {
-                    'user_name': {
-                        'ComparisonOperator': 'BEGINS_WITH',
-                        'AttributeValueList': [
-                            {
-                                'S': u'bar'
-                            }
-                        ]
+                'KeyConditionExpression': '#0 = :0 AND begins_with (#1, :1)',
+                'ExpressionAttributeNames': {
+                    '#0': 'user_id',
+                    '#1': 'user_name'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': u'foo'
                     },
-                    'user_id': {
-                        'ComparisonOperator': 'EQ',
-                        'AttributeValueList': [
-                            {
-                                'S': u'foo'
-                            }
-                        ]
+                    ':1': {
+                        'S': u'bar'
                     }
                 },
                 'IndexName': 'uid_index',

--- a/pynamodb/tests/test_table_connection.py
+++ b/pynamodb/tests/test_table_connection.py
@@ -431,15 +431,21 @@ class ConnectionTestCase(TestCase):
             req.return_value = {}
             conn.query(
                 "FooForum",
-                key_conditions={'ForumName': {'ComparisonOperator': 'BEGINS_WITH', 'AttributeValueList': ['thread']}}
+                key_conditions={'Subject': {'ComparisonOperator': 'BEGINS_WITH', 'AttributeValueList': ['thread']}}
             )
             params = {
                 'ReturnConsumedCapacity': 'TOTAL',
-                'KeyConditions': {
-                    'ForumName': {
-                        'ComparisonOperator': 'BEGINS_WITH', 'AttributeValueList': [{
-                            'S': 'thread'
-                        }]
+                'KeyConditionExpression': '#0 = :0 AND begins_with (#1, :1)',
+                'ExpressionAttributeNames': {
+                    '#0': 'ForumName',
+                    '#1': 'Subject'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'FooForum'
+                    },
+                    ':1': {
+                        'S': 'thread'
                     }
                 },
                 'TableName': self.test_table_name


### PR DESCRIPTION
This PR is a second step towards moving off of the legacy conditional parameters (#219).

With this change, the `key_conditions` query parameter now uses the KeyConditionExpression API.
To support this, this change introduces primitive support for the subset of Condition Expressions required for partition and sort key comparisons along with support for Expression Attribute Values:
http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-KeyConditionExpression
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeValues.html

In order to maintain backwards compatibility, the Expression and Condition objects take attribute path and attribute value maps as parameters. To simplify development, helper functions have been added to the Attribute class:

```
>>> from pynamodb.attributes import UnicodeAttribute
>>> partition_key = UnicodeAttribute(attr_name='foo')
>>> sort_key = UnicodeAttribute(attr_name='bar')
>>> condition = (partition_key == 'Hello') & sort_key.startswith('World!')
>>> name_placeholders, expression_attribute_values = {}, {}
>>> condition.serialize(name_placeholders, expression_attribute_values)
'#0 = :0 AND begins_with (#1, :1)'
>>> name_placeholders
{'foo': '#0', 'bar': '#1'}
>>> expression_attribute_values
{':0': {'S': u'Hello'}, ':1': {'S': u'World!'}}
>>> 
```