### PR TITLE
Support setting attributes on "raw" MapAttribute instances.

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -221,8 +221,6 @@ class Model(AttributeContainer):
         :param range_key: Only required if the table has a range key attribute.
         :param attrs: A dictionary of attributes to set on this object.
         """
-        self.attribute_values = {}
-        self._set_defaults()
         if hash_key is not None:
             attrs[self._dynamo_to_python_attr(self._get_meta_data().hash_keyname)] = hash_key
         if range_key is not None:
@@ -232,7 +230,7 @@ class Model(AttributeContainer):
                     "This table has no range key, but a range key value was provided: {0}".format(range_key)
                 )
             attrs[self._dynamo_to_python_attr(range_keyname)] = range_key
-        self._set_attributes(**attrs)
+        super(Model, self).__init__(**attrs)
 
     @classmethod
     def has_map_or_list_attributes(cls):
@@ -1262,15 +1260,6 @@ class Model(AttributeContainer):
         item_data = data.get(RESPONSES).get(cls.Meta.table_name)
         unprocessed_items = data.get(UNPROCESSED_KEYS).get(cls.Meta.table_name, {}).get(KEYS, None)
         return item_data, unprocessed_items
-
-    def _set_attributes(self, **attrs):
-        """
-        Sets the attributes for this object
-        """
-        for attr_name, attr_value in six.iteritems(attrs):
-            if attr_name not in self._get_attributes():
-                raise ValueError("Attribute {0} specified does not exist".format(attr_name))
-            setattr(self, attr_name, attr_value)
 
     @classmethod
     def add_throttle_record(cls, records):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -595,6 +595,17 @@ class TestMapAttribute:
             }
         }
 
+    def test_raw_set_attr(self):
+        item = AttributeTestModel()
+        item.map_attr = {}
+        item.map_attr.foo = 'bar'
+        item.map_attr.num = 3
+        item.map_attr.nested = {'nestedfoo': 'nestedbar'}
+
+        assert item.map_attr['foo'] == 'bar'
+        assert item.map_attr['num'] == 3
+        assert item.map_attr['nested']['nestedfoo'] == 'nestedbar'
+
     def test_raw_map_from_dict(self):
         item = AttributeTestModel(
             map_attr={


### PR DESCRIPTION
This PR attempts to provide parity between "raw" MapAttributes and MapAttribute subclasses.

MapAttribute subclasses can set bound attribute values using the Attribute data descriptors.
Prior to this change, "raw" MapAttribute instances could only set name-value pairs during initialization.

With this change, all MapAttribute instances are instantiated as AttributeContainers and can access data stored on the internal attribute_values dictionary (either via the __getattr__ and __setattr__ methods in the case of "raw" MapAttributes, or via the Attribute data descriptors in the case of subclasses).

MapAttribute instances that are class objects of other AttributeContainers (Models or other MapAttribute subclasses) are "re-initialized" as Attributes by AttributeContainerMeta during class creation.