### PR TITLE
Allow users to create models that will not store undefined attributes. Fixes #331

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -207,6 +207,8 @@ class AttributeContainerMeta(type):
 @add_metaclass(AttributeContainerMeta)
 class AttributeContainer(object):
 
+    __slots__ = ('__weakref__', 'attribute_values')
+
     def __init__(self, **attributes):
         # The `attribute_values` dictionary is used by the Attribute data descriptors in cls._attributes
         # to store the values that are bound to this instance. Attributes store values in the dictionary
@@ -628,7 +630,7 @@ class MapAttribute(Attribute, AttributeContainer):
         # Determine if this instance is being used as an AttributeContainer or an Attribute.
         # AttributeContainer instances have an internal `attribute_values` dictionary that is removed
         # by the `_make_attribute` call during initialization of the containing class.
-        return 'attribute_values' in self.__dict__
+        return hasattr(self, 'attribute_values')
 
     def _make_attribute(self):
         # WARNING! This function is only intended to be called from the AttributeContainerMeta metaclass.

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -221,6 +221,9 @@ class Model(AttributeContainer):
     _index_classes = None
     DoesNotExist = DoesNotExist
 
+    # Allow users to create models that will not store undefined attributes.
+    __slots__ = ()
+
     def __init__(self, hash_key=None, range_key=None, **attributes):
         """
         :param hash_key: Required. The hash key for this object.

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -442,6 +442,16 @@ class Dog(Animal):
     breed = UnicodeAttribute()
 
 
+class ModelWithoutDict(Model):
+
+    __slots__ = ()
+
+    class Meta:
+        table_name = 'foo'
+
+    hk = UnicodeAttribute(hash_key=True)
+
+
 class ModelTestCase(TestCase):
     """
     Tests for the models API
@@ -4432,3 +4442,10 @@ class ModelInitTestCase(TestCase):
         self.assertEquals(actual.left.left.value, left_instance.left.value)
         self.assertEquals(actual.right.right.left.value, right_instance.right.left.value)
         self.assertEquals(actual.right.right.value, right_instance.right.value)
+
+    # See https://github.com/pynamodb/PynamoDB/issues/331
+    def test_undefined_attribute(self):
+        model_without_dict = ModelWithoutDict()
+        model_without_dict.hk = 'foo'
+        with self.assertRaises(AttributeError):
+            model_without_dict.sk = 'bar'


### PR DESCRIPTION
For users who wish to prevent setting unknown attributes on their model subclasses, this change removes the Model (and AttributeContainer) internal dictionaries. This allows subclasses to define an empty `__slots__` attribute and achieve that behavior.