### PR TITLE
Support MapAttribute map dereferencing in condition expressions.

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -37,8 +37,15 @@ class Attribute(object):
             self.null = null
         self.is_hash_key = hash_key
         self.is_range_key = range_key
-        self.attr_name = attr_name
-        self.attr_path = []
+        self.attr_path = [attr_name]
+
+    @property
+    def attr_name(self):
+        return self.attr_path[-1]
+
+    @attr_name.setter
+    def attr_name(self, value):
+        self.attr_path[-1] = value
 
     def __set__(self, instance, value):
         if instance and not self._is_map_attribute_class_object(instance):
@@ -127,7 +134,7 @@ class Attribute(object):
 class AttributePath(Path):
 
     def __init__(self, attribute):
-        super(AttributePath, self).__init__(attribute.attr_path + [attribute.attr_name])
+        super(AttributePath, self).__init__(attribute.attr_path)
         self.attribute = attribute
 
     def __getitem__(self, idx):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -5,6 +5,7 @@ import six
 from six import add_metaclass
 import json
 from base64 import b64encode, b64decode
+from copy import deepcopy
 from datetime import datetime
 from dateutil.parser import parse
 from dateutil.tz import tzutc
@@ -37,6 +38,7 @@ class Attribute(object):
         self.is_hash_key = hash_key
         self.is_range_key = range_key
         self.attr_name = attr_name
+        self.attr_path = []
 
     def __set__(self, instance, value):
         if instance and not self._is_map_attribute_class_object(instance):
@@ -44,7 +46,11 @@ class Attribute(object):
             instance.attribute_values[attr_name] = value
 
     def __get__(self, instance, owner):
-        if instance and not self._is_map_attribute_class_object(instance):
+        if self._is_map_attribute_class_object(instance):
+            # MapAttribute class objects store a local copy of the attribute with `attr_path` set to the document path.
+            attr_name = instance._dynamo_to_python_attrs.get(self.attr_name, self.attr_name)
+            return instance.__dict__.get(attr_name, None) or self
+        elif instance:
             attr_name = instance._dynamo_to_python_attrs.get(self.attr_name, self.attr_name)
             return instance.attribute_values.get(attr_name, None)
         else:
@@ -121,12 +127,14 @@ class Attribute(object):
 class AttributePath(Path):
 
     def __init__(self, attribute):
-        super(AttributePath, self).__init__(attribute.attr_name, attribute_name=True)
+        super(AttributePath, self).__init__(attribute.attr_path + [attribute.attr_name])
         self.attribute = attribute
 
     def __getitem__(self, idx):
         if self.attribute.attr_type != LIST:  # only list elements support the list dereference operator
             raise TypeError("'{0}' object has no attribute __getitem__".format(self.attribute.__class__.__name__))
+        # The __getitem__ call returns a new Path instance, not an AttributePath instance.
+        # This is intended since the list element is not the same attribute as the list itself.
         return super(AttributePath, self).__getitem__(idx)
 
     def contains(self, item):
@@ -145,7 +153,7 @@ class AttributePath(Path):
             return self.attribute.serialize([value])[0]
         if self.attribute.attr_type == MAP and not isinstance(value, dict):
             # Map attributes assume the values to be serialized are maps.
-            return self.attribute.serialize({'': value})['']
+            return super(AttributePath, self)._serialize(value)
         return {ATTR_TYPE_MAP[self.attribute.attr_type]: self.attribute.serialize(value)}
 
 
@@ -184,6 +192,12 @@ class AttributeContainerMeta(type):
                     cls._dynamo_to_python_attrs[instance.attr_name] = item_name
                 else:
                     instance.attr_name = item_name
+
+                if isinstance(instance, MapAttribute):
+                    # To support creating expressions from nested attributes, MapAttribute instances
+                    # store local copies of the attributes in cls._attributes with `attr_path` set.
+                    # Prepend the `attr_path` lists with the dynamo attribute name.
+                    instance._update_attribute_paths(instance.attr_name)
 
 
 @add_metaclass(AttributeContainerMeta)
@@ -599,7 +613,7 @@ class MapAttribute(Attribute, AttributeContainer):
         # It is possible that attributes names can collide with argument names of Attribute.__init__.
         # Assume that this is the case if any of the following are true:
         #   - the user passed in other attributes that did not match any argument names
