### PR TITLE
Expression operands can be attribute names or attribute values.

### DIFF
--- a/pynamodb/expressions/operand.py
+++ b/pynamodb/expressions/operand.py
@@ -234,6 +234,9 @@ class Size(Operand):
     def serialize(self, placeholder_names, expression_attribute_values):
         return "size ({0})".format(substitute_names(self.path.path, placeholder_names))
 
+    def _has_type(self, short_type):
+        return short_type == NUMBER_SHORT
+
     def __str__(self):
         return "size({0})".format(self.path)
 

--- a/pynamodb/expressions/update.py
+++ b/pynamodb/expressions/update.py
@@ -1,94 +1,32 @@
-from pynamodb.constants import BINARY_SET_SHORT, LIST_SHORT, NUMBER_SET_SHORT, NUMBER_SHORT, STRING_SET_SHORT
-from pynamodb.expressions.util import get_value_placeholder, substitute_names
+from pynamodb.constants import BINARY_SET_SHORT, NUMBER_SET_SHORT, NUMBER_SHORT, STRING_SET_SHORT
 
 
 class Action(object):
     format_string = ''
 
-    def __init__(self, path, value=None):
-        self.path = path
-        self.value = value
+    def __init__(self, *values):
+        self.values = values
 
     def serialize(self, placeholder_names, expression_attribute_values):
-        path = substitute_names(self.path.path, placeholder_names)
-        value = get_value_placeholder(self.value, expression_attribute_values) if self.value else None
-        return self.format_string.format(value, path=path)
+        values = [value.serialize(placeholder_names, expression_attribute_values) for value in self.values]
+        return self.format_string.format(*values)
 
 
 class SetAction(Action):
     """
     The SET action adds an attribute to an item.
     """
-    format_string = '{path} = {0}'
+    format_string = '{0} = {1}'
 
     def __init__(self, path, value):
         super(SetAction, self).__init__(path, value)
-
-
-class IncrementAction(SetAction):
-    """
-    A SET action that is used to add to a number attribute.
-    """
-    format_string = '{path} = {path} + {0}'
-
-    def __init__(self, path, amount):
-        (attr_type, value), = amount.items()
-        if attr_type != NUMBER_SHORT:
-            raise ValueError("{0} must be a number".format(value))
-        super(IncrementAction, self).__init__(path, amount)
-
-
-class DecrementAction(SetAction):
-    """
-    A SET action that is used to subtract from a number attribute.
-    """
-    format_string = '{path} = {path} - {0}'
-
-    def __init__(self, path, amount):
-        (attr_type, value), = amount.items()
-        if attr_type != NUMBER_SHORT:
-            raise ValueError("{0} must be a number".format(value))
-        super(DecrementAction, self).__init__(path, amount)
-
-
-class AppendAction(SetAction):
-    """
-    A SET action that appends elements to the end of a list.
-    """
-    format_string = '{path} = list_append({path}, {0})'
-
-    def __init__(self, path, elements):
-        (attr_type, value), = elements.items()
-        if attr_type != LIST_SHORT:
-            raise ValueError("{0} must be a list".format(value))
-        super(AppendAction, self).__init__(path, elements)
-
-
-class PrependAction(SetAction):
-    """
-    A SET action that prepends elements to the beginning of a list.
-    """
-    format_string = '{path} = list_append({0}, {path})'
-
-    def __init__(self, path, elements):
-        (attr_type, value), = elements.items()
-        if attr_type != LIST_SHORT:
-            raise ValueError("{0} must be a list".format(value))
-        super(PrependAction, self).__init__(path, elements)
-
-
-class SetIfNotExistsAction(SetAction):
-    """
-    A SET action that avoids overwriting an existing attribute.
-    """
-    format_string = '{path} = if_not_exists({path}, {0})'
 
 
 class RemoveAction(Action):
     """
     The REMOVE action deletes an attribute from an item.
     """
