### PR TITLE
Support limiting the total number of items evaluated by a query or scan operation.

### DIFF
--- a/pynamodb/constants.py
+++ b/pynamodb/constants.py
@@ -62,6 +62,9 @@ KEYS = 'Keys'
 UTC = 'UTC'
 KEY = 'Key'
 
+# Response Parameters
+SCANNED_COUNT = 'ScannedCount'
+
 # Expression Parameters
 CONDITION_EXPRESSION = 'ConditionExpression'
 EXPRESSION_ATTRIBUTE_NAMES = 'ExpressionAttributeNames'

--- a/pynamodb/pagination.py
+++ b/pynamodb/pagination.py
@@ -1,27 +1,75 @@
-from pynamodb.constants import CAMEL_COUNT, ITEMS, LAST_EVALUATED_KEY
+from pynamodb.constants import CAMEL_COUNT, ITEMS, LAST_EVALUATED_KEY, SCANNED_COUNT
+
+
+class PageIterator(object):
+    """
+    PageIterator handles Query and Scan result pagination.
+
+    http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.Pagination
+    http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Pagination
+    """
+    def __init__(self, operation, args, kwargs):
+        self._operation = operation
+        self._args = args
+        self._kwargs = kwargs
+        self._first_iteration = True
+        self._last_evaluated_key = None
+        self._total_scanned_count = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._last_evaluated_key is None and not self._first_iteration:
+            raise StopIteration()
+
+        self._first_iteration = False
+
+        self._kwargs['exclusive_start_key'] = self._last_evaluated_key
+        page = self._operation(*self._args, **self._kwargs)
+        self._last_evaluated_key = page.get(LAST_EVALUATED_KEY)
+        self._total_scanned_count += page[SCANNED_COUNT]
+
+        return page
+
+    def next(self):
+        return self.__next__()
+
+    @property
+    def page_size(self):
+        return self._kwargs.get('limit')
+
+    @page_size.setter
+    def page_size(self, page_size):
+        self._kwargs['limit'] = page_size
+
+    @property
+    def last_evaluated_key(self):
+        return self._last_evaluated_key
+
+    @property
+    def total_scanned_count(self):
+        return self._total_scanned_count
 
 
 class ResultIterator(object):
     """
-    ResultIterator handles Query and Scan result pagination.
+    ResultIterator handles Query and Scan item pagination.
 
     http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.Pagination
     http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Pagination
     """
     def __init__(self, operation, args, kwargs, map_fn=None, limit=None):
-        self._operation = operation
-        self._args = args
-        self._kwargs = kwargs
+        self.page_iter = PageIterator(operation, args, kwargs)
+        self._first_iteration = True
         self._map_fn = map_fn
         self._limit = limit
-        self._needs_execute = True
         self._total_count = 0
 
-    def _execute(self):
-        data = self._operation(*self._args, **self._kwargs)
-        self._count = data[CAMEL_COUNT]
-        self._items = data.get(ITEMS)  # not returned if 'Select' is set to 'COUNT'
-        self._last_evaluated_key = data.get(LAST_EVALUATED_KEY)
+    def _get_next_page(self):
+        page = next(self.page_iter)
+        self._count = page[CAMEL_COUNT]
+        self._items = page.get(ITEMS)  # not returned if 'Select' is set to 'COUNT'
         self._index = 0 if self._items else self._count
         self._total_count += self._count
 
@@ -32,16 +80,12 @@ class ResultIterator(object):
         if self._limit == 0:
             raise StopIteration
 
-        if self._needs_execute:
-            self._needs_execute = False
-            self._execute()
+        if self._first_iteration:
+            self._first_iteration = False
+            self._get_next_page()
 
-        while self._index == self._count and self._last_evaluated_key:
-            self._kwargs['exclusive_start_key'] = self._last_evaluated_key
-            self._execute()
-
-        if self._index == self._count:
-            raise StopIteration
+        while self._index == self._count:
+            self._get_next_page()
 
         item = self._items[self._index]
         self._index += 1
@@ -56,7 +100,7 @@ class ResultIterator(object):
 
     @property
     def last_evaluated_key(self):
-        return self._last_evaluated_key
+        return self.page_iter.last_evaluated_key
 
     @property
     def total_count(self):


### PR DESCRIPTION
Support limiting the total number of items evaluated by a query or scan operation (replaces #315).
This gives users better control over the capacity consumed by these operations, e.g.:
```
class PageLimitedIterator(object):

    def __init__(self, page_iterator, max_scanned_count):
        self._iter = page_iterator
        self._max_scanned_count = max_scanned_count

    def __iter__(self):
        return self

    def __next__(self):
        limit = self._max_scanned_count - self._iter.total_scanned_count
        if limit == 0:
            raise StopIteration()
        if limit < self._iter.page_size:
            self._iter.page_size = limit
        return next(self._iter)

    def next(self):
        return self.__next__()

result_iterator = Model.scan()
result_iterator.page_iter = PageLimitedIterator(result_iterator.page_iter, 10)
for item in result_iterator:
    # pass
```