### PR TITLE
Make model deserialization public

### DIFF
--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -4229,7 +4229,7 @@ class ModelTestCase(TestCase):
             }
         }
         instance = ExplicitRawMapModel()
-        instance._deserialize({'map_attr': map_serialized})
+        instance.deserialize({'map_attr': map_serialized})
         actual = instance.map_attr
         for k, v in six.iteritems(map_native):
             self.assertEqual(v, actual[k])


### PR DESCRIPTION
Allows manual creation of model instances from DynamoDB JSON. Useful
e.g. when working with DynamoDB Streams.