### PR TITLE
Externalizes AWS Credentials

### DIFF
--- a/docs/awsaccess.rst
+++ b/docs/awsaccess.rst
@@ -12,5 +12,16 @@ policies as required, see the
 `DynamoDB <http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/UsingIAMWithDDB.html>`_ docs for more
 information.
 
+If for some reason you can't use conventional AWS configuration methods, you can set the credentials in the Model Meta class:
+
+.. code-block:: python
+
+    from pynamodb.models import Model
+
+    class MyModel(Model):
+        class Meta:
+            aws_access_key_id = 'my_access_key_id'
+            aws_secret_access_key = 'my_secret_access_key'
+
 Finally, see the `AWS CLI documentation <http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-installing-credentials>`_
 for more details on how to pass credentials to botocore.

--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -17,7 +17,9 @@ class TableConnection(object):
                  session_cls=None,
                  request_timeout_seconds=None,
                  max_retry_attempts=None,
-                 base_backoff_ms=None):
+                 base_backoff_ms=None,
+                 aws_access_key_id=None,
+                 aws_secret_access_key=None):
         self._hash_keyname = None
         self._range_keyname = None
         self.table_name = table_name
@@ -27,6 +29,10 @@ class TableConnection(object):
                                      request_timeout_seconds=request_timeout_seconds,
                                      max_retry_attempts=max_retry_attempts,
                                      base_backoff_ms=base_backoff_ms)
+
+        if aws_access_key_id and aws_secret_access_key:
+            self.connection.session.set_credentials(aws_access_key_id,
+                                                    aws_secret_access_key)
 
     def get_meta_table(self, refresh=False):
         """
@@ -145,7 +151,8 @@ class TableConnection(object):
             consistent_read=consistent_read,
             attributes_to_get=attributes_to_get)
 
-    def rate_limited_scan(self,
+    def rate_limited_scan(
+             self,
              filter_condition=None,
              attributes_to_get=None,
              page_size=None,

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -184,6 +184,10 @@ class MetaModel(AttributeContainerMeta):
                         setattr(attr_obj, 'base_backoff_ms', get_settings_value('base_backoff_ms'))
                     if not hasattr(attr_obj, 'max_retry_attempts'):
                         setattr(attr_obj, 'max_retry_attempts', get_settings_value('max_retry_attempts'))
+                    if not hasattr(attr_obj, 'aws_access_key_id'):
+                        setattr(attr_obj, 'aws_access_key_id', None)
+                    if not hasattr(attr_obj, 'aws_secret_access_key'):
+                        setattr(attr_obj, 'aws_secret_access_key', None)
                 elif issubclass(attr_obj.__class__, (Index, )):
                     attr_obj.Meta.model = cls
                     if not hasattr(attr_obj.Meta, "index_name"):

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1269,7 +1269,9 @@ class Model(AttributeContainer):
                                               session_cls=cls.Meta.session_cls,
                                               request_timeout_seconds=cls.Meta.request_timeout_seconds,
                                               max_retry_attempts=cls.Meta.max_retry_attempts,
-                                              base_backoff_ms=cls.Meta.base_backoff_ms)
+                                              base_backoff_ms=cls.Meta.base_backoff_ms,
+                                              aws_access_key_id=cls.Meta.aws_access_key_id,
+                                              aws_secret_access_key=cls.Meta.aws_secret_access_key)
         return cls._connection
 
     def _deserialize(self, attrs):

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -425,6 +425,8 @@ class OverriddenSessionModel(Model):
         request_timeout_seconds = 9999
         max_retry_attempts = 200
         base_backoff_ms = 4120
+        aws_access_key_id = 'access_key_id'
+        aws_secret_access_key = 'secret_access_key'
         session_cls = OverriddenSession
 
     random_user_name = UnicodeAttribute(hash_key=True, attr_name='random_name_1')
@@ -671,6 +673,8 @@ class ModelTestCase(TestCase):
         self.assertEqual(OverriddenSessionModel.Meta.request_timeout_seconds, 9999)
         self.assertEqual(OverriddenSessionModel.Meta.max_retry_attempts, 200)
         self.assertEqual(OverriddenSessionModel.Meta.base_backoff_ms, 4120)
+        self.assertEqual(OverriddenSessionModel.Meta.aws_access_key_id, 'access_key_id')
+        self.assertEqual(OverriddenSessionModel.Meta.aws_secret_access_key, 'secret_access_key')
         self.assertTrue(OverriddenSessionModel.Meta.session_cls is OverriddenSession)
 
         self.assertEqual(OverriddenSessionModel._connection.connection._request_timeout_seconds, 9999)

--- a/pynamodb/tests/test_table_connection.py
+++ b/pynamodb/tests/test_table_connection.py
@@ -33,6 +33,17 @@ class ConnectionTestCase(TestCase):
         conn = TableConnection(self.test_table_name)
         self.assertIsNotNone(conn)
 
+    def test_connection_session_set_credentials(self):
+        conn = TableConnection(
+            self.test_table_name,
+            aws_access_key_id='access_key_id',
+            aws_secret_access_key='secret_access_key')
+
+        credentials = conn.connection.session.get_credentials()
+
+        self.assertEqual(credentials.access_key, 'access_key_id')
+        self.assertEqual(credentials.secret_key, 'secret_access_key')
+
     def test_create_table(self):
         """
         TableConnection.create_table


### PR DESCRIPTION
Hi! I'm currently working with microservice using Zato and we have all of our config settings in a specific place (not the same as the default files expected by botocore). We have made our integration with Dynamo using boto3 (because it allows us to set the AWS credentials when we create a session) but we are looking forward to migrate to PynamoDB and setting the credentials on the fly is a requirement...

For this, I externalized the AWS credentials attributes in the Model's MetaClass and passed them along to the TableConnection to set the session credentials. This solution works for me and now I'm using this forked version. I decided to open this PR as a way to discuss if this is a valid solution or if we could improve it (I'm not a dynamo expert whatsoever). Let me know your thoughts! 😃 