### PR TITLE
Introduce AttributeContainerMeta

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -11,7 +11,7 @@ import warnings
 from six import add_metaclass
 from pynamodb.exceptions import DoesNotExist, TableDoesNotExist, TableError
 from pynamodb.throttle import NoThrottle
-from pynamodb.attributes import Attribute, AttributeContainer, MapAttribute, ListAttribute
+from pynamodb.attributes import Attribute, AttributeContainer, AttributeContainerMeta, MapAttribute, ListAttribute
 from pynamodb.connection.base import MetaTable
 from pynamodb.connection.table import TableConnection
 from pynamodb.connection.util import pythonic
@@ -153,7 +153,7 @@ class ResultSet(object):
         return iter(self.results)
 
 
-class MetaModel(type):
+class MetaModel(AttributeContainerMeta):
     """
     Model meta class
 
@@ -161,6 +161,7 @@ class MetaModel(type):
     Model.index.query()
     """
     def __init__(cls, name, bases, attrs):
+        super(MetaModel, cls).__init__(name, bases, attrs)
         if isinstance(attrs, dict):
             for attr_name, attr_obj in attrs.items():
                 if attr_name == META_CLASS_NAME:

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -19,7 +19,7 @@ from pynamodb.models import Model
 from pynamodb.attributes import (
     BinarySetAttribute, BinaryAttribute, NumberSetAttribute, NumberAttribute,
     UnicodeAttribute, UnicodeSetAttribute, UTCDateTimeAttribute, BooleanAttribute, LegacyBooleanAttribute,
-    MapAttribute, ListAttribute, Attribute,
+    MapAttribute, MapAttributeMeta, ListAttribute, Attribute,
     JSONAttribute, DEFAULT_ENCODING, NUMBER, STRING, STRING_SET, NUMBER_SET, BINARY_SET,
     BINARY, MAP, LIST, BOOLEAN, _get_value_for_deserialize)
 
@@ -715,6 +715,9 @@ class TestMapAttribute:
             bad = t.nested.double_nested['bad']
         with pytest.raises(KeyError):
             bad = t.nested['something_else']
+
+    def test_metaclass(self):
+        assert type(MapAttribute) == MapAttributeMeta
 
 
 class TestValueDeserialize:


### PR DESCRIPTION
This pull request is a follow-up to https://github.com/pynamodb/PynamoDB/pull/324.

This change moves the `_initialize_attributes` call to the init method of a new metaclass for `AttributeContainer`. The result of this is both `_attributes` and `_dynamo_to_python_attrs` are valid as soon as the class is created as opposed to after the class is first instantiated. Contrast the following code snippet to the examples in the description of the above mentioned pull request.
```
>>> from pynamodb.attributes import Attribute, MapAttribute
>>> class SubMapAttribute(MapAttribute):
...     a = Attribute()
... 
>>> class SubSubMapAttribute(SubMapAttribute):
...     b = Attribute()
... 
>>> MapAttribute._attributes
{}
>>> SubMapAttribute._attributes
{'a': <pynamodb.attributes.Attribute object at 0x109ae9e90>}
>>> SubSubMapAttribute._attributes
{'a': <pynamodb.attributes.Attribute object at 0x109ae9e90>, 'b': <pynamodb.attributes.Attribute object at 0x109afaa50>}
```

In addition, this change re-introduces `MapAttributeMeta` to undo a breaking change from the prior pull request. `type(MapAttribute)` now continues to return `MapAttributeMeta`