-        #   - this is "raw" (i.e. non-subclassed) MapAttribute instance and attempting to store the attributes
+        #   - this is a "raw" (i.e. non-subclassed) MapAttribute instance and attempting to store the attributes
         #     cannot raise a ValueError (if this assumption is wrong, calling `_make_attribute` removes them)
         #   - the names of all attributes in self.attribute_kwargs match attributes defined on the class
         if self.attribute_kwargs and (
@@ -615,12 +629,28 @@ class MapAttribute(Attribute, AttributeContainer):
     def _make_attribute(self):
         # WARNING! This function is only intended to be called from the AttributeContainerMeta metaclass.
         if not self._is_attribute_container():
-            return
+            raise AssertionError("MapAttribute._make_attribute called multiple times")
         # During initialization the kwargs were stored in `attribute_kwargs`. Remove them and re-initialize the class.
         kwargs = self.attribute_kwargs
         del self.attribute_kwargs
         del self.attribute_values
         Attribute.__init__(self, **kwargs)
+        for name, attr in self._get_attributes().items():
+            # Set a local attribute with the same name that shadows the class attribute.
+            # Because attr is a data descriptor and the attribute already exists on the class,
+            # we have to store the local copy directly into __dict__ to prevent calling attr.__set__.
+            # Use deepcopy so that `attr_path` and any local attributes are also copied.
+            self.__dict__[name] = deepcopy(attr)
+
+    def _update_attribute_paths(self, path_segment):
+        # WARNING! This function is only intended to be called from the AttributeContainerMeta metaclass.
+        if self._is_attribute_container():
+            raise AssertionError("MapAttribute._update_attribute_paths called before MapAttribute._make_attribute")
+        for name in self._get_attributes().keys():
+            local_attr = self.__dict__[name]
+            local_attr.attr_path.insert(0, path_segment)
+            if isinstance(local_attr, MapAttribute):
+                local_attr._update_attribute_paths(path_segment)
 
     def __iter__(self):
         return iter(self.attribute_values)

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -1433,7 +1433,7 @@ class Connection(object):
             {self.get_attribute_type(table_name, attribute_name, value): self.parse_attribute(value)}
             for value in values
         ]
-        return getattr(Path(attribute_name, attribute_name=True), operator)(*values)
+        return getattr(Path([attribute_name]), operator)(*values)
 
     def _check_condition(self, name, condition, expected_or_filter, conditional_operator):
         if condition is not None:

--- a/pynamodb/expressions/projection.py
+++ b/pynamodb/expressions/projection.py
@@ -6,14 +6,13 @@ from pynamodb.expressions.util import substitute_names
 def create_projection_expression(attributes_to_get, placeholders):
     if not isinstance(attributes_to_get, list):
         attributes_to_get = [attributes_to_get]
-    expression_split_pairs = [_get_expression_split_pair(attribute) for attribute in attributes_to_get]
-    expressions = [substitute_names(expr, placeholders, split=split) for (expr, split) in expression_split_pairs]
+    expressions = [substitute_names(_get_document_path(attribute), placeholders) for attribute in attributes_to_get]
     return ', '.join(expressions)
 
 
-def _get_expression_split_pair(attribute):
+def _get_document_path(attribute):
     if isinstance(attribute, Attribute):
-        return attribute.attr_name, False
+        return [attribute.attr_name]
     if isinstance(attribute, Path):
-        return attribute.path, not attribute.attribute_name
-    return attribute, True
+        return attribute.path
+    return attribute.split('.')

--- a/pynamodb/expressions/update.py
+++ b/pynamodb/expressions/update.py
@@ -10,7 +10,7 @@ class Action(object):
         self.value = value
 
     def serialize(self, placeholder_names, expression_attribute_values):
-        path = substitute_names(self.path, placeholder_names, split=True)
+        path = substitute_names(self.path.split('.'), placeholder_names)
         value = get_value_placeholder(self.value, expression_attribute_values) if self.value else None
         return self.format_string.format(value, path=path)
 

--- a/pynamodb/expressions/util.py
+++ b/pynamodb/expressions/util.py
@@ -7,6 +7,13 @@ def substitute_names(document_path, placeholders):
     """
     Replaces all attribute names in the given document path with placeholders.
     Stores the placeholders in the given dictionary.
+
+    :param document_path: list of path segments (an attribute name and optional list dereference)
+    :param placeholders:  a dictionary to store mappings from attribute names to expression attribute name placeholders
+
+    For example: given the document_path for some attribute "baz", that is the first element of a list attribute "bar",
+    that itself is a map element of "foo" (i.e. ['foo', 'bar[0], 'baz']) and an empty placeholders dictionary,
+    `substitute_names` will return "#0.#1[0].#2" and placeholders will contain {"foo": "#0", "bar": "#1", "baz": "#2}
     """
     for idx, segment in enumerate(document_path):
         match = PATH_SEGMENT_REGEX.match(segment)

--- a/pynamodb/expressions/util.py
+++ b/pynamodb/expressions/util.py
@@ -3,24 +3,23 @@ import re
 PATH_SEGMENT_REGEX = re.compile(r'([^\[\]]+)((?:\[\d+\])*)$')
 
 
