### PR TITLE
Support document paths and attribute names containing dot characters.

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -71,33 +71,49 @@ class Attribute(object):
     def __eq__(self, other):
         if other is None or isinstance(other, Attribute):  # handle object identity comparison
             return self is other
-        return Path(self.attr_name).__eq__(self._get_attribute_value(other))
+        return AttributePath(self).__eq__(other)
 
     def __lt__(self, other):
-        return Path(self.attr_name).__lt__(self._get_attribute_value(other))
+        return AttributePath(self).__lt__(other)
 
     def __le__(self, other):
-        return Path(self.attr_name).__le__(self._get_attribute_value(other))
+        return AttributePath(self).__le__(other)
 
     def __gt__(self, other):
-        return Path(self.attr_name).__gt__(self._get_attribute_value(other))
+        return AttributePath(self).__gt__(other)
 
     def __ge__(self, other):
-        return Path(self.attr_name).__ge__(self._get_attribute_value(other))
+        return AttributePath(self).__ge__(other)
 
-    def __getitem__(self, idx):  # support accessing list elements in condition expressions
-        if not isinstance(idx, int):
-            raise TypeError('list indices must be integers, not {}'.format(type(idx).__name__))
-        return Path('{0}[{1}]'.format(self.attr_name, idx))  # TODO include attribute value formatting
+    def __getitem__(self, idx):
+        return AttributePath(self)[idx]
 
-    def between(self, value1, value2):
-        return Path(self.attr_name).between(self._get_attribute_value(value1), self._get_attribute_value(value2))
+    def between(self, lower, upper):
+        return AttributePath(self).between(lower, upper)
 
     def startswith(self, prefix):
-        return Path(self.attr_name).startswith(self._get_attribute_value(prefix))
+        return AttributePath(self).startswith(prefix)
 
-    def _get_attribute_value(self, value):
-        return {ATTR_TYPE_MAP[self.attr_type]: self.serialize(value)}
+
+class AttributePath(Path):
+
+    def __init__(self, attribute):
+        super(AttributePath, self).__init__(attribute.attr_name, attribute_name=True)
+        self.attribute = attribute
+
+    def __getitem__(self, idx):
+        if self.attribute.attr_type != LIST:  # only list elements support the list dereference operator
+            raise TypeError("'{0}' object has no attribute __getitem__".format(self.attribute.__class__.__name__))
+        return super(AttributePath, self).__getitem__(idx)
+
+    def _serialize(self, value):
+        if self.attribute.attr_type == LIST and not isinstance(value, list):
+            # List attributes assume the values to be serialized are lists.
+            return self.attribute.serialize([value])[0]
+        if self.attribute.attr_type == MAP and not isinstance(value, dict):
+            # Map attributes assume the values to be serialized are maps.
+            return self.attribute.serialize({'': value})['']
+        return {ATTR_TYPE_MAP[self.attribute.attr_type]: self.attribute.serialize(value)}
 
 
 class AttributeContainer(object):

--- a/pynamodb/expressions/condition.py
+++ b/pynamodb/expressions/condition.py
@@ -1,10 +1,21 @@
+from copy import copy
+from pynamodb.constants import AND, BETWEEN
 from pynamodb.expressions.util import get_value_placeholder, substitute_names
 
 
 class Path(object):
 
-    def __init__(self, path):
+    def __init__(self, path, attribute_name=False):
         self.path = path
+        self.attribute_name = attribute_name
+
+    def __getitem__(self, idx):
+        # list dereference operator
+        if not isinstance(idx, int):
+            raise TypeError("list indices must be integers, not {0}".format(type(idx).__name__))
+        element_path = copy(self)
+        element_path.path = '{0}[{1}]'.format(self.path, idx)
+        return element_path
 
     def __eq__(self, other):
         return self._compare('=', other)
@@ -21,18 +32,32 @@ class Path(object):
     def __ge__(self, other):
         return self._compare('>=', other)
 
-    def _compare(self, operator, value):
-        return Condition(self.path, operator, value)
+    def _compare(self, operator, other):
+        return Condition(self, operator, self._serialize(other))
 
-    def between(self, value1, value2):
+    def between(self, lower, upper):
         # This seemed preferable to other options such as merging value1 <= attribute & attribute <= value2
         # into one condition expression. DynamoDB only allows a single sort key comparison and having this
         # work but similar expressions like value1 <= attribute & attribute < value2 fail seems too brittle.
-        return Between(self.path, value1, value2)
+        return Between(self, self._serialize(lower), self._serialize(upper))
 
     def startswith(self, prefix):
         # A 'pythonic' replacement for begins_with to match string behavior (e.g. "foo".startswith("f"))
