### PR TITLE
Add print_cloudformation method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,13 @@ PynamoDB allows you to create the table if needed (it must exist before you can 
 
     UserModel.create_table(read_capacity_units=1, write_capacity_units=1)
 
+If you would rather manage your table via CloudFormation, you can print out your table representation:
+
+.. code-block:: python
+
+    # Default output is `json`. You can specify `yaml` or `yml` if you prefer.
+    UserModel.print_cloudformation(output='yml', read_capacity_units=1, write_capacity_units=1)
+
 Now, search your table for all users with a last name of 'Smith' and whose
 first name begins with 'J':
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,6 +32,10 @@ PynamoDB allows you to create the table:
 
     >>> UserModel.create_table(read_capacity_units=1, write_capacity_units=1)
 
+If you prefer to manage with CloudFormation, you can print the CloudFormation representation of your table:
+
+    >>> UserModel.print_cloudformation(read_capacity_units=1, write_capacity_units=1)
+
 Now you can create a user:
 
     >>> user = UserModel('test@example.com', first_name='Samuel', last_name='Adams')

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -7,6 +7,7 @@ import six
 import copy
 import logging
 import warnings
+import yaml
 
 from six import add_metaclass
 from pynamodb.exceptions import DoesNotExist, TableDoesNotExist, TableError
@@ -865,29 +866,7 @@ class Model(AttributeContainer):
         """
         if not cls.exists():
             schema = cls._get_schema()
-            if hasattr(cls.Meta, pythonic(READ_CAPACITY_UNITS)):
-                schema[pythonic(READ_CAPACITY_UNITS)] = cls.Meta.read_capacity_units
-            if hasattr(cls.Meta, pythonic(WRITE_CAPACITY_UNITS)):
-                schema[pythonic(WRITE_CAPACITY_UNITS)] = cls.Meta.write_capacity_units
-            if hasattr(cls.Meta, pythonic(STREAM_VIEW_TYPE)):
-                schema[pythonic(STREAM_SPECIFICATION)] = {
-                    pythonic(STREAM_ENABLED): True,
-                    pythonic(STREAM_VIEW_TYPE): cls.Meta.stream_view_type
-                }
-            if read_capacity_units is not None:
-                schema[pythonic(READ_CAPACITY_UNITS)] = read_capacity_units
-            if write_capacity_units is not None:
-                schema[pythonic(WRITE_CAPACITY_UNITS)] = write_capacity_units
-            index_data = cls._get_indexes()
-            schema[pythonic(GLOBAL_SECONDARY_INDEXES)] = index_data.get(pythonic(GLOBAL_SECONDARY_INDEXES))
-            schema[pythonic(LOCAL_SECONDARY_INDEXES)] = index_data.get(pythonic(LOCAL_SECONDARY_INDEXES))
-            index_attrs = index_data.get(pythonic(ATTR_DEFINITIONS))
-            attr_keys = [attr.get(pythonic(ATTR_NAME)) for attr in schema.get(pythonic(ATTR_DEFINITIONS))]
-            for attr in index_attrs:
-                attr_name = attr.get(pythonic(ATTR_NAME))
-                if attr_name not in attr_keys:
-                    schema[pythonic(ATTR_DEFINITIONS)].append(attr)
-                    attr_keys.append(attr_name)
+            schema = cls._enrich_schema(schema, read_capacity_units, write_capacity_units)
             cls._get_connection().create_table(
                 **schema
             )
@@ -902,6 +881,25 @@ class Model(AttributeContainer):
                         time.sleep(2)
                 else:
                     raise TableError("No TableStatus returned for table")
+
+    @classmethod
+    def print_cloudformation(cls, output='json', read_capacity_units=None, write_capacity_units=None):
+        """
+        Print the generated CloudFormation for this table
+
+        :param output: Specify if you want printed in JSON or YAML. Options are 'json, 'yaml', and 'yml'. Default is JSON.
+        :param read_capacity_units: Sets the read capacity units for this table
+        :param write_capacity_units: Sets the write capacity units for this table
+        """
+        schema = cls._get_schema()
+        schema = cls._enrich_schema(schema, read_capacity_units, write_capacity_units)
+
+        schema['table_name'] = cls.Meta.table_name
+        obj = make_cloudformation_object(schema)
+        if output.lower() in ['yaml', 'yml']:
+            print(yaml.dump(obj, default_flow_style=False))
+        else:
+            print(json.dumps(obj, indent=2))
 
     @classmethod
     def dumps(cls):
@@ -1133,6 +1131,37 @@ class Model(AttributeContainer):
                     pythonic(KEY_TYPE): RANGE,
                     pythonic(ATTR_NAME): attr_cls.attr_name
                 })
+        return schema
+
+    @classmethod
+    def _enrich_schema(cls, schema, read_capacity_units, write_capacity_units):
+        """
+        Enriches the given schema with all additional metadata, such as secondary indexes
+        """
+        if hasattr(cls.Meta, pythonic(READ_CAPACITY_UNITS)):
+            schema[pythonic(READ_CAPACITY_UNITS)] = cls.Meta.read_capacity_units
+        if hasattr(cls.Meta, pythonic(WRITE_CAPACITY_UNITS)):
+            schema[pythonic(WRITE_CAPACITY_UNITS)] = cls.Meta.write_capacity_units
+        if hasattr(cls.Meta, pythonic(STREAM_VIEW_TYPE)):
+            schema[pythonic(STREAM_SPECIFICATION)] = {
+                pythonic(STREAM_ENABLED): True,
+                pythonic(STREAM_VIEW_TYPE): cls.Meta.stream_view_type
+            }
+        if read_capacity_units is not None:
+            schema[pythonic(READ_CAPACITY_UNITS)] = read_capacity_units
+        if write_capacity_units is not None:
+            schema[pythonic(WRITE_CAPACITY_UNITS)] = write_capacity_units
+        index_data = cls._get_indexes()
+        schema[pythonic(GLOBAL_SECONDARY_INDEXES)] = index_data.get(pythonic(GLOBAL_SECONDARY_INDEXES))
+        schema[pythonic(LOCAL_SECONDARY_INDEXES)] = index_data.get(pythonic(LOCAL_SECONDARY_INDEXES))
+        index_attrs = index_data.get(pythonic(ATTR_DEFINITIONS))
+        attr_keys = [attr.get(pythonic(ATTR_NAME)) for attr in schema.get(pythonic(ATTR_DEFINITIONS))]
+        for attr in index_attrs:
+            attr_name = attr.get(pythonic(ATTR_NAME))
+            if attr_name not in attr_keys:
+                schema[pythonic(ATTR_DEFINITIONS)].append(attr)
+                attr_keys.append(attr_name)
+
         return schema
 
     @classmethod
@@ -1396,3 +1425,74 @@ class Model(AttributeContainer):
         if range_key is not None:
             range_key = cls._range_key_attribute().serialize(range_key)
         return hash_key, range_key
+
+
+def make_cloudformation_object(schema):
+    properties = {}
+    properties['AttributeDefinitions'] = _make_attribute_definitions(schema.get('attribute_definitions'))
+    properties['KeySchema'] = _make_key_schema(schema.get('key_schema'))
+    properties['ProvisionedThroughpout'] = {
+        'ReadCapacityUnits': schema.get('read_capacity_units'),
+        'WriteCapacityUnits': schema.get('write_capacity_units'),
+    }
+    properties['TableName'] = schema.get('table_name')
+    if schema.get('global_secondary_indexes'):
+        properties['GlobalSecondaryIndexes'] = _make_global_secondary_indexes(schema.get('global_secondary_indexes'))
+    if schema.get('local_secondary_indexes'):
+        properties['LocalSecondaryIndexes'] = _make_local_secondary_indexes(schema.get('local_secondary_indexes'))
+    if schema.get('stream_specification'):
+        properties['StreamSpecification'] = {
+            'StreamViewType': schema.get('stream_specification').get('stream_view_type'),
+        }
+    obj = {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": properties
+    }
+    return obj
+
+
+def _make_attribute_definitions(attributes):
+    definitions = []
+    for attribute in attributes:
+        definitions.append({
+            "AttributeName": attribute['attribute_name'],
+            "AttributeType": attribute['attribute_type'],
+        })
+
+    return definitions
+
+
+def _make_key_schema(keys):
+    schema = []
+    for key in keys:
+        schema.append({
+            "AttributeName": key["attribute_name"],
+            "KeyType": key["key_type"]
+        })
+
+    return schema
+
+
+def _make_global_secondary_indexes(indexes):
+    global_secondary_indexes = []
+    for index in indexes:
+        global_secondary_indexes.append({
+            "IndexName": index.get('index_name'),
+            "ProvisionedThroughpout": index.get('provisioned_throughput'),
+            "Projection": index.get('projection'),
+            "KeySchema": index.get('key_schema'),
+        })
+
+    return global_secondary_indexes
+
+
+def _make_local_secondary_indexes(indexes):
+    local_secondary_indexes = []
+    for index in indexes:
+        local_secondary_indexes.append({
+            "IndexName": index.get('index_name'),
+            "Projection": index.get('projection'),
+            "KeySchema": index.get('key_schema'),
+        })
+
+    return local_secondary_indexes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 botocore==1.2.0
 six==1.9.0
+PyYAML==3.12


### PR DESCRIPTION
First of all, this library is great. Thank you for doing the work to make this.

This PR adds a `print_cloudformation()` method to the `Model` object. I like to manage my infrastructure in CloudFormation, but it's tedious and error-prone to try to sync up my defined Model with the required CloudFormation. This method makes it so I can define my Model with PynamoDB but still manage the table with CloudFormation.

The implementation is pretty straight-forward as it's mostly following the `create_table` logic. I pulled out some of schema enrichment in the `create_table` method into a private method as I need to use it here. Then it's just a few simple functions to convert the schema object into the proper CloudFormation representation.

I updated the documentation in a few spots. I'm also willing to add tests, but I wanted to get approval on the addition and the approach before writing those out. It shouldn't break any existing tests, though I was only able to test Python 2.7 locally as I don't have the other interpreters installed.

Please let me know if you would like any changes.