### PR TITLE
Don't serialize null nested attributed. Fixes #240 and #309

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -744,6 +744,8 @@ class MapAttribute(Attribute, AttributeContainer):
         rval = {}
         for k in values:
             v = values[k]
+            if v is None:
+                continue
             attr_class = self._get_serialize_class(k, v)
             if attr_class is None:
                 continue

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -744,7 +744,9 @@ class MapAttribute(Attribute, AttributeContainer):
         rval = {}
         for k in values:
             v = values[k]
-            if v is None:
+            # Continue to serialize NULL values in "raw" map attributes for backwards compatibility.
+            # This special case behavior for "raw" attribtues should be removed in the future.
+            if not self.is_raw() and v is None:
                 continue
             attr_class = self._get_serialize_class(k, v)
             if attr_class is None:

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -557,6 +557,14 @@ class TestMapAttribute:
         serialized = attr.serialize(person_attribute)
         assert attr.deserialize(serialized) == person_attribute
 
+    def test_null_attribute(self):
+        null_attribute = {
+            'skip': None
+        }
+        attr = MapAttribute()
+        serialized = attr.serialize(null_attribute)
+        assert serialized == {}
+
     def test_map_of_map(self):
         attribute = {
             'name': 'Justin',

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -557,11 +557,20 @@ class TestMapAttribute:
         serialized = attr.serialize(person_attribute)
         assert attr.deserialize(serialized) == person_attribute
 
-    def test_null_attribute(self):
+    # Special case for raw map attributes
+    def test_null_attribute_raw_map(self):
         null_attribute = {
             'skip': None
         }
         attr = MapAttribute()
+        serialized = attr.serialize(null_attribute)
+        assert serialized == {'skip': {'NULL': True}}
+
+    def test_null_attribute_subclassed_map(self):
+        null_attribute = {
+            'map_field': None
+        }
+        attr = DefaultsMap()
         serialized = attr.serialize(null_attribute)
         assert serialized == {}
 


### PR DESCRIPTION
Models do not serialize null attributes. MapAttributes should not serialize them either.