### PR TITLE
Better handling of MapAttribute iteration and item assignment.

### DIFF
--- a/pynamodb/expressions/operand.py
+++ b/pynamodb/expressions/operand.py
@@ -241,6 +241,10 @@ class Path(_NumericOperand, _ListAppendOperand, _ConditionOperand):
     def path(self):
         return self.values[0]
 
+    def __iter__(self):
+        # Because we define __getitem__ Path is considered an iterable
+        raise TypeError("'{0}' object is not iterable".format(self.__class__.__name__))
+
     def __getitem__(self, item):
         # The __getitem__ call returns a new Path instance without any attribute set.
         # This is intended since the nested element is not the same attribute as ``self``.

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -606,6 +606,17 @@ class TestMapAttribute:
         assert item.map_attr['num'] == 3
         assert item.map_attr['nested']['nestedfoo'] == 'nestedbar'
 
+    def test_raw_set_item(self):
+        item = AttributeTestModel()
+        item.map_attr = {}
+        item.map_attr['foo'] = 'bar'
+        item.map_attr['num'] = 3
+        item.map_attr['nested'] = {'nestedfoo': 'nestedbar'}
+
+        assert item.map_attr['foo'] == 'bar'
+        assert item.map_attr['num'] == 3
+        assert item.map_attr['nested']['nestedfoo'] == 'nestedbar'
+
     def test_raw_map_from_dict(self):
         item = AttributeTestModel(
             map_attr={

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -644,6 +644,18 @@ class TestMapAttribute:
         for k, v in six.iteritems(raw):
             assert attr[k] == v
 
+    def test_raw_map_iter(self):
+        raw = {
+            "foo": "bar",
+            "num": 3,
+            "nested": {
+                "nestedfoo": "nestedbar"
+            }
+        }
+        attr = MapAttribute(**raw)
+
+        assert list(iter(raw)) == list(iter(attr))
+
     def test_raw_map_json_serialize(self):
         raw = {
             "foo": "bar",


### PR DESCRIPTION
Now that we support nested element access in condition expressions using Python's `__getitem__` operator, Attributes are considered iterables (see PEP 234).

This commit prevents `iter()` calls on attributes (except for MapAttributes that are being used as AttributeContainers).

In addition, we add support for item assignment to MapAttributes to be symmetric with item access.