### PR TITLE
Query and Scan Filters using Condition Expressions

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -1319,8 +1319,10 @@ class Connection(object):
             # FilterExpression does not allow key attributes. Check for hash and range key name placeholders
             hash_key_placeholder = name_placeholders.get(hash_keyname)
             range_key_placeholder = range_keyname and name_placeholders.get(range_keyname)
-            if hash_key_placeholder in filter_expression or \
-                (range_key_placeholder and range_key_placeholder in filter_expression):
+            if (
+                hash_key_placeholder in filter_expression or
+                (range_key_placeholder and range_key_placeholder in filter_expression)
+            ):
                 raise ValueError("'filter_condition' cannot contain key attributes")
             operation_kwargs[FILTER_EXPRESSION] = filter_expression
         if attributes_to_get:

--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -138,6 +138,7 @@ class TableConnection(object):
             attributes_to_get=attributes_to_get)
 
     def rate_limited_scan(self,
+             filter_condition=None,
              attributes_to_get=None,
              page_size=None,
              limit=None,
@@ -157,6 +158,7 @@ class TableConnection(object):
         """
         return self.connection.rate_limited_scan(
             self.table_name,
+            filter_condition=filter_condition,
             attributes_to_get=attributes_to_get,
             page_size=page_size,
             limit=limit,
@@ -173,6 +175,7 @@ class TableConnection(object):
             consistent_read=consistent_read)
 
     def scan(self,
+             filter_condition=None,
              attributes_to_get=None,
              limit=None,
              conditional_operator=None,
@@ -187,6 +190,7 @@ class TableConnection(object):
         """
         return self.connection.scan(
             self.table_name,
+            filter_condition=filter_condition,
             attributes_to_get=attributes_to_get,
             limit=limit,
             conditional_operator=conditional_operator,
@@ -199,6 +203,8 @@ class TableConnection(object):
 
     def query(self,
               hash_key,
+              range_key_condition=None,
+              filter_condition=None,
               attributes_to_get=None,
               consistent_read=False,
               exclusive_start_key=None,
@@ -217,6 +223,8 @@ class TableConnection(object):
         return self.connection.query(
             self.table_name,
             hash_key,
+            range_key_condition=range_key_condition,
+            filter_condition=filter_condition,
             attributes_to_get=attributes_to_get,
             consistent_read=consistent_read,
             exclusive_start_key=exclusive_start_key,

--- a/pynamodb/expressions/condition.py
+++ b/pynamodb/expressions/condition.py
@@ -137,6 +137,10 @@ class Condition(object):
         self.operator = operator
         self.values = values
 
+    # http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-KeyConditionExpression
+    def is_valid_range_key_condition(self, path):
+        return str(self.path) == path and self.operator in ['=', '<', '<=', '>', '>=', BETWEEN, 'begins_with']
+
     def serialize(self, placeholder_names, expression_attribute_values):
         path = self._get_path(self.path, placeholder_names)
         values = self._get_values(placeholder_names, expression_attribute_values)
@@ -175,7 +179,7 @@ class Condition(object):
         return Not(self)
 
     def __repr__(self):
-        values = [repr(value) if isinstance(value, Condition) else value.items()[0][1] for value in self.values]
+        values = [repr(value) if isinstance(value, Condition) else list(value.items())[0][1] for value in self.values]
         return self.format_string.format(*values, path=self.path, operator = self.operator)
 
     def __nonzero__(self):

--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -45,6 +45,8 @@ class Index(with_metaclass(IndexMeta)):
     @classmethod
     def count(cls,
               hash_key,
+              range_key_condition=None,
+              filter_condition=None,
               consistent_read=False,
               **filters):
         """
@@ -52,6 +54,8 @@ class Index(with_metaclass(IndexMeta)):
         """
         return cls.Meta.model.count(
             hash_key,
+            range_key_condition=range_key_condition,
+            filter_condition=filter_condition,
             index_name=cls.Meta.index_name,
             consistent_read=consistent_read,
             **filters
@@ -60,6 +64,8 @@ class Index(with_metaclass(IndexMeta)):
     @classmethod
     def query(self,
               hash_key,
+              range_key_condition=None,
+              filter_condition=None,
               scan_index_forward=None,
               consistent_read=False,
               limit=None,
@@ -71,6 +77,8 @@ class Index(with_metaclass(IndexMeta)):
         """
         return self.Meta.model.query(
             hash_key,
+            range_key_condition=range_key_condition,
+            filter_condition=filter_condition,
             index_name=self.Meta.index_name,
             scan_index_forward=scan_index_forward,
             consistent_read=consistent_read,

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -517,6 +517,8 @@ class Model(AttributeContainer):
     @classmethod
     def count(cls,
               hash_key=None,
+              range_key_condition=None,
+              filter_condition=None,
               consistent_read=False,
               index_name=None,
               limit=None,
@@ -525,6 +527,8 @@ class Model(AttributeContainer):
         Provides a filtered count
 
         :param hash_key: The hash key to query. Can be None.
+        :param range_key_condition: Condition for range key
+        :param filter_condition: Condition used to restrict the query results
         :param consistent_read: If True, a consistent read is performed
         :param index_name: If set, then this index is used
         :param filters: A dictionary of filters to be used in the query. Requires a hash_key to be passed.
@@ -562,6 +566,8 @@ class Model(AttributeContainer):
             started = True
             data = cls._get_connection().query(
                 hash_key,
+                range_key_condition=range_key_condition,
+                filter_condition=filter_condition,
                 index_name=index_name,
                 consistent_read=consistent_read,
                 key_conditions=key_conditions,
@@ -578,6 +584,8 @@ class Model(AttributeContainer):
     @classmethod
     def query(cls,
               hash_key,
+              range_key_condition=None,
+              filter_condition=None,
               consistent_read=False,
               index_name=None,
               scan_index_forward=None,
@@ -591,6 +599,8 @@ class Model(AttributeContainer):
         Provides a high level query API
 
         :param hash_key: The hash key to query
+        :param range_key_condition: Condition for range key
+        :param filter_condition: Condition used to restrict the query results
         :param consistent_read: If True, a consistent read is performed
         :param index_name: If set, then this index is used
         :param limit: Used to limit the number of results returned
@@ -630,6 +640,8 @@ class Model(AttributeContainer):
         log.debug("Fetching first query page")
 
         query_kwargs = dict(
+            range_key_condition=range_key_condition,
+            filter_condition=filter_condition,
             index_name=index_name,
             exclusive_start_key=last_evaluated_key,
             consistent_read=consistent_read,
@@ -668,6 +680,7 @@ class Model(AttributeContainer):
 
     @classmethod
     def rate_limited_scan(cls,
+            filter_condition=None,
             attributes_to_get=None,
             segment=None,
             total_segments=None,
@@ -686,6 +699,7 @@ class Model(AttributeContainer):
         Scans the items in the table at a definite rate.
         Invokes the low level rate_limited_scan API.
 
+        :param filter_condition: Condition used to restrict the scan results
         :param attributes_to_get: A list of attributes to return.
         :param segment: If set, then scans the segment
         :param total_segments: If set, then specifies total segments
@@ -717,6 +731,7 @@ class Model(AttributeContainer):
         key_filter.update(scan_filter)
 
         scan_result = cls._get_connection().rate_limited_scan(
+            filter_condition=filter_condition,
             attributes_to_get=attributes_to_get,
             page_size=page_size,
             limit=limit,
@@ -738,6 +753,7 @@ class Model(AttributeContainer):
 
     @classmethod
     def scan(cls,
+             filter_condition=None,
              segment=None,
              total_segments=None,
              limit=None,
@@ -749,6 +765,7 @@ class Model(AttributeContainer):
         """
         Iterates through all items in the table
 
+        :param filter_condition: Condition used to restrict the scan results
         :param segment: If set, then scans the segment
         :param total_segments: If set, then specifies total segments
         :param limit: Used to limit the number of results returned
@@ -770,6 +787,7 @@ class Model(AttributeContainer):
             page_size = limit
 
         data = cls._get_connection().scan(
+            filter_condition=filter_condition,
             exclusive_start_key=last_evaluated_key,
             segment=segment,
             limit=page_size,
@@ -790,6 +808,7 @@ class Model(AttributeContainer):
         while last_evaluated_key:
             log.debug("Fetching scan page with exclusive start key: %s", last_evaluated_key)
             data = cls._get_connection().scan(
+                filter_condition=filter_condition,
                 exclusive_start_key=last_evaluated_key,
                 limit=page_size,
                 scan_filter=key_filter,

--- a/pynamodb/tests/test_table_connection.py
+++ b/pynamodb/tests/test_table_connection.py
@@ -452,6 +452,32 @@ class ConnectionTestCase(TestCase):
         with patch(PATCH_METHOD) as req:
             req.return_value = DESCRIBE_TABLE_DATA
             conn.describe_table()
+
+        with patch(PATCH_METHOD) as req:
+            req.return_value = {}
+            conn.query(
+                "FooForum",
+                Path('Subject').startswith('thread')
+            )
+            params = {
+                'ReturnConsumedCapacity': 'TOTAL',
+                'KeyConditionExpression': '(#0 = :0 AND begins_with (#1, :1))',
+                'ExpressionAttributeNames': {
+                    '#0': 'ForumName',
+                    '#1': 'Subject'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'FooForum'
+                    },
+                    ':1': {
+                        'S': 'thread'
+                    }
+                },
+                'TableName': self.test_table_name
+            }
+            self.assertEqual(req.call_args[0][1], params)
+
         with patch(PATCH_METHOD) as req:
             req.return_value = {}
             conn.query(
@@ -518,6 +544,7 @@ class ConnectionTestCase(TestCase):
             )
             self.assertEqual(self.test_table_name, req.call_args[0][0])
             params = {
+                'filter_condition': None,
                 'attributes_to_get': 'attributes_to_get',
                 'page_size': 1,
                 'limit': 2,


### PR DESCRIPTION
This PR is the sixth step towards moving off of the legacy conditional parameters (#219).

With this change `query` and `scan` now take additional keyword args for `range_key_condition` (query only) and `filter_condition`.

Using legacy filter parameters will emit a warning. Using both condition expressions and legacy parameters will raise a ValueError.

Note: The legacy filter parameters allow some invalid commands to be created. The new parameters correctly detect invalid commands and raise a ValueError.