-def substitute_names(expression, placeholders, split=True):
+def substitute_names(document_path, placeholders):
     """
-    Replaces names in the given expression with placeholders.
+    Replaces all attribute names in the given document path with placeholders.
     Stores the placeholders in the given dictionary.
     """
-    path_segments = expression.split('.') if split else [expression]
-    for idx, segment in enumerate(path_segments):
+    for idx, segment in enumerate(document_path):
         match = PATH_SEGMENT_REGEX.match(segment)
         if not match:
-            raise ValueError('{0} is not a valid document path'.format(expression))
+            raise ValueError('{0} is not a valid document path'.format('.'.join(document_path)))
         name, indexes = match.groups()
         if name in placeholders:
             placeholder = placeholders[name]
         else:
             placeholder = '#' + str(len(placeholders))
             placeholders[name] = placeholder
-        path_segments[idx] = placeholder + indexes
-    return '.'.join(path_segments)
+        document_path[idx] = placeholder + indexes
+    return '.'.join(document_path)
 
 
 def get_value_placeholder(value, expression_attribute_values):

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -215,22 +215,22 @@ class Model(AttributeContainer):
     _throttle = NoThrottle()
     DoesNotExist = DoesNotExist
 
-    def __init__(self, hash_key=None, range_key=None, **attrs):
+    def __init__(self, hash_key=None, range_key=None, **attributes):
         """
         :param hash_key: Required. The hash key for this object.
         :param range_key: Only required if the table has a range key attribute.
         :param attrs: A dictionary of attributes to set on this object.
         """
         if hash_key is not None:
-            attrs[self._dynamo_to_python_attr(self._get_meta_data().hash_keyname)] = hash_key
+            attributes[self._dynamo_to_python_attr(self._get_meta_data().hash_keyname)] = hash_key
         if range_key is not None:
             range_keyname = self._get_meta_data().range_keyname
             if range_keyname is None:
                 raise ValueError(
                     "This table has no range key, but a range key value was provided: {0}".format(range_key)
                 )
-            attrs[self._dynamo_to_python_attr(range_keyname)] = range_key
-        super(Model, self).__init__(**attrs)
+            attributes[self._dynamo_to_python_attr(range_keyname)] = range_key
+        super(Model, self).__init__(**attributes)
 
     @classmethod
     def has_map_or_list_attributes(cls):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -738,35 +738,41 @@ class TestMapAttribute:
             bar = UnicodeAttribute(attr_name='dyn_bar')
 
         class SubModel(Model):
-            sub_map = SubMapAttribute()
+            sub_map = SubMapAttribute(attr_name='dyn_sub_map')
 
         class SubSubModel(SubModel):
             sub_sub_map = SubSubMapAttribute()
 
-        assert SubModel.sub_map.foo.attr_path == ['sub_map']
-        assert SubSubModel.sub_map.foo.attr_path == ['sub_map']
+        assert SubModel.sub_map.foo.attr_name == 'dyn_foo'
+        assert SubModel.sub_map.foo.attr_path == ['dyn_sub_map']
+        assert SubSubModel.sub_map.foo.attr_name == 'dyn_foo'
+        assert SubSubModel.sub_map.foo.attr_path == ['dyn_sub_map']
+        assert SubSubModel.sub_sub_map.foo.attr_name == 'dyn_foo'
         assert SubSubModel.sub_sub_map.foo.attr_path == ['sub_sub_map']
+        assert SubSubModel.sub_sub_map.bar.attr_name == 'dyn_bar'
         assert SubSubModel.sub_sub_map.bar.attr_path == ['sub_sub_map']
 
     def test_attribute_paths_wrapping(self):
         class InnerMapAttribute(MapAttribute):
-            map_attr = MapAttribute()
+            map_attr = MapAttribute(attr_name='dyn_map_attr')
 
         class MiddleMapAttributeA(MapAttribute):
-            inner_map = InnerMapAttribute()
+            inner_map = InnerMapAttribute(attr_name='dyn_in_map_a')
 
         class MiddleMapAttributeB(MapAttribute):
-            inner_map = InnerMapAttribute()
+            inner_map = InnerMapAttribute(attr_name='dyn_in_map_b')
 
         class OuterMapAttribute(MapAttribute):
             mid_map_a = MiddleMapAttributeA()
             mid_map_b = MiddleMapAttributeB()
 
         class MyModel(Model):
-            outer_map = OuterMapAttribute()
+            outer_map = OuterMapAttribute(attr_name='dyn_out_map')
 
