### PR TITLE
Allow passing values to delete operations from Model.update() (#132)

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -410,7 +410,7 @@ class Model(AttributeContainer):
             attribute_cls = attrs[attr]
             action = params['action'] and params['action'].upper()
             attr_values = {ACTION: action}
-            if action != DELETE:
+            if 'value' in params:
                 attr_values[VALUE] = self._serialize_value(attribute_cls, params['value'])
 
             kwargs[pythonic(ATTR_UPDATES)][attribute_cls.attr_name] = attr_values


### PR DESCRIPTION
While the connection logic accounts for delete operations with values and uses
the correct operation (DELETE instead of REMOVE), the Model.update() drops the
values provided for the DELETE operation early, leading to always executing REMOVE
even on sets.

Not dropping the values in the Model.update() operation, allows the update expression
to be used as intended

The results from the integration tests show that this now works as intended

{'Attributes': {'epoch': {'S': '2017-08-31T12:18:15.388755+0000'}, 'forum': {'S': 'foo'}, 'thread': {'S': 'query_thread'}, 'view': {'N': '2'}}}
Updated item: pynamodb-ci<5, 6>: Scores: {1, 2, 3}, Teams: {'three', 'two', 'one'}
Updated item: pynamodb-ci<5, 6>: Scores: {2, 3}, Teams: {'three', 'two'}
Updated item: pynamodb-ci<5, 6>: Scores: None, Teams: None
