### PR TITLE
Replace AttributeUpdates with UpdateExpression

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -34,9 +34,9 @@ from pynamodb.constants import (
     WRITE_CAPACITY_UNITS, GLOBAL_SECONDARY_INDEXES, PROJECTION, EXCLUSIVE_START_TABLE_NAME, TOTAL,
     DELETE_TABLE, UPDATE_TABLE, LIST_TABLES, GLOBAL_SECONDARY_INDEX_UPDATES,
     CONSUMED_CAPACITY, CAPACITY_UNITS, QUERY_FILTER, QUERY_FILTER_VALUES, CONDITIONAL_OPERATOR,
-    CONDITIONAL_OPERATORS, NULL, NOT_NULL, SHORT_ATTR_TYPES, DELETE,
+    CONDITIONAL_OPERATORS, NULL, NOT_NULL, SHORT_ATTR_TYPES, DELETE, PUT,
     ITEMS, DEFAULT_ENCODING, BINARY_SHORT, BINARY_SET_SHORT, LAST_EVALUATED_KEY, RESPONSES, UNPROCESSED_KEYS,
-    UNPROCESSED_ITEMS, STREAM_SPECIFICATION, STREAM_VIEW_TYPE, STREAM_ENABLED,
+    UNPROCESSED_ITEMS, STREAM_SPECIFICATION, STREAM_VIEW_TYPE, STREAM_ENABLED, UPDATE_EXPRESSION,
     EXPRESSION_ATTRIBUTE_NAMES, EXPRESSION_ATTRIBUTE_VALUES, KEY_CONDITION_OPERATOR_MAP,
     CONDITION_EXPRESSION, FILTER_EXPRESSION, FILTER_EXPRESSION_OPERATOR_MAP, NOT_CONTAINS, AND)
 from pynamodb.exceptions import (
@@ -45,6 +45,7 @@ from pynamodb.exceptions import (
 )
 from pynamodb.expressions.condition import Condition, Path
 from pynamodb.expressions.projection import create_projection_expression
+from pynamodb.expressions.update import AddAction, DeleteAction, RemoveAction, SetAction, Update
 from pynamodb.settings import get_settings_value
 from pynamodb.signals import pre_dynamodb_send, post_dynamodb_send
 from pynamodb.types import HASH, RANGE
@@ -866,20 +867,28 @@ class Connection(object):
         if not attribute_updates:
             raise ValueError("{0} cannot be empty".format(ATTR_UPDATES))
 
-        operation_kwargs[ATTR_UPDATES] = {}
-        for key, update in attribute_updates.items():
-            value = update.get(VALUE)
-            attr_type, value = self.parse_attribute(value, return_type=True)
+        update_expression = Update()
+        # We sort the keys here for determinism. This is mostly done to simplify testing.
+        keys = list(attribute_updates.keys())
+        keys.sort()
+        for key in keys:
+            update = attribute_updates[key]
             action = update.get(ACTION)
-            if attr_type is None and action is not None and action.upper() != DELETE:
-                attr_type = self.get_attribute_type(table_name, key, value)
             if action not in ATTR_UPDATE_ACTIONS:
                 raise ValueError("{0} must be one of {1}".format(ACTION, ATTR_UPDATE_ACTIONS))
-            operation_kwargs[ATTR_UPDATES][key] = {
-                ACTION: action,
-            }
-            if action.upper() != DELETE:
-                operation_kwargs[ATTR_UPDATES][key][VALUE] = {attr_type: value}
+            value = update.get(VALUE)
+            attr_type, value = self.parse_attribute(value, return_type=True)
+            if attr_type is None and action != DELETE:
+                attr_type = self.get_attribute_type(table_name, key, value)
+            value = {attr_type: value}
+            if action == DELETE:
+                action = RemoveAction(key) if attr_type is None else DeleteAction(key, value)
+            elif action == PUT:
+                action = SetAction(key, value)
+            else:
+                action = AddAction(key, value)
+            update_expression.add_action(action)
+        operation_kwargs[UPDATE_EXPRESSION] = update_expression.serialize(name_placeholders, expression_attribute_values)
 
         # We read the conditional operator even without expected passed in to maintain existing behavior.
         conditional_operator = self.get_conditional_operator(conditional_operator or AND)
@@ -1438,6 +1447,9 @@ class Connection(object):
                 raise ValueError("'{0}' must be an instance of Condition".format(name))
             if expected_or_filter or conditional_operator is not None:
                 raise ValueError("Legacy conditional parameters cannot be used with condition expressions")
+        else:
+            if expected_or_filter or conditional_operator is not None:
+                warnings.warn("Legacy conditional parameters are deprecated in favor of condition expressions")
 
     @staticmethod
     def _reverse_dict(d):

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -870,8 +870,7 @@ class Connection(object):
         update_expression = Update()
         # We sort the keys here for determinism. This is mostly done to simplify testing.
         keys = list(attribute_updates.keys())
-        keys.sort()
-        for key in keys:
+        for key in sorted(keys):
             update = attribute_updates[key]
             action = update.get(ACTION)
             if action not in ATTR_UPDATE_ACTIONS:
@@ -1378,8 +1377,7 @@ class Connection(object):
         conditional_operator = conditional_operator[CONDITIONAL_OPERATOR]
         # We sort the keys here for determinism. This is mostly done to simplify testing.
         keys = list(expected.keys())
-        keys.sort()
-        for key in keys:
+        for key in sorted(keys):
             condition = expected[key]
             if EXISTS in condition:
                 operator = NOT_NULL if condition.get(EXISTS, True) else NULL
@@ -1414,8 +1412,7 @@ class Connection(object):
         conditional_operator = conditional_operator[CONDITIONAL_OPERATOR]
         # We sort the keys here for determinism. This is mostly done to simplify testing.
         keys = list(filters.keys())
-        keys.sort()
-        for key in keys:
+        for key in sorted(keys):
             condition = filters[key]
             operator = condition.get(COMPARISON_OPERATOR)
             if operator not in QUERY_FILTER_VALUES:

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -869,8 +869,7 @@ class Connection(object):
 
         update_expression = Update()
         # We sort the keys here for determinism. This is mostly done to simplify testing.
-        keys = list(attribute_updates.keys())
-        for key in sorted(keys):
+        for key in sorted(attribute_updates.keys()):
             update = attribute_updates[key]
             action = update.get(ACTION)
             if action not in ATTR_UPDATE_ACTIONS:
@@ -1376,8 +1375,7 @@ class Connection(object):
         condition_expression = None
         conditional_operator = conditional_operator[CONDITIONAL_OPERATOR]
         # We sort the keys here for determinism. This is mostly done to simplify testing.
-        keys = list(expected.keys())
-        for key in sorted(keys):
+        for key in sorted(expected.keys()):
             condition = expected[key]
             if EXISTS in condition:
                 operator = NOT_NULL if condition.get(EXISTS, True) else NULL
@@ -1411,8 +1409,7 @@ class Connection(object):
         condition_expression = None
         conditional_operator = conditional_operator[CONDITIONAL_OPERATOR]
         # We sort the keys here for determinism. This is mostly done to simplify testing.
-        keys = list(filters.keys())
-        for key in sorted(keys):
+        for key in sorted(filters.keys()):
             condition = filters[key]
             operator = condition.get(COMPARISON_OPERATOR)
             if operator not in QUERY_FILTER_VALUES:

--- a/pynamodb/constants.py
+++ b/pynamodb/constants.py
@@ -69,6 +69,7 @@ EXPRESSION_ATTRIBUTE_VALUES = 'ExpressionAttributeValues'
 FILTER_EXPRESSION = 'FilterExpression'
 KEY_CONDITION_EXPRESSION = 'KeyConditionExpression'
 PROJECTION_EXPRESSION = 'ProjectionExpression'
+UPDATE_EXPRESSION = 'UpdateExpression'
 
 # Defaults
 DEFAULT_ENCODING = 'utf-8'

--- a/pynamodb/expressions/update.py
+++ b/pynamodb/expressions/update.py
@@ -1,0 +1,149 @@
+from pynamodb.constants import BINARY_SET_SHORT, LIST_SHORT, NUMBER_SET_SHORT, NUMBER_SHORT, STRING_SET_SHORT
+from pynamodb.expressions.util import get_value_placeholder, substitute_names
+
+
+class Action(object):
+    format_string = ''
+
+    def __init__(self, path, value=None):
+        self.path = path
+        self.value = value
+
+    def serialize(self, placeholder_names, expression_attribute_values):
+        path = substitute_names(self.path, placeholder_names, split=True)
+        value = get_value_placeholder(self.value, expression_attribute_values) if self.value else None
+        return self.format_string.format(value, path=path)
+
+
+class SetAction(Action):
+    """
+    The SET action adds an attribute to an item.
+    """
+    format_string = '{path} = {0}'
+
+    def __init__(self, path, value):
+        super(SetAction, self).__init__(path, value)
+
+
+class IncrementAction(SetAction):
+    """
+    A SET action that is used to add to a number attribute.
+    """
+    format_string = '{path} = {path} + {0}'
+
+
+class DecrementAction(SetAction):
+    """
+    A SET action that is used to subtract from a number attribute.
+    """
+    format_string = '{path} = {path} - {0}'
+
+
+class AppendAction(SetAction):
+    """
+    A SET action that appends elements to the end of a list.
+    """
+    format_string = '{path} = list_append({path}, {0})'
+
+    def __init__(self, path, elements):
+        (attr_type, value), = elements.items()
+        if attr_type != LIST_SHORT:
+            raise ValueError("{0} must be a list".format(value))
+        super(AppendAction, self).__init__(path, elements)
+
+
+class PrependAction(SetAction):
+    """
+    A SET action that prepends elements to the beginning of a list.
+    """
+    format_string = '{path} = list_append({0}, {path})'
+
+    def __init__(self, path, elements):
+        (attr_type, value), = elements.items()
+        if attr_type != LIST_SHORT:
+            raise ValueError("{0} must be a list".format(value))
+        super(PrependAction, self).__init__(path, elements)
+
+
+class SetIfNotExistsAction(SetAction):
+    """
+    A SET action that avoids overwriting an existing attribute.
+    """
+    format_string = '{path} = if_not_exists({path}, {0})'
+
+
+class RemoveAction(Action):
+    """
+    The REMOVE action deletes an attribute from an item.
+    """
+    format_string = '{path}'
+
+    def __init__(self, path):
+        super(RemoveAction, self).__init__(path)
+
+
+class AddAction(Action):
+    """
+    The ADD action appends elements to a set or mathematically adds to a number attribute.
+    """
+    format_string = '{path} {0}'
+
+    def __init__(self, path, subset):
+        (attr_type, value), = subset.items()
+        if attr_type not in [BINARY_SET_SHORT, NUMBER_SET_SHORT, NUMBER_SHORT, STRING_SET_SHORT]:
+            raise ValueError("{0} must be a set".format(value))
+        super(AddAction, self).__init__(path, subset)
+
+
+class DeleteAction(Action):
+    """
+    The DELETE action removes elements from a set.
+    """
+    format_string = '{path} {0}'
+
+    def __init__(self, path, subset):
+        (attr_type, value), = subset.items()
+        if attr_type not in [BINARY_SET_SHORT, NUMBER_SET_SHORT, STRING_SET_SHORT]:
+            raise ValueError("{0} must be a set".format(value))
+        super(DeleteAction, self).__init__(path, subset)
+
+
+class Update(object):
+
+    def __init__(self):
+        self.set_actions = []
+        self.remove_actions = []
+        self.add_actions = []
+        self.delete_actions = []
+
+    def add_action(self, action):
+        if isinstance(action, SetAction):
+            self.set_actions.append(action)
+        elif isinstance(action, RemoveAction):
+            self.remove_actions.append(action)
+        elif isinstance(action, AddAction):
+            self.add_actions.append(action)
+        elif isinstance(action, DeleteAction):
+            self.delete_actions.append(action)
+        else:
+            raise ValueError("unsupported action type: '{0}'".format(action.__class__.__name__))
+
+    def serialize(self, placeholder_names, expression_attribute_values):
+        expression = None
+        expression = self._add_clause(expression, 'SET', self.set_actions, placeholder_names, expression_attribute_values)
+        expression = self._add_clause(expression, 'REMOVE', self.remove_actions, placeholder_names, expression_attribute_values)
+        expression = self._add_clause(expression, 'ADD', self.add_actions, placeholder_names, expression_attribute_values)
+        expression = self._add_clause(expression, 'DELETE', self.delete_actions, placeholder_names, expression_attribute_values)
+        return expression
+
+    @staticmethod
+    def _add_clause(expression, keyword, actions, placeholder_names, expression_attribute_values):
+        clause = Update._get_clause(keyword, actions, placeholder_names, expression_attribute_values)
+        if clause is None:
+            return expression
+        return clause if expression is None else expression + " " + clause
+
+    @staticmethod
+    def _get_clause(keyword, actions, placeholder_names, expression_attribute_values):
+        actions = ", ".join([action.serialize(placeholder_names, expression_attribute_values) for action in actions])
+        return keyword + " " + actions if actions else None

--- a/pynamodb/expressions/update.py
+++ b/pynamodb/expressions/update.py
@@ -31,12 +31,24 @@ class IncrementAction(SetAction):
     """
     format_string = '{path} = {path} + {0}'
 
+    def __init__(self, path, amount):
+        (attr_type, value), = amount.items()
+        if attr_type != NUMBER_SHORT:
+            raise ValueError("{0} must be a number".format(value))
+        super(IncrementAction, self).__init__(path, amount)
+
 
 class DecrementAction(SetAction):
     """
     A SET action that is used to subtract from a number attribute.
     """
     format_string = '{path} = {path} - {0}'
+
+    def __init__(self, path, amount):
+        (attr_type, value), = amount.items()
+        if attr_type != NUMBER_SHORT:
+            raise ValueError("{0} must be a number".format(value))
+        super(DecrementAction, self).__init__(path, amount)
 
 
 class AppendAction(SetAction):
@@ -91,7 +103,7 @@ class AddAction(Action):
     def __init__(self, path, subset):
         (attr_type, value), = subset.items()
         if attr_type not in [BINARY_SET_SHORT, NUMBER_SET_SHORT, NUMBER_SHORT, STRING_SET_SHORT]:
-            raise ValueError("{0} must be a set".format(value))
+            raise ValueError("{0} must be a number or set".format(value))
         super(AddAction, self).__init__(path, subset)
 
 

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -720,15 +720,14 @@ class ConnectionTestCase(TestCase):
                     }
                 },
                 'ConditionExpression': 'attribute_not_exists (#0)',
+                'UpdateExpression': 'SET #1 = :0',
                 'ExpressionAttributeNames': {
-                    '#0': 'Forum'
+                    '#0': 'Forum',
+                    '#1': 'Subject'
                 },
-                'AttributeUpdates': {
-                    'Subject': {
-                        'Value': {
-                            'S': 'foo-subject'
-                        },
-                        'Action': 'PUT'
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'foo-subject'
                     }
                 },
                 'TableName': 'ci-table'
@@ -759,16 +758,15 @@ class ConnectionTestCase(TestCase):
                         'S': 'foo-range-key'
                     }
                 },
-                'ConditionExpression': 'attribute_not_exists (#0)',
+                'ConditionExpression': 'attribute_not_exists (#1)',
+                'UpdateExpression': 'SET #0 = :0',
                 'ExpressionAttributeNames': {
-                    '#0': 'Forum'
+                    '#0': 'Subject',
+                    '#1': 'Forum'
                 },
-                'AttributeUpdates': {
-                    'Subject': {
-                        'Value': {
-                            'S': 'foo-subject'
-                        },
-                        'Action': 'PUT'
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'foo-subject'
                     }
                 },
                 'TableName': 'ci-table'
@@ -792,12 +790,13 @@ class ConnectionTestCase(TestCase):
                         'S': 'foo-range-key'
                     }
                 },
-                'AttributeUpdates': {
-                    'Subject': {
-                        'Value': {
-                            'S': 'foo-subject'
-                        },
-                        'Action': 'PUT'
+                'UpdateExpression': 'SET #0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'Subject'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'foo-subject'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -828,12 +827,13 @@ class ConnectionTestCase(TestCase):
                         'S': 'foo-range-key'
                     }
                 },
-                'AttributeUpdates': {
-                    'Subject': {
-                        'Value': {
-                            'S': 'foo-subject'
-                        },
-                        'Action': 'PUT'
+                'UpdateExpression': 'SET #0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'Subject'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'foo-subject'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -864,12 +864,13 @@ class ConnectionTestCase(TestCase):
                         'S': 'foo-range-key'
                     }
                 },
-                'AttributeUpdates': {
-                    'Subject': {
-                        'Value': {
-                            'S': 'Foo'
-                        },
-                        'Action': 'PUT'
+                'UpdateExpression': 'SET #0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'Subject'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'Foo'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -927,15 +928,8 @@ class ConnectionTestCase(TestCase):
                         'S': 'foo-range-key'
                     }
                 },
-                'AttributeUpdates': {
-                    'Subject': {
-                        'Value': {
-                            'S': 'Bar'
-                        },
-                        'Action': 'PUT'
-                    }
-                },
                 'ConditionExpression': '(attribute_not_exists (#0) AND #1 = :0)',
+                'UpdateExpression': 'SET #1 = :1',
                 'ExpressionAttributeNames': {
                     '#0': 'ForumName',
                     '#1': 'Subject'
@@ -943,6 +937,9 @@ class ConnectionTestCase(TestCase):
                 'ExpressionAttributeValues': {
                     ':0': {
                         'S': 'Foo'
+                    },
+                    ':1': {
+                        'S': 'Bar'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
@@ -980,21 +977,17 @@ class ConnectionTestCase(TestCase):
                         'S': 'foo-range-key'
                     }
                 },
-                'AttributeUpdates': {
-                    'Subject': {
-                        'Value': {
-                            'S': 'Bar'
-                        },
-                        'Action': 'PUT'
-                    }
-                },
-                'ConditionExpression': '(attribute_not_exists (#0) AND #1 = :0)',
+                'ConditionExpression': '(attribute_not_exists (#1) AND #0 = :1)',
+                'UpdateExpression': 'SET #0 = :0',
                 'ExpressionAttributeNames': {
-                    '#0': 'ForumName',
-                    '#1': 'Subject'
+                    '#0': 'Subject',
+                    '#1': 'ForumName'
                 },
                 'ExpressionAttributeValues': {
                     ':0': {
+                        'S': 'Bar'
+                    },
+                    ':1': {
                         'S': 'Foo'
                     }
                 },

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -989,34 +989,27 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'AttributeUpdates': {
-                    'email': {
-                        'Action': 'PUT',
-                        'Value': {
-                            'S': 'foo@example.com',
-                        },
+                'UpdateExpression': 'SET #0 = :0, #1 = :1, #2 = :2, #3 = :3 REMOVE #4',
+                'ExpressionAttributeNames': {
+                    '#0': 'aliases',
+                    '#1': 'email',
+                    '#2': 'is_active',
+                    '#3': 'signature',
+                    '#4': 'views'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'SS': set(['bob'])
                     },
-                    'views': {
-                        'Action': 'DELETE',
+                    ':1': {
+                        'S': 'foo@example.com',
                     },
-                    'is_active': {
-                        'Action': 'PUT',
-                        'Value': {
-                            'NULL': True,
-                        },
+                    ':2': {
+                        'NULL': True
                     },
-                    'signature': {
-                        'Action': 'PUT',
-                        'Value': {
-                            'NULL': True,
-                        },
-                    },
-                    'aliases': {
-                        'Action': 'PUT',
-                        'Value': {
-                            'SS': set(['bob']),
-                        },
-                    },
+                    ':3': {
+                        'NULL': True
+                    }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
             }
@@ -1068,12 +1061,13 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'N': '10'
-                        }
+                'UpdateExpression': 'ADD #0 :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'views'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'N': '10'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1101,9 +1095,11 @@ class ModelTestCase(TestCase):
                     }
                 },
                 'ConditionExpression': '(#0 = :0 AND (NOT contains (#1, :1)))',
+                'UpdateExpression': 'ADD #2 :2',
                 'ExpressionAttributeNames': {
                     '#0': 'user_name',
-                    '#1': 'email'
+                    '#1': 'email',
+                    '#2': 'views'
                 },
                 'ExpressionAttributeValues': {
                     ':0': {
@@ -1111,14 +1107,9 @@ class ModelTestCase(TestCase):
                     },
                     ':1': {
                         'S': '@'
-                    }
-                },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'N': '10'
-                        }
+                    },
+                    ':2': {
+                        'N': '10'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1143,25 +1134,22 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'ConditionExpression': '((NOT contains (#0, :0)) AND #1 = :1)',
+                'ConditionExpression': '((NOT contains (#1, :1)) AND #2 = :2)',
+                'UpdateExpression': 'ADD #0 :0',
                 'ExpressionAttributeNames': {
-                    '#0': 'email',
-                    '#1': 'user_name'
+                    '#0': 'views',
+                    '#1': 'email',
+                    '#2': 'user_name'
                 },
                 'ExpressionAttributeValues': {
                     ':0': {
-                        'S': '@'
+                        'N': '10'
                     },
                     ':1': {
+                        'S': '@'
+                    },
+                    ':2': {
                         'S': 'foo'
-                    }
-                },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'N': '10'
-                        }
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1187,15 +1175,14 @@ class ModelTestCase(TestCase):
                     }
                 },
                 'ConditionExpression': 'attribute_not_exists (#0)',
+                'UpdateExpression': 'ADD #1 :0',
                 'ExpressionAttributeNames': {
-                    '#0': 'user_name'
+                    '#0': 'user_name',
+                    '#1': 'views'
                 },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'N': '10'
-                        }
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'N': '10'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1220,16 +1207,15 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'ConditionExpression': 'attribute_not_exists (#0)',
+                'ConditionExpression': 'attribute_not_exists (#1)',
+                'UpdateExpression': 'ADD #0 :0',
                 'ExpressionAttributeNames': {
-                    '#0': 'user_name'
+                    '#0': 'views',
+                    '#1': 'user_name'
                 },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'N': '10'
-                        }
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'N': '10'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1246,8 +1232,14 @@ class ModelTestCase(TestCase):
             args = req.call_args[0][1]
 
             params = {
-                'AttributeUpdates': {
-                    'zip_code': {'Action': 'ADD', 'Value': {'N': '10'}}
+                'UpdateExpression': 'ADD #0 :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'zip_code'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'N': '10'
+                    }
                 },
                 'TableName': 'UserModel',
                 'ReturnValues': 'ALL_NEW',
@@ -1278,12 +1270,13 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'N': '10'
-                        }
+                'UpdateExpression': 'ADD #0 :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'views'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'N': '10'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1306,10 +1299,9 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'DELETE',
-                    }
+                'UpdateExpression': 'REMOVE #0',
+                'ExpressionAttributeNames': {
+                    '#0': 'views'
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
             }
@@ -1334,20 +1326,17 @@ class ModelTestCase(TestCase):
                     }
                 },
                 'ConditionExpression': '#0 = :0',
+                'UpdateExpression': 'ADD #1 :1',
                 'ExpressionAttributeNames': {
-                    '#0': 'numbers'
+                    '#0': 'numbers',
+                    '#1': 'views'
                 },
                 'ExpressionAttributeValues': {
                     ':0': {
                         'NS': ['1', '2']
-                    }
-                },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'N': '10'
-                        }
+                    },
+                    ':1': {
+                        'N': '10'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1372,21 +1361,18 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'ConditionExpression': '#0 = :0',
+                'ConditionExpression': '#1 = :1',
+                'UpdateExpression': 'ADD #0 :0',
                 'ExpressionAttributeNames': {
-                    '#0': 'numbers'
+                    '#0': 'views',
+                    '#1': 'numbers'
                 },
                 'ExpressionAttributeValues': {
                     ':0': {
+                        'N': '10'
+                    },
+                    ':1': {
                         'NS': ['1', '2']
-                    }
-                },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'N': '10'
-                        }
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1413,8 +1399,10 @@ class ModelTestCase(TestCase):
                     }
                 },
                 'ConditionExpression': '#0 IN (:0, :1)',
+                'UpdateExpression': 'ADD #1 :2',
                 'ExpressionAttributeNames': {
-                    '#0': 'email'
+                    '#0': 'email',
+                    '#1': 'views'
                 },
                 'ExpressionAttributeValues': {
                     ':0': {
@@ -1422,14 +1410,9 @@ class ModelTestCase(TestCase):
                     },
                     ':1': {
                         'S': '2@pynamo.db'
-                    }
-                },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'N': '10'
-                        }
+                    },
+                    ':2': {
+                        'N': '10'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1455,24 +1438,21 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'ConditionExpression': '#0 IN (:0, :1)',
+                'ConditionExpression': '#1 IN (:1, :2)',
+                'UpdateExpression': 'ADD #0 :0',
                 'ExpressionAttributeNames': {
-                    '#0': 'email'
+                    '#0': 'views',
+                    '#1': 'email'
                 },
                 'ExpressionAttributeValues': {
                     ':0': {
-                        'S': '1@pynamo.db'
+                        'N': '10'
                     },
                     ':1': {
+                        'S': '1@pynamo.db'
+                    },
+                    ':2': {
                         'S': '2@pynamo.db'
-                    }
-                },
-                'AttributeUpdates': {
-                    'views': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'N': '10'
-                        }
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1497,12 +1477,13 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'AttributeUpdates': {
-                    'aliases': {
-                        'Action': 'ADD',
-                        'Value': {
-                            'SS': set(['lita'])
-                        }
+                'UpdateExpression': 'ADD #0 :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'aliases'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'SS': set(['lita'])
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'
@@ -1521,12 +1502,13 @@ class ModelTestCase(TestCase):
                         'S': 'foo'
                     }
                 },
-                'AttributeUpdates': {
-                    'is_active': {
-                        'Action': 'PUT',
-                        'Value': {
-                            'BOOL': True
-                        }
+                'UpdateExpression': 'SET #0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'is_active'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'BOOL': True
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL'

--- a/pynamodb/tests/test_table_connection.py
+++ b/pynamodb/tests/test_table_connection.py
@@ -209,7 +209,7 @@ class ConnectionTestCase(TestCase):
 
     def test_update_item(self):
         """
-        TableConnection.delete_item
+        TableConnection.update_item
         """
         conn = TableConnection(self.test_table_name)
         with patch(PATCH_METHOD) as req:
@@ -239,12 +239,13 @@ class ConnectionTestCase(TestCase):
                         'S': 'foo-range-key'
                     }
                 },
-                'AttributeUpdates': {
-                    'Subject': {
-                        'Value': {
-                            'S': 'foo-subject'
-                        },
-                        'Action': 'PUT'
+                'UpdateExpression': 'SET #0 = :0',
+                'ExpressionAttributeNames': {
+                    '#0': 'Subject'
+                },
+                'ExpressionAttributeValues': {
+                    ':0': {
+                        'S': 'foo-subject'
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',


### PR DESCRIPTION
This PR introduces a translation from the legacy attribute update syntax to update expressions.
It is just a "complete enough" implementation in order to make update commands functional.

Further work is required to provide proper low-level and high-level APIs that tie into the "Path" and "Attribute" objects. This is purely an initial step given that the exact design of those APIs is not yet complete.