### PR TITLE
Replace Expected / QueryFilter / ScanFilter with ConditionExpresion / FilterExpression

### DIFF
--- a/pynamodb/constants.py
+++ b/pynamodb/constants.py
@@ -63,8 +63,10 @@ UTC = 'UTC'
 KEY = 'Key'
 
 # Expression Parameters
+CONDITION_EXPRESSION = 'ConditionExpression'
 EXPRESSION_ATTRIBUTE_NAMES = 'ExpressionAttributeNames'
 EXPRESSION_ATTRIBUTE_VALUES = 'ExpressionAttributeValues'
+FILTER_EXPRESSION = 'FilterExpression'
 KEY_CONDITION_EXPRESSION = 'KeyConditionExpression'
 PROJECTION_EXPRESSION = 'ProjectionExpression'
 
@@ -216,6 +218,21 @@ TOTAL_SEGMENTS = 'TotalSegments'
 SCAN_FILTER_VALUES = [EQ, NE, LE, LT, GE, GT, NOT_NULL, NULL, CONTAINS, NOT_CONTAINS, BEGINS_WITH, IN, BETWEEN]
 QUERY_FILTER_VALUES = SCAN_FILTER_VALUES
 DELETE_FILTER_VALUES = SCAN_FILTER_VALUES
+FILTER_EXPRESSION_OPERATOR_MAP = {
+    EQ: '__eq__',
+    NE: '__ne__',
+    LE: '__le__',
+    LT: '__lt__',
+    GE: '__ge__',
+    GT: '__gt__',
+    NOT_NULL: 'exists',
+    NULL: 'not_exists',
+    CONTAINS: 'contains',
+    NOT_CONTAINS: 'contains',  # special cased
+    BEGINS_WITH: 'startswith',
+    IN: 'is_in',
+    BETWEEN: 'between'
+}
 
 
 # These are constants used in the expected condition for PutItem

--- a/pynamodb/expressions/condition.py
+++ b/pynamodb/expressions/condition.py
@@ -1,5 +1,7 @@
 from copy import copy
-from pynamodb.constants import AND, ATTR_TYPE_MAP, BETWEEN, IN, OR, SHORT_ATTR_TYPES, STRING_SHORT
+from pynamodb.constants import (
+    AND, ATTR_TYPE_MAP, BETWEEN, BINARY_SHORT, IN, NUMBER_SHORT, OR, SHORT_ATTR_TYPES, STRING_SHORT
+)
 from pynamodb.expressions.util import get_value_placeholder, substitute_names
 from six.moves import range
 
@@ -68,7 +70,7 @@ class Size(Operand):
     def _serialize(self, value):
         if not isinstance(value, int):
             raise TypeError("size must be compared to an integer, not {0}".format(type(value).__name__))
-        return {'N': str(value)}
+        return {NUMBER_SHORT: str(value)}
 
     def __str__(self):
         return "size({0})".format(self.path)
@@ -235,8 +237,8 @@ class Contains(Condition):
 
     def __init__(self, path, item):
         (attr_type, value), = item.items()
-        if attr_type != STRING_SHORT:
-            raise ValueError("{0} must be a string".format(value))
+        if attr_type not in [BINARY_SHORT, NUMBER_SHORT, STRING_SHORT]:
+            raise ValueError("{0} must be a string, number, or binary element".format(value))
         super(Contains, self).__init__(path, 'contains', item)
 
 

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -529,10 +529,9 @@ class ConnectionTestCase(TestCase):
                         'S': 'How do I update multiple items?'
                     }
                 },
-                'Expected': {
-                    'ForumName': {
-                        'Exists': False
-                    }
+                'ConditionExpression': 'attribute_not_exists (#0)',
+                'ExpressionAttributeNames': {
+                    '#0': 'ForumName'
                 },
                 'TableName': self.test_table_name,
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -559,13 +558,11 @@ class ConnectionTestCase(TestCase):
                         'S': 'How do I update multiple items?'
                     }
                 },