-    format_string = '{path}'
+    format_string = '{0}'
 
     def __init__(self, path):
         super(RemoveAction, self).__init__(path)
@@ -98,10 +36,10 @@ class AddAction(Action):
     """
     The ADD action appends elements to a set or mathematically adds to a number attribute.
     """
-    format_string = '{path} {0}'
+    format_string = '{0} {1}'
 
     def __init__(self, path, subset):
-        (attr_type, value), = subset.items()
+        (attr_type, value), = subset.value.items()
         if attr_type not in [BINARY_SET_SHORT, NUMBER_SET_SHORT, NUMBER_SHORT, STRING_SET_SHORT]:
             raise ValueError("{0} must be a number or set".format(value))
         super(AddAction, self).__init__(path, subset)
@@ -111,10 +49,10 @@ class DeleteAction(Action):
     """
     The DELETE action removes elements from a set.
     """
-    format_string = '{path} {0}'
+    format_string = '{0} {1}'
 
     def __init__(self, path, subset):
-        (attr_type, value), = subset.items()
+        (attr_type, value), = subset.value.items()
         if attr_type not in [BINARY_SET_SHORT, NUMBER_SET_SHORT, STRING_SET_SHORT]:
             raise ValueError("{0} must be a set".format(value))
         super(DeleteAction, self).__init__(path, subset)

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -225,6 +225,14 @@ class ConditionExpressionTestCase(TestCase):
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S' : 'bar'}}
 
+    def test_contains_attribute(self):
+        condition = ListAttribute(attr_name='foo').contains(Path('bar'))
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "contains (#0, #1)"
+        assert placeholder_names == {'foo': '#0', 'bar': '#1'}
+        assert expression_attribute_values == {}
+
     def test_size(self):
         condition = size(self.attribute) == 3
         placeholder_names, expression_attribute_values = {}, {}
@@ -232,6 +240,14 @@ class ConditionExpressionTestCase(TestCase):
         assert expression == "size (#0) = :0"
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'N' : '3'}}
+
+    def test_sizes(self):
+        condition = size(self.attribute) == size(Path('bar'))
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "size (#0) = size (#1)"
+        assert placeholder_names == {'foo': '#0', 'bar': '#1'}
+        assert expression_attribute_values == {}
 
     def test_and(self):
         condition = (self.attribute < 'bar') & (self.attribute > 'baz')

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -3,10 +3,7 @@ from pynamodb.compat import CompatTestCase as TestCase
 from pynamodb.expressions.condition import size
 from pynamodb.expressions.operand import Path
 from pynamodb.expressions.projection import create_projection_expression
-from pynamodb.expressions.update import (
-    AddAction, AppendAction, DecrementAction, DeleteAction, IncrementAction, PrependAction, SetAction,
-    SetIfNotExistsAction, RemoveAction, Update
-)
+from pynamodb.expressions.update import Update
 
 
 class PathTestCase(TestCase):
@@ -332,62 +329,6 @@ class UpdateExpressionTestCase(TestCase):
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S': 'bar'}}
 