-        return BeginsWith(self.path, prefix)
+        return BeginsWith(self, self._serialize(prefix))
+
+    def _serialize(self, value):
+        # Allow subclasses to define value serialization.
+        return value
+
+    def __str__(self):
+        if self.attribute_name and '.' in self.path:
+            # Quote the path to illustrate that the dot characters are not dereference operators.
+            path, sep, rem = self.path.partition('[')
+            return repr(path) + sep + rem
+        return self.path
+
+    def __repr__(self):
+        return "Path('{0}', attribute_name={1})".format(self.path, self.attribute_name)
 
 
 class Condition(object):
@@ -46,7 +71,8 @@ class Condition(object):
         self.other_condition = None
 
     def serialize(self, placeholder_names, expression_attribute_values):
-        path = substitute_names(self.path, placeholder_names)
+        split = not self.path.attribute_name
+        path = substitute_names(self.path.path, placeholder_names, split=split)
         values = [get_value_placeholder(value, expression_attribute_values) for value in self.values]
         condition = self.format_string.format(*values, path=path, operator=self.operator)
         if self.logical_operator:
@@ -58,9 +84,17 @@ class Condition(object):
         if not isinstance(other, Condition):
             raise TypeError("unsupported operand type(s) for &: '{0}' and '{1}'",
                             self.__class__.__name__, other.__class__.__name__)
-        self.logical_operator = 'AND'
+        self.logical_operator = AND
         self.other_condition = other
         return self
+
+    def __repr__(self):
+        values = [value.items()[0][1] for value in self.values]
+        condition = self.format_string.format(*values, path=self.path, operator = self.operator)
+        if self.logical_operator:
+            other_conditions = repr(self.other_condition)
+            return '{0} {1} {2}'.format(condition, self.logical_operator, other_conditions)
+        return condition
 
     def __nonzero__(self):
         # Prevent users from accidentally comparing the condition object instead of the attribute instance
@@ -74,12 +108,12 @@ class Condition(object):
 class Between(Condition):
     format_string = '{path} {operator} {0} AND {1}'
 
-    def __init__(self, attribute, value1, value2):
-        super(Between, self).__init__(attribute, 'BETWEEN', value1, value2)
+    def __init__(self, path, lower, upper):
+        super(Between, self).__init__(path, BETWEEN, lower, upper)
 
 
 class BeginsWith(Condition):
     format_string = '{operator} ({path}, {0})'
 
-    def __init__(self, attribute, prefix):
-        super(BeginsWith, self).__init__(attribute, 'begins_with', prefix)
+    def __init__(self, path, prefix):
+        super(BeginsWith, self).__init__(path, 'begins_with', prefix)

--- a/pynamodb/expressions/projection.py
+++ b/pynamodb/expressions/projection.py
@@ -1,6 +1,19 @@
+from pynamodb.attributes import Attribute
+from pynamodb.expressions.condition import Path
 from pynamodb.expressions.util import substitute_names
 
 
 def create_projection_expression(attributes_to_get, placeholders):
-    expressions = [substitute_names(attribute, placeholders) for attribute in attributes_to_get]
+    if not isinstance(attributes_to_get, list):
+        attributes_to_get = [attributes_to_get]
+    expression_split_pairs = [_get_expression_split_pair(attribute) for attribute in attributes_to_get]
+    expressions = [substitute_names(expr, placeholders, split=split) for (expr, split) in expression_split_pairs]
     return ', '.join(expressions)
+
+
+def _get_expression_split_pair(attribute):
+    if isinstance(attribute, Attribute):
+        return attribute.attr_name, False
+    if isinstance(attribute, Path):
+        return attribute.path, not attribute.attribute_name
+    return attribute, True

--- a/pynamodb/expressions/util.py
+++ b/pynamodb/expressions/util.py
@@ -3,12 +3,12 @@ import re
 PATH_SEGMENT_REGEX = re.compile(r'([^\[\]]+)((?:\[\d+\])*)$')
 
 
-def substitute_names(expression, placeholders):
+def substitute_names(expression, placeholders, split=True):
     """
     Replaces names in the given expression with placeholders.
     Stores the placeholders in the given dictionary.
     """
-    path_segments = expression.split('.')
+    path_segments = expression.split('.') if split else [expression]
     for idx, segment in enumerate(path_segments):
         match = PATH_SEGMENT_REGEX.match(segment)
         if not match:


### PR DESCRIPTION
This PR introduces support for both Document Paths and '.' characters in expressions.

Expressions are generated assuming that the path given in the object is a document path;
for example, `Path('foo.bar.baz[0]') == value` is translated into `#0.#1.#2[0] = :0` with the following expression attribute names: `{'#0': 'foo', '#1': 'bar', "#2': 'baz'}`.

With this change, expressions generated from Attribute objects will use whatever attribute name is defined by the `attr_name` field, allowing support for dotted attribute names; for example,
`ListAttribute(attr_name='foo.bar.baz')[0] == value` is translated into `#0[0] = :0` with the following expression attribute names: `{'#0: 'foo.bar.baz'}`.