### PR TITLE
Add python 3.5 for Travis ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - "3.6"
+  - "3.5"
   - "3.4"
   - "3.3"
   - "2.7"


### PR DESCRIPTION
Ubuntu still defaults to 3.5 for python 3.x.