### PR TITLE
Handle values from keys when batch get returns unprocessed keys

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -419,8 +419,8 @@ class Connection(object):
             for attr in six.itervalues(data[LAST_EVALUATED_KEY]):
                 _convert_binary(attr)
         if UNPROCESSED_KEYS in data:
-            for item_list in six.itervalues(data[UNPROCESSED_KEYS]):
-                for item in item_list:
+            for table_data in six.itervalues(data[UNPROCESSED_KEYS]):
+                for item in table_data[KEYS]:
                     for attr in six.itervalues(item):
                         _convert_binary(attr)
         if UNPROCESSED_ITEMS in data:

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -2584,6 +2584,44 @@ class ConnectionTestCase(TestCase):
             _assert=True
         )
 
+    def test_handle_binary_attributes_for_unprocessed_keys(self):
+        binary_blob = six.b('\x00\xFF\x00\xFF')
+        unprocessed_keys = {
+            'UnprocessedKeys': {
+                'MyTable': {
+                    'AttributesToGet': ['ForumName'],
+                    'Keys': [
+                        {
+                            'ForumName': {'S': 'FooForum'},
+                            'Subject': {'B': base64.b64encode(binary_blob).decode(DEFAULT_ENCODING)}
+                        },
+                        {
+                            'ForumName': {'S': 'FooForum'},
+                            'Subject': {'S': 'thread-1'}
+                        }
+                    ],
+                    'ConsistentRead': False
+                },
+                'MyOtherTable': {
+                    'AttributesToGet': ['ForumName'],
+                    'Keys': [
+                        {
+                            'ForumName': {'S': 'FooForum'},
+                            'Subject': {'B': base64.b64encode(binary_blob).decode(DEFAULT_ENCODING)}
+                        },
+                        {
+                            'ForumName': {'S': 'FooForum'},
+                            'Subject': {'S': 'thread-1'}
+                        }
+                    ],
+                    'ConsistentRead': False
+                }
+            }
+        }
+        data = Connection._handle_binary_attributes(unprocessed_keys)
+        self.assertEqual(data['UnprocessedKeys']['MyTable']['Keys'][0]['Subject']['B'], binary_blob)
+        self.assertEqual(data['UnprocessedKeys']['MyOtherTable']['Keys'][0]['Subject']['B'], binary_blob)
+
     def test_get_expected_map(self):
         conn = Connection(self.region)
         with patch(PATCH_METHOD) as req:


### PR DESCRIPTION
As described in the docs, the response from batch get looks like so:

http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html#DDB-BatchGetItem-response-UnprocessedKeys

```
   "UnprocessedKeys": {
      "string" : {
         "AttributesToGet": [ "string" ],
         "ConsistentRead": boolean,
         "ExpressionAttributeNames": {
            "string" : "string"
         },
         "Keys": [
            {
               "string" : {
                  "B": blob,
                  "BOOL": boolean,
                  "BS": [ blob ],
                  "L": [
                     "AttributeValue"
                  ],
                  "M": {
                     "string" : "AttributeValue"
                  },
                  "N": "string",
                  "NS": [ "string" ],
                  "NULL": boolean,
                  "S": "string",
                  "SS": [ "string" ]
               }
            }
         ],
         "ProjectionExpression": "string"
      }
   }
```

This fix accounts for the keys being in the table's dict under the key 'Keys'

Another pull request for the same issue: #253

Fixes #252