-        assert MyModel.outer_map.mid_map_a.inner_map.map_attr.attr_path == ['outer_map', 'mid_map_a', 'inner_map']
-        assert MyModel.outer_map.mid_map_b.inner_map.map_attr.attr_path == ['outer_map', 'mid_map_b', 'inner_map']
+        assert MyModel.outer_map.mid_map_a.inner_map.map_attr.attr_name == 'dyn_map_attr'
+        assert MyModel.outer_map.mid_map_a.inner_map.map_attr.attr_path == ['dyn_out_map', 'mid_map_a', 'dyn_in_map_a']
+        assert MyModel.outer_map.mid_map_b.inner_map.map_attr.attr_name == 'dyn_map_attr'
+        assert MyModel.outer_map.mid_map_b.inner_map.map_attr.attr_path == ['dyn_out_map', 'mid_map_b', 'dyn_in_map_b']
 
 
 class TestValueDeserialize:

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -744,13 +744,13 @@ class TestMapAttribute:
             sub_sub_map = SubSubMapAttribute()
 
         assert SubModel.sub_map.foo.attr_name == 'dyn_foo'
-        assert SubModel.sub_map.foo.attr_path == ['dyn_sub_map']
+        assert SubModel.sub_map.foo.attr_path == ['dyn_sub_map', 'dyn_foo']
         assert SubSubModel.sub_map.foo.attr_name == 'dyn_foo'
-        assert SubSubModel.sub_map.foo.attr_path == ['dyn_sub_map']
+        assert SubSubModel.sub_map.foo.attr_path == ['dyn_sub_map', 'dyn_foo']
         assert SubSubModel.sub_sub_map.foo.attr_name == 'dyn_foo'
-        assert SubSubModel.sub_sub_map.foo.attr_path == ['sub_sub_map']
+        assert SubSubModel.sub_sub_map.foo.attr_path == ['sub_sub_map', 'dyn_foo']
         assert SubSubModel.sub_sub_map.bar.attr_name == 'dyn_bar'
-        assert SubSubModel.sub_sub_map.bar.attr_path == ['sub_sub_map']
+        assert SubSubModel.sub_sub_map.bar.attr_path == ['sub_sub_map', 'dyn_bar']
 
     def test_attribute_paths_wrapping(self):
         class InnerMapAttribute(MapAttribute):
@@ -769,10 +769,13 @@ class TestMapAttribute:
         class MyModel(Model):
             outer_map = OuterMapAttribute(attr_name='dyn_out_map')
 
-        assert MyModel.outer_map.mid_map_a.inner_map.map_attr.attr_name == 'dyn_map_attr'
-        assert MyModel.outer_map.mid_map_a.inner_map.map_attr.attr_path == ['dyn_out_map', 'mid_map_a', 'dyn_in_map_a']
-        assert MyModel.outer_map.mid_map_b.inner_map.map_attr.attr_name == 'dyn_map_attr'
-        assert MyModel.outer_map.mid_map_b.inner_map.map_attr.attr_path == ['dyn_out_map', 'mid_map_b', 'dyn_in_map_b']
+        mid_map_a_map_attr = MyModel.outer_map.mid_map_a.inner_map.map_attr
+        mid_map_b_map_attr = MyModel.outer_map.mid_map_b.inner_map.map_attr
+
+        assert mid_map_a_map_attr.attr_name == 'dyn_map_attr'
+        assert mid_map_a_map_attr.attr_path == ['dyn_out_map', 'mid_map_a', 'dyn_in_map_a', 'dyn_map_attr']
+        assert mid_map_b_map_attr.attr_name == 'dyn_map_attr'
+        assert mid_map_b_map_attr.attr_path == ['dyn_out_map', 'mid_map_b', 'dyn_in_map_b', 'dyn_map_attr']
 
 
 class TestValueDeserialize:


### PR DESCRIPTION
This commit adds support for creating condition expressions from nested attributes.

Consider the following model definition:
```
>>> class MyMap(MapAttribute):
...     ua = UnicodeAttribute(attr_name='str_attr')  
... 
>>> class MyModel(Model):
...     class Meta:
...         table_name='foo'
...     my_map = MyMap(attr_name='map_attr')
... 
```

Without this change, condition expressions did not include the document path:
```
>>> MyModel.my_map.ua == 'baz'
str_attr = baz
```

With this change, the condition expression correctly constructs the document path:
```
>>> MyModel.my_map.ua == 'baz'
map_attr.str_attr = baz
```

When initializing AttributeContainer class objects, any MapAttribute instances in the attribute list now make local copies of their class attributes. Using the above example, when initializing the `MyModel` class object, a copy of `MyMap.ua` is made and stored on `MyModel.my_map`. The attribute name of the MapAttribute instance is then prepended to the local copies of the attributes, recursively. Again using the above example, while `MyMap.ua.attr_path == ['str_attr']`, the local copy is mutated such that `MyModel.my_map.ua.attr_path == ['map_attr', 'str_attr']`. This attribute path list is then used as the document path when creating Condition objects.