### PR TITLE
Bug Fix: the CONTAINS and NOT_CONTAINS operators compare set elements

### DIFF
--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -2674,7 +2674,7 @@ class ModelTestCase(TestCase):
                     'aliases': {
                         'AttributeValueList': [
                             {
-                                'SS': ['1']
+                                'S': '1'
                             }
                         ],
                         'ComparisonOperator': 'CONTAINS'


### PR DESCRIPTION
From the docs:

"AttributeValueList can contain only one value of type String, Number, or Binary (not a set)."

http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.Conditions.html