### PR TITLE
Fix __get__ for MapAttributes to return the type of the MapAttribute …

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -465,6 +465,19 @@ class MapAttribute(AttributeContainer, Attribute):
         self._set_defaults()
         self._set_attributes(**attrs)
 
+    def __get__(self, instance, owner):
+        if instance:
+            return super(MapAttribute, self).__get__(instance, owner)
+        else:
+            # If we're accessing a MapAttribute field from an AttributeContainer
+            # class we want the type of the MapAttribute, not the instance
+            # itself.  This matches the user's expectations that something like:
+            #
+            # ModelClass.map_attr.field.attr_name
+            #
+            # should work.
+            return type(self)
+
     def __iter__(self):
         return iter(self.attribute_values)
 

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -49,6 +49,10 @@ class CustomAttrMap(MapAttribute):
     overridden_unicode_attr = UnicodeAttribute(attr_name="unicode_attr")
 
 
+class CustomMapModel(Model):
+    custom_map_attr = CustomAttrMap()
+
+
 class DefaultsMap(MapAttribute):
     map_field = MapAttribute(default={})
 
@@ -585,6 +589,15 @@ class TestMapAttribute:
         }
         expected = {'number_attr': {'N': '10'}, 'unicode_attr': {'S': six.u('Hello')}}
         assert CustomAttrMap().serialize(attribute) == expected
+
+    def test_map_access_child_field_attributes(self):
+        self.assertEquals(
+            CustomMapModel.custom_map_attr.overridden_number_attr.attr_name,
+            'number_attr'
+        )
+        self.assertIsNone(
+            CustomMapModel().custom_map_attr
+        )
 
     def test_defaults(self):
         item = DefaultsMap()


### PR DESCRIPTION
…as opposed to the instance when accessed from a AttributeContainer class.

For example, the code below should just work:

```python
from pynamodb.models import Model
from pynamodb.attributes import MapAttribute, NumberAttribute

class MyMap(MapAttribute):
    foo = NumberAttribute()

class MyModel(Model):
    class Meta:
        table_name = 'tbl'
    map_attr = MyMap()

MyMap.map_attr.foo.attr_name
```