### PR TITLE
Replace the shared _attributes field with a per-subclass fields.

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -2,7 +2,6 @@
 PynamoDB attributes
 """
 import six
-from six import add_metaclass
 import json
 from base64 import b64encode, b64decode
 from datetime import datetime
@@ -102,7 +101,6 @@ class Attribute(object):
 
 class AttributeContainer(object):
 
-    _attributes = None
     _dynamo_to_python_attrs = None
 
     @classmethod
@@ -137,7 +135,8 @@ class AttributeContainer(object):
 
         :rtype: dict[str, Attribute]
         """
-        if cls._attributes is None:
+        if '_attributes' not in cls.__dict__:
+            # Each subclass of AttributeContainer needs its own attributes map.
             cls._initialize_attributes()
         return cls._attributes
 
@@ -445,12 +444,6 @@ class NullAttribute(Attribute):
         return None
 
 
-class MapAttributeMeta(type):
-    def __init__(cls, name, bases, attrs):
-        setattr(cls, '_attributes', None)
-
-
-@add_metaclass(MapAttributeMeta)
 class MapAttribute(AttributeContainer, Attribute):
     attr_type = MAP
 


### PR DESCRIPTION
This lets us remove the MapAttributeMeta metaclass in preparation for adding a metaclass to AttributeContainer to make MapAttribute subclasses behave more like Models.

To illustrate the equivalence, the following snippets show the value of `_attributes` before and after class instantiation before the removal of the metaclass:
```
>>> from pynamodb.attributes import Attribute, MapAttribute
>>> class SubMapAttribute(MapAttribute):
...     a = Attribute()
... 
>>> class SubSubMapAttribute(SubMapAttribute):
...     b = Attribute()
... 
>>> MapAttribute._attributes
{}
>>> print(SubMapAttribute._attributes)
None
>>> print(SubSubMapAttribute._attributes)
None
>>> SubMapAttribute()
<__main__.SubMapAttribute object at 0x1039b7fd0>
>>> SubMapAttribute._attributes
{'a': <pynamodb.attributes.Attribute object at 0x1039a6e90>}
>>> print(SubSubMapAttribute._attributes)
None
>>> SubSubMapAttribute()
<__main__.SubSubMapAttribute object at 0x1039b7fd0>
>>> SubSubMapAttribute._attributes
{'a': <pynamodb.attributes.Attribute object at 0x1039a6e90>, 'b': <pynamodb.attributes.Attribute object at 0x1039b7d90>}
```

and after the removal of the metaclass:
```
>>> from pynamodb.attributes import Attribute, MapAttribute
>>> class SubMapAttribute(MapAttribute):
...     a = Attribute()
... 
>>> class SubSubMapAttribute(SubMapAttribute):
...     b = Attribute()
... 
>>> MapAttribute._attributes
{}
>>> SubMapAttribute._attributes
{}
>>> SubSubMapAttribute._attributes
{}
>>> SubMapAttribute()
<__main__.SubMapAttribute object at 0x10150df50>
>>> SubMapAttribute._attributes
{'a': <pynamodb.attributes.Attribute object at 0x1014fce90>}
>>> SubSubMapAttribute._attributes
{'a': <pynamodb.attributes.Attribute object at 0x1014fce90>}
>>> SubSubMapAttribute()
<__main__.SubSubMapAttribute object at 0x10150df50>
>>> SubSubMapAttribute._attributes
{'a': <pynamodb.attributes.Attribute object at 0x1014fce90>, 'b': <pynamodb.attributes.Attribute object at 0x10150dd10>}
```

Here we can see that without the metaclass, the attribute lookup continues through the class hierarchy until it reaches `MapAttribute` which is instantiated during the import of `attributes.py` to create `DESERIALIZE_CLASS_MAP` and `SERIALIZE_CLASS_MAP`.

However,  during the first initialization of each subclass, a per-class value is computed.