-    def test_increment_action(self):
-        action = IncrementAction(Path('foo'), {'N': '0'})
-        placeholder_names, expression_attribute_values = {}, {}
-        expression = action.serialize(placeholder_names, expression_attribute_values)
-        assert expression == "#0 = #0 + :0"
-        assert placeholder_names == {'foo': '#0'}
-        assert expression_attribute_values == {':0': {'N': '0'}}
-
-    def test_increment_action_non_numeric(self):
-        with self.assertRaises(ValueError):
-            IncrementAction(Path('foo'), {'S': '0'})
-
-    def test_decrement_action(self):
-        action = DecrementAction(Path('foo'), {'N': '0'})
-        placeholder_names, expression_attribute_values = {}, {}
-        expression = action.serialize(placeholder_names, expression_attribute_values)
-        assert expression == "#0 = #0 - :0"
-        assert placeholder_names == {'foo': '#0'}
-        assert expression_attribute_values == {':0': {'N': '0'}}
-
-    def test_decrement_action_non_numeric(self):
-        with self.assertRaises(ValueError):
-            DecrementAction(Path('foo'), {'S': '0'})
-
-    def test_append_action(self):
-        action = AppendAction(Path('foo'), {'L': [{'S': 'bar'}]})
-        placeholder_names, expression_attribute_values = {}, {}
-        expression = action.serialize(placeholder_names, expression_attribute_values)
-        assert expression == "#0 = list_append(#0, :0)"
-        assert placeholder_names == {'foo': '#0'}
-        assert expression_attribute_values == {':0': {'L': [{'S': 'bar'}]}}
-
-    def test_append_action_non_list(self):
-        with self.assertRaises(ValueError):
-            AppendAction(Path('foo'), {'S': 'bar'})
-
-    def test_prepend_action(self):
-        action = PrependAction(Path('foo'), {'L': [{'S': 'bar'}]})
-        placeholder_names, expression_attribute_values = {}, {}
-        expression = action.serialize(placeholder_names, expression_attribute_values)
-        assert expression == "#0 = list_append(:0, #0)"
-        assert placeholder_names == {'foo': '#0'}
-        assert expression_attribute_values == {':0': {'L': [{'S': 'bar'}]}}
-
-    def test_prepend_action_non_list(self):
-        with self.assertRaises(ValueError):
-            PrependAction(Path('foo'), {'S': 'bar'})
-
-    def test_set_if_not_exists_action(self):
-        action = SetIfNotExistsAction(Path('foo'), {'S': 'bar'})
-        placeholder_names, expression_attribute_values = {}, {}
-        expression = action.serialize(placeholder_names, expression_attribute_values)
-        assert expression == "#0 = if_not_exists(#0, :0)"
-        assert placeholder_names == {'foo': '#0'}
-        assert expression_attribute_values == {':0': {'S': 'bar'}}
-
     def test_remove_action(self):
         action = Path('foo').remove()
         placeholder_names, expression_attribute_values = {}, {}
@@ -414,7 +355,7 @@ class UpdateExpressionTestCase(TestCase):
 
     def test_add_action_list(self):
         with self.assertRaises(ValueError):
-            AddAction(Path('foo'), {'L': [{'N': '0'}]})
+            Path('foo').update({'L': [{'N': '0'}]})
 
     def test_delete_action(self):
         action = Path('foo').difference_update({'NS': ['0']})
@@ -424,17 +365,17 @@ class UpdateExpressionTestCase(TestCase):
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'NS': ['0']}}
 
-    def test_add_action_non_set(self):
+    def test_delete_action_non_set(self):
         with self.assertRaises(ValueError):
-            DeleteAction(Path('foo'), {'N': '0'})
+            Path('foo').difference_update({'N': '0'})
 
     def test_update(self):
         path = Path('foo')
         update = Update()
-        update.add_action(SetAction(path, {'S': 'bar'}))
-        update.add_action(RemoveAction(path))
-        update.add_action(AddAction(path, {'N': '0'}))
-        update.add_action(DeleteAction(path, {'NS': ['0']}))
+        update.add_action(path.set({'S': 'bar'}))
+        update.add_action(path.remove())
+        update.add_action(path.update({'N': '0'}))
+        update.add_action(path.difference_update({'NS': ['0']}))
         placeholder_names, expression_attribute_values = {}, {}
         expression = update.serialize(placeholder_names, expression_attribute_values)
         assert expression == "SET #0 = :0 REMOVE #0 ADD #0 :1 DELETE #0 :2"


### PR DESCRIPTION
This commit extends the expression api to always allow attribute names and values as operands:

```
>>> from pynamodb.expressions.operand import Path, Size
>>> Path('foo') == Path('bar')
foo = bar
>>> Size('foo') != Size('bar')
size(foo) <> size(bar)
```