### PR TITLE
Add attributes_to_get to Model.scan

### DIFF
--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -99,6 +99,7 @@ class Index(with_metaclass(IndexMeta)):
              last_evaluated_key=None,
              page_size=None,
              consistent_read=None,
+             attributes_to_get=None,
              **filters):
         """
         Scans an index

--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -114,6 +114,7 @@ class Index(with_metaclass(IndexMeta)):
             page_size=page_size,
             consistent_read=consistent_read,
             index_name=self.Meta.index_name,
+            attributes_to_get=attributes_to_get,
             **filters
         )
 

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -759,6 +759,7 @@ class Model(AttributeContainer):
              page_size=None,
              consistent_read=None,
              index_name=None,
+             attributes_to_get=None,
              **filters):
         """
         Iterates through all items in the table
@@ -772,6 +773,7 @@ class Model(AttributeContainer):
         :param page_size: Page size of the scan to DynamoDB
         :param filters: A list of item filters
         :param consistent_read: If True, a consistent read is performed
+        :param attributes_to_get: If set, specifies the properties to include in the projection expression
         """
         cls._conditional_operator_check(conditional_operator)
         key_filter, scan_filter = cls._build_filters(
@@ -795,7 +797,8 @@ class Model(AttributeContainer):
             total_segments=total_segments,
             conditional_operator=conditional_operator,
             consistent_read=consistent_read,
-            index_name=index_name
+            index_name=index_name,
+            attributes_to_get=attributes_to_get
         )
 
         return ResultIterator(

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -2863,6 +2863,26 @@ class ModelTestCase(TestCase):
             }
             self.assertEquals(params, req.call_args[0][1])
 
+        with patch(PATCH_METHOD) as req:
+            items = []
+            for idx in range(10):
+                item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
+                item['user_id'] = {STRING_SHORT: 'id-{0}'.format(idx)}
+                items.append(item)
+            req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
+            for item in UserModel.scan(
+                    attributes_to_get=['email']):
+                self.assertIsNotNone(item)
+            params = {
+                'ReturnConsumedCapacity': 'TOTAL',
+                'ProjectionExpression': '#0',
+                'ExpressionAttributeNames': {
+                    '#0': 'email'
+                },
+                'TableName': 'UserModel'
+            }
+            self.assertEquals(params, req.call_args[0][1])
+
         # you cannot scan with multiple conditions against the same key
         self.assertRaises(
             ValueError,


### PR DESCRIPTION
Add the attributes_to_get parameter to Model.scan to enable projection expressions on scan operations.