### PR TITLE
Support "raw" MapAttribute dereferencing in condition expressions.

### DIFF
--- a/docs/conditional.rst
+++ b/docs/conditional.rst
@@ -54,13 +54,24 @@ for more details.
     OR, \|, (Thread.views < 1) | (Thread.views > 5)
     NOT, ~, ~Thread.subject.contains('foobar')
 
-If necessary, you can use document paths to access nested list and map attributes:
+Conditions expressions using nested list and map attributes can be created with Python's item operator ``[]``:
 
 .. code-block:: python
 
-    from pynamodb.expressions.condition import size
+    from pynamodb.models import Model
+    from pynamodb.attributes import (
+        ListAttribute, MapAttribute, UnicodeAttribute
+    )
 
-    print(size('foo.bar[0].baz') == 0)
+    class Container(Model):
+        class Meta:
+            table_name = 'Container'
+
+        name = UnicodeAttribute(hash_key = True)
+        my_map = MapAttribute()
+        my_list = ListAttribute()
+
+    print(Container.my_map['foo'].exists() | Container.my_list[0].contains('bar'))
 
 
 Conditional Model.save

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -28,9 +28,14 @@ class PathTestCase(TestCase):
         assert str(path) == "'foo.bar'[0]"
         assert repr(path) == "Path(['foo.bar[0]'])"
 
+    def test_index_map_attribute(self):
+        path = Path(['foo.bar'])['baz']
+        assert str(path) == "'foo.bar'.baz"
+        assert repr(path) == "Path(['foo.bar', 'baz'])"
+
     def test_index_invalid(self):
         with self.assertRaises(TypeError):
-            Path('foo.bar')['foo']
+            Path('foo.bar')[0.0]
 
 
 class ActionTestCase(TestCase):

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -326,6 +326,19 @@ class ConditionExpressionTestCase(TestCase):
         assert placeholder_names == {'foo.bar': '#0'}
         assert expression_attribute_values == {':0': {'S': 'baz'}}
 
+    def test_map_attribute_indexing(self):
+        # Simulate initialization from inside an AttributeContainer
+        my_map_attribute = MapAttribute(attr_name='foo.bar')
+        my_map_attribute._make_attribute()
+        my_map_attribute._update_attribute_paths(my_map_attribute.attr_name)
+
+        condition = my_map_attribute['foo'] == 'baz'
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0.#1 = :0"
+        assert placeholder_names == {'foo.bar': '#0', 'foo': '#1'}
+        assert expression_attribute_values == {':0': {'S': 'baz'}}
+
     def test_map_attribute_dereference(self):
         class MyMapAttribute(MapAttribute):
             nested_string = self.attribute
@@ -341,6 +354,34 @@ class ConditionExpressionTestCase(TestCase):
         assert expression == "#0.#1 = :0"
         assert placeholder_names == {'foo.bar': '#0', 'foo': '#1'}
         assert expression_attribute_values == {':0': {'S': 'baz'}}
+
+    def test_map_attribute_dereference_via_indexing(self):
+        class MyMapAttribute(MapAttribute):
+            nested_string = self.attribute
+
+        # Simulate initialization from inside an AttributeContainer
+        my_map_attribute = MyMapAttribute(attr_name='foo.bar')
+        my_map_attribute._make_attribute()
+        my_map_attribute._update_attribute_paths(my_map_attribute.attr_name)
+
+        condition = my_map_attribute['nested_string'] == 'baz'
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0.#1 = :0"
+        assert placeholder_names == {'foo.bar': '#0', 'foo': '#1'}
+        assert expression_attribute_values == {':0': {'S': 'baz'}}
+
+    def test_map_attribute_dereference_via_indexing_missing_attribute(self):
+        class MyMapAttribute(MapAttribute):
+            nested_string = self.attribute
+
+        # Simulate initialization from inside an AttributeContainer
+        my_map_attribute = MyMapAttribute(attr_name='foo.bar')
+        my_map_attribute._make_attribute()
+        my_map_attribute._update_attribute_paths(my_map_attribute.attr_name)
+
+        with self.assertRaises(AttributeError):
+            my_map_attribute['missing_attribute'] == 'baz'
 
 
 class UpdateExpressionTestCase(TestCase):


### PR DESCRIPTION
This commit adds support for creating condition expressions for nested map attributes using Python's item operator: `[]`

Consider the following item definition:

```
>>> class MyMap(MapAttribute):
...     ma = MapAttribute(attr_name='raw')
... 
>>> class MyModel(Model):
...     class Meta:
...         table_name='foo'
...     my_map = MyMap(attr_name='map_attr')
```

Without this change, condition expressions cannot be created for nested attributes of `ma`:
```
>>> MyModel.my_map.ma.foo == 'bar'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pynamodb/attributes.py", line 680, in __getattr__
    raise AttributeError("'{0}' has no attribute '{1}'".format(self.__class__.__name__, item))
AttributeError: 'MapAttribute' has no attribute 'foo'
```

With this change, condition expressions can be created and match Python's item access:
```
>>> MyModel.my_map['ma']['foo'] == 'bar'
map_attr.raw.foo = {'S': u'bar'}
>>> my_model = MyModel(**{'my_map':{'ma':{'foo':'bar'}}})
>>> my_model.my_map['ma']['foo']
'bar'
```