-                'Expected': {
-                    'ForumName': {
-                        'Exists': False
-                    }
+                'ConditionExpression': 'attribute_not_exists (#0)',
+                'ExpressionAttributeNames': {
+                    '#0': 'ForumName'
                 },
                 'TableName': self.test_table_name,
-                'ConditionalOperator': 'AND',
                 'ReturnConsumedCapacity': 'TOTAL',
                 'ReturnItemCollectionMetrics': 'SIZE'
             }
@@ -693,10 +690,9 @@ class ConnectionTestCase(TestCase):
                         'S': 'foo-range-key'
                     }
                 },
-                'Expected': {
-                    'Forum': {
-                        'Exists': False
-                    }
+                'ConditionExpression': 'attribute_not_exists (#0)',
+                'ExpressionAttributeNames': {
+                    '#0': 'Forum'
                 },
                 'AttributeUpdates': {
                     'Subject': {
@@ -877,17 +873,16 @@ class ConnectionTestCase(TestCase):
                         'Action': 'PUT'
                     }
                 },
-                'Expected': {
-                    'ForumName': {
-                        'Exists': False
-                    },
-                    'Subject': {
-                        'Value': {
-                            'S': 'Foo'
-                        }
+                'ConditionExpression': '(attribute_not_exists (#0) AND #1 = :0)',
+                'ExpressionAttributeNames': {
+                    '#0': 'ForumName',
+                    '#1': 'Subject'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'Foo'
                     }
                 },
-                'ConditionalOperator': 'AND',
                 'ReturnConsumedCapacity': 'TOTAL',
                 'TableName': 'ci-table'
             }
@@ -1004,12 +999,14 @@ class ConnectionTestCase(TestCase):
             params = {
                 'ReturnConsumedCapacity': 'TOTAL',
                 'TableName': self.test_table_name,
-                'Expected': {
-                    'Forum': {
-                        'Exists': False
-                    },
-                    'Subject': {
-                        'Value': {'S': 'Foo'}
+                'ConditionExpression': '(attribute_not_exists (#0) AND #1 = :0)',
+                'ExpressionAttributeNames': {
+                    '#0': 'Forum',
+                    '#1': 'Subject'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'Foo'
                     }
                 },
                 'Item': {
@@ -1037,11 +1034,13 @@ class ConnectionTestCase(TestCase):
             )
             params = {
                 'TableName': self.test_table_name,
-                'Expected': {
-                    'ForumName': {
-                        'Value': {
-                            'S': 'item1-hash'
-                        }
+                'ConditionExpression': '#0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'ForumName'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'item1-hash'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -1481,8 +1480,7 @@ class ConnectionTestCase(TestCase):
                     }
                 },
                 'TableName': 'Thread',
-                'Select': 'ALL_ATTRIBUTES',
-                'ConditionalOperator': 'AND'
+                'Select': 'ALL_ATTRIBUTES'
             }
             self.assertEqual(req.call_args[0][1], params)
 
@@ -1741,12 +1739,13 @@ class ConnectionTestCase(TestCase):
             params = {
                 'ReturnConsumedCapacity': 'TOTAL',
                 'TableName': table_name,
-                'ScanFilter': {
-                    'ForumName': {
-                        'AttributeValueList': [
-                            {'S': 'Foo'}
-                        ],
-                        'ComparisonOperator': 'BEGINS_WITH'
+                'FilterExpression': 'begins_with (#0, :0)',
+                'ExpressionAttributeNames': {
+                    '#0': 'ForumName'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'Foo'
                     }
                 }
             }
@@ -1761,12 +1760,13 @@ class ConnectionTestCase(TestCase):
             params = {
                 'ReturnConsumedCapacity': 'TOTAL',
                 'TableName': table_name,
-                'ScanFilter': {
-                    'ForumName': {
-                        'AttributeValueList': [
-                            {'S': 'Foo'}
-                        ],
-                        'ComparisonOperator': 'BEGINS_WITH'
+                'FilterExpression': 'begins_with (#0, :0)',
+                'ExpressionAttributeNames': {
+                    '#0': 'ForumName'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'Foo'
                     }
                 }
             }
@@ -1795,21 +1795,19 @@ class ConnectionTestCase(TestCase):
             params = {
                 'ReturnConsumedCapacity': 'TOTAL',
                 'TableName': table_name,
-                'ScanFilter': {
-                    'ForumName': {
-                        'AttributeValueList': [
-                            {'S': 'Foo'}
-                        ],
-                        'ComparisonOperator': 'BEGINS_WITH'
-                    },
-                    'Subject': {
-                        'AttributeValueList': [
-                            {'S': 'Foo'}
-                        ],
-                        'ComparisonOperator': 'CONTAINS'
-                    }
+                'FilterExpression': '(begins_with (#0, :0) AND contains (#1, :1))',
+                'ExpressionAttributeNames': {
+                    '#0': 'ForumName',
+                    '#1': 'Subject'
                 },
-                'ConditionalOperator': 'AND'
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'Foo'
+                    },
+                    ':1': {
+                        'S': 'Foo'
+                    }
+                }
             }
             self.assertEqual(req.call_args[0][1], params)
 

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -1,4 +1,4 @@
-from pynamodb.attributes import ListAttribute, UnicodeAttribute
+from pynamodb.attributes import ListAttribute, NumberSetAttribute, UnicodeAttribute, UnicodeSetAttribute
 from pynamodb.compat import CompatTestCase as TestCase
 from pynamodb.expressions.condition import Path, size
 from pynamodb.expressions.projection import create_projection_expression
@@ -193,6 +193,30 @@ class ConditionExpressionTestCase(TestCase):
 
     def test_contains(self):
         condition = self.attribute.contains('bar')
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "contains (#0, :0)"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S' : 'bar'}}
+
+    def test_contains_string_set(self):
+        condition = UnicodeSetAttribute(attr_name='foo').contains('bar')
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "contains (#0, :0)"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S' : 'bar'}}
+
+    def test_contains_number_set(self):
+        condition = NumberSetAttribute(attr_name='foo').contains(1)
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "contains (#0, :0)"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'N' : '1'}}
+
+    def test_contains_list(self):
+        condition = ListAttribute(attr_name='foo').contains('bar')
         placeholder_names, expression_attribute_values = {}, {}
         expression = condition.serialize(placeholder_names, expression_attribute_values)
         assert expression == "contains (#0, :0)"

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -772,9 +772,13 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'Expected': {
-                    'user_id': {
-                        'Value': {'S': 'bar'},
+                'ConditionExpression': '#0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'user_id'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'bar'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -795,9 +799,13 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'Expected': {
-                    'user_id': {
-                        'Value': {'S': 'bar'},
+                'ConditionExpression': '#0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'user_id'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'bar'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -818,20 +826,19 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'Expected': {
-                    'email': {
-                        'AttributeValueList': [
-                            {'S': '@'}
-                        ],
-                        'ComparisonOperator': 'CONTAINS'
+                'ConditionExpression': '(contains (#0, :0) AND #1 = :1)',
+                'ExpressionAttributeNames': {
+                    '#0': 'email',
+                    '#1': 'user_id'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': '@'
                     },
-                    'user_id': {
-                        'Value': {
-                            'S': 'bar'
-                        }
+                    ':1': {
+                        'S': 'bar'
                     }
                 },
-                'ConditionalOperator': 'AND',
                 'ReturnConsumedCapacity': 'TOTAL',
                 'TableName': 'UserModel'
             }
@@ -1006,16 +1013,18 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'Expected': {
-                    'user_name': {
-                        'Value': {'S': 'foo'}
+                'ConditionExpression': '((NOT contains (#0, :0)) AND #1 = :1)',
+                'ExpressionAttributeNames': {
+                    '#0': 'email',
+                    '#1': 'user_name'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': '@'
                     },
-                    'email': {
-                        'AttributeValueList': [
-                            {'S': '@'}
-                        ],
-                        'ComparisonOperator': 'NOT_CONTAINS'
-                    },
+                    ':1': {
+                        'S': 'foo'
+                    }
                 },
                 'AttributeUpdates': {
                     'views': {
@@ -1047,8 +1056,9 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'Expected': {
-                    'user_name': {'Exists': False}
+                'ConditionExpression': 'attribute_not_exists (#0)',
+                'ExpressionAttributeNames': {
+                    '#0': 'user_name'
                 },
                 'AttributeUpdates': {
                     'views': {
@@ -1159,13 +1169,14 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'Expected': {
-                    'numbers': {
-                        'AttributeValueList': [
-                            {'NS': ['1', '2']}
-                        ],
-                        'ComparisonOperator': 'EQ'
-                    },
+                'ConditionExpression': '#0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'numbers'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'NS': ['1', '2']
+                    }
                 },
                 'AttributeUpdates': {
                     'views': {
@@ -1198,14 +1209,17 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'Expected': {
-                    'email': {
-                        'AttributeValueList': [
-                            {'S': '1@pynamo.db'},
-                            {'S': '2@pynamo.db'}
-                        ],
-                        'ComparisonOperator': 'IN'
+                'ConditionExpression': '#0 IN (:0, :1)',
+                'ExpressionAttributeNames': {
+                    '#0': 'email'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': '1@pynamo.db'
                     },
+                    ':1': {
+                        'S': '2@pynamo.db'
+                    }
                 },
                 'AttributeUpdates': {
                     'views': {
@@ -1326,10 +1340,9 @@ class ModelTestCase(TestCase):
                         'S': u'foo'
                     },
                 },
-                'Expected': {
-                    'email': {
-                        'Exists': False
-                    }
+                'ConditionExpression': 'attribute_not_exists (#0)',
+                'ExpressionAttributeNames': {
+                    '#0': 'email'
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
                 'TableName': 'UserModel'
@@ -1355,13 +1368,10 @@ class ModelTestCase(TestCase):
                         'S': u'foo'
                     },
                 },
-                'Expected': {
-                    'email': {
-                        'Exists': False
-                    },
-                    'zip_code': {
-                        'ComparisonOperator': 'NOT_NULL'
-                    }
+                'ConditionExpression': '(attribute_not_exists (#0) AND attribute_exists (#1))',
+                'ExpressionAttributeNames': {
+                    '#0': 'email',
+                    '#1': 'zip_code'
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
                 'TableName': 'UserModel'
@@ -1387,19 +1397,18 @@ class ModelTestCase(TestCase):
                         'S': u'foo'
                     },
                 },
-                'ConditionalOperator': 'OR',
-                'Expected': {
-                    'user_name': {
-                        'Value': {'S': 'bar'}
+                'ConditionExpression': '((contains (#0, :0) OR #1 = :1) OR attribute_not_exists (#2))',
+                'ExpressionAttributeNames': {
+                    '#0': 'email',
+                    '#1': 'user_name',
+                    '#2': 'zip_code'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': '@'
                     },
-                    'zip_code': {
-                        'ComparisonOperator': 'NULL'
-                    },
-                    'email': {
-                        'ComparisonOperator': 'CONTAINS',
-                        'AttributeValueList': [
-                            {'S': '@'}
-                        ]
+                    ':1': {
+                        'S': 'bar'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -1426,9 +1435,13 @@ class ModelTestCase(TestCase):
                         'S': u'foo'
                     },
                 },
-                'Expected': {
-                    'user_name': {
-                        'Value': {'S': 'foo'}
+                'ConditionExpression': '#0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'user_name'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'foo'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -1833,9 +1846,13 @@ class ModelTestCase(TestCase):
                 queried.append(item._serialize())
             params = {
                 'KeyConditionExpression': '(#0 = :0 AND begins_with (#1, :1))',
+                'FilterExpression': '((contains (#2, :2) AND attribute_exists (#3)) AND #4 BETWEEN :3 AND :4)',
                 'ExpressionAttributeNames': {
                     '#0': 'user_name',
-                    '#1': 'user_id'
+                    '#1': 'user_id',
+                    '#2': 'email',
+                    '#3': 'picture',
+                    '#4': 'zip_code'
                 },
                 'ExpressionAttributeValues': {
                     ':0': {
@@ -1843,24 +1860,15 @@ class ModelTestCase(TestCase):
                     },
                     ':1': {
                         'S': u'id'
-                    }
-                },
-                'QueryFilter': {
-                    'email': {
-                        'AttributeValueList': [
-                            {'S': '@'}
-                        ],
-                        'ComparisonOperator': 'CONTAINS'
                     },
-                    'zip_code': {
-                        'ComparisonOperator': 'BETWEEN',
-                        'AttributeValueList': [
-                            {'N': '2'},
-                            {'N': '3'}
-                        ]
+                    ':2': {
+                        'S': '@'
                     },
-                    'picture': {
-                        'ComparisonOperator': 'NOT_NULL'
+                    ':3': {
+                        'N': '2'
+                    },
+                    ':4': {
+                        'N': '3'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -1942,9 +1950,13 @@ class ModelTestCase(TestCase):
                 queried.append(item._serialize())
             params = {
                 'KeyConditionExpression': '(#0 = :0 AND begins_with (#1, :1))',
+                'FilterExpression': '((contains (#2, :2) AND attribute_exists (#3)) AND #4 >= :3)',
                 'ExpressionAttributeNames': {
                     '#0': 'user_name',
-                    '#1': 'user_id'
+                    '#1': 'user_id',
+                    '#2': 'email',
+                    '#3': 'picture',
+                    '#4': 'zip_code'
                 },
                 'ExpressionAttributeValues': {
                     ':0': {
@@ -1952,39 +1964,19 @@ class ModelTestCase(TestCase):
                     },
                     ':1': {
                         'S': u'id'
+                    },
+                    ':2': {
+                        'S': '@'
+                    },
+                    ':3': {
+                        'N': '2'
                     }
                 },
-                'query_filter': {
-                    'email': {
-                        'AttributeValueList': [
-                            {'S': '@'}
-                        ],
-                        'ComparisonOperator': 'CONTAINS'
-                    },
-                    'zip_code': {
-                        'ComparisonOperator': 'GE',
-                        'AttributeValueList': [
-                            {'N': '2'},
-                        ]
-                    },
-                    'picture': {
-                        'ComparisonOperator': 'NOT_NULL'
-                    }
-                },
-                'ConditionalOperator': 'AND',
                 'ReturnConsumedCapacity': 'TOTAL',
                 'TableName': 'UserModel'
             }
 
-            for key in ('ConditionalOperator', 'ReturnConsumedCapacity', 'TableName'):
-                self.assertEqual(req.call_args[0][1][key], params[key])
-            for key in ('KeyConditionExpression', 'ExpressionAttributeNames', 'ExpressionAttributeValues'):
-                self.assertEqual(req.call_args[0][1][key], params[key])
-            for key in ('email', 'zip_code', 'picture'):
-                self.assertEqual(
-                    sorted(req.call_args[0][1]['QueryFilter'][key].items(), key=lambda x: x[0]),
-                    sorted(params['query_filter'][key].items(), key=lambda x: x[0]),
-                )
+            self.assertEqual(req.call_args[0][1], params)
             self.assertTrue(len(queried) == len(items))
 
     def test_rate_limited_scan(self):
@@ -2069,18 +2061,15 @@ class ModelTestCase(TestCase):
             params = {
                 'Limit': 13,
                 'ReturnConsumedCapacity': 'TOTAL',
-                'ScanFilter': {
-                    'user_id': {
-                        'AttributeValueList': [
-                            {'S': 'tux'}
-                        ],
-                        'ComparisonOperator': 'CONTAINS'
-                    },
-                    'zip_code': {
-                        'ComparisonOperator': 'NOT_NULL'
-                    },
-                    'email': {
-                        'ComparisonOperator': 'NULL'
+                'FilterExpression': '((attribute_not_exists (#0) AND contains (#1, :0)) AND attribute_exists (#2))',
+                'ExpressionAttributeNames': {
+                    '#0': 'email',
+                    '#1': 'user_id',
+                    '#2': 'zip_code'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'tux'
                     }
                 },
                 'TableName': 'UserModel'
@@ -2104,21 +2093,17 @@ class ModelTestCase(TestCase):
             params = {
                 'Limit': 12,
                 'ReturnConsumedCapacity': 'TOTAL',
-                'ScanFilter': {
-                    'user_id': {
-                        'AttributeValueList': [
-                            {'S': 'tux'}
-                        ],
-                        'ComparisonOperator': 'CONTAINS'
-                    },
-                    'zip_code': {
-                        'ComparisonOperator': 'NOT_NULL'
-                    },
-                    'email': {
-                        'ComparisonOperator': 'NULL'
+                'FilterExpression': '((attribute_not_exists (#0) OR contains (#1, :0)) OR attribute_exists (#2))',
+                'ExpressionAttributeNames': {
+                    '#0': 'email',
+                    '#1': 'user_id',
+                    '#2': 'zip_code'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'tux'
                     },
                 },
-                'ConditionalOperator': 'OR',
                 'TableName': 'UserModel'
             }
 
@@ -2185,18 +2170,15 @@ class ModelTestCase(TestCase):
                 self.assertIsNotNone(item)
             params = {
                 'ReturnConsumedCapacity': 'TOTAL',
-                'ScanFilter': {
-                    'user_id': {
-                        'AttributeValueList': [
-                            {'S': 'tux'}
-                        ],
-                        'ComparisonOperator': 'CONTAINS'
-                    },
-                    'zip_code': {
-                        'ComparisonOperator': 'NOT_NULL'
-                    },
-                    'email': {
-                        'ComparisonOperator': 'NULL'
+                'FilterExpression': '((attribute_not_exists (#0) AND contains (#1, :0)) AND attribute_exists (#2))',
+                'ExpressionAttributeNames': {
+                    '#0': 'email',
+                    '#1': 'user_id',
+                    '#2': 'zip_code'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'tux'
                     }
                 },
                 'TableName': 'UserModel'
@@ -2218,21 +2200,17 @@ class ModelTestCase(TestCase):
                 self.assertIsNotNone(item)
             params = {
                 'ReturnConsumedCapacity': 'TOTAL',
-                'ScanFilter': {
-                    'user_id': {
-                        'AttributeValueList': [
-                            {'S': 'tux'}
-                        ],
-                        'ComparisonOperator': 'CONTAINS'
-                    },
-                    'zip_code': {
-                        'ComparisonOperator': 'NOT_NULL'
-                    },
-                    'email': {
-                        'ComparisonOperator': 'NULL'
-                    },
+                'FilterExpression': '((attribute_not_exists (#0) OR contains (#1, :0)) OR attribute_exists (#2))',
+                'ExpressionAttributeNames': {
+                    '#0': 'email',
+                    '#1': 'user_id',
+                    '#2': 'zip_code'
                 },
-                'ConditionalOperator': 'OR',
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'tux'
+                    }
+                },
                 'TableName': 'UserModel'
             }
             self.assertEquals(params, req.call_args[0][1])
@@ -2658,9 +2636,11 @@ class ModelTestCase(TestCase):
 
             params = {
                 'KeyConditionExpression': '(#0 = :0 AND begins_with (#1, :1))',
+                'FilterExpression': 'contains (#2, :2)',
                 'ExpressionAttributeNames': {
                     '#0': 'email',
-                    '#1': 'user_name'
+                    '#1': 'user_name',
+                    '#2': 'aliases'
                 },
                 'ExpressionAttributeValues': {
                     ':0': {
@@ -2668,16 +2648,9 @@ class ModelTestCase(TestCase):
                     },
                     ':1': {
                         'S': u'bar'
-                    }
-                },
-                'QueryFilter': {
-                    'aliases': {
-                        'AttributeValueList': [
-                            {
-                                'S': '1'
-                            }
-                        ],
-                        'ComparisonOperator': 'CONTAINS'
+                    },
+                    ':2': {
+                        'S': '1'
                     }
                 },
                 'IndexName': 'email_index',

--- a/pynamodb/tests/test_table_connection.py
+++ b/pynamodb/tests/test_table_connection.py
@@ -333,11 +333,9 @@ class ConnectionTestCase(TestCase):
                     }
                 },
                 'TableName': self.test_table_name,
-                'ConditionalOperator': 'AND',
-                'Expected': {
-                    'ForumName': {
-                        'Exists': False
-                    }
+                'ConditionExpression': 'attribute_not_exists (#0)',
+                'ExpressionAttributeNames': {
+                    '#0': 'ForumName'
                 }
             }
             self.assertEqual(req.call_args[0][1], params)


### PR DESCRIPTION
This PR is the fourth step towards moving off of the legacy conditional parameters (#219).

With this change the `conditional_operator `, `expected`, `scan_filter`, and `query_filter` parameters now use the ConditionExpression / FilterExpression API.