### PR TITLE
Use attr.get_value(value) when deserialize

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -468,7 +468,7 @@ class BooleanAttribute(Attribute):
         # previously, BOOL was serialized as N
         value_to_deserialize = super(BooleanAttribute, self).get_value(value)
         if value_to_deserialize is None:
-            value_to_deserialize = json.loads(value.get(NUMBER_SHORT, 0))
+            value_to_deserialize = json.loads(value.get(NUMBER_SHORT, '0'))
         return value_to_deserialize
 
 

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -437,7 +437,7 @@ class Model(AttributeContainer):
             attr_name = self._dynamo_to_python_attr(name)
             attr = self._get_attributes().get(attr_name)
             if attr:
-                setattr(self, attr_name, attr.deserialize(value.get(ATTR_TYPE_MAP[attr.attr_type])))
+                setattr(self, attr_name, attr.deserialize(attr.get_value(value)))
         return data
 
     def save(self, condition=None, conditional_operator=None, **expected_values):

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -437,7 +437,7 @@ class Model(AttributeContainer):
             attr_name = self._dynamo_to_python_attr(name)
             attr = self._get_attributes().get(attr_name)
             if attr:
-                setattr(self, attr_name, attr.deserialize(attr.get_value(value)))
+                setattr(self, attr_name, attr.deserialize(value.get(ATTR_TYPE_MAP[attr.attr_type])))
         return data
 
     def save(self, condition=None, conditional_operator=None, **expected_values):

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -385,7 +385,7 @@ class Model(AttributeContainer):
             attr_name = self._dynamo_to_python_attr(name)
             attr = self._get_attributes().get(attr_name)
             if attr:
-                setattr(self, attr_name, attr.deserialize(value.get(ATTR_TYPE_MAP[attr.attr_type])))
+                setattr(self, attr_name, attr.deserialize(attr.get_value(value)))
         return data
 
     def update(self, attributes=None, actions=None, condition=None, conditional_operator=None, **expected_values):
@@ -437,7 +437,7 @@ class Model(AttributeContainer):
             attr_name = self._dynamo_to_python_attr(name)
             attr = self._get_attributes().get(attr_name)
             if attr:
-                setattr(self, attr_name, attr.deserialize(value.get(ATTR_TYPE_MAP[attr.attr_type])))
+                setattr(self, attr_name, attr.deserialize(attr.get_value(value)))
         return data
 
     def save(self, condition=None, conditional_operator=None, **expected_values):

--- a/pynamodb/tests/integration/test_migration.py
+++ b/pynamodb/tests/integration/test_migration.py
@@ -176,23 +176,35 @@ def test_legacy_boolean_attribute_deserialization_compatibility(ddb_url):
 
     BAModel.create_table(read_capacity_units=1, write_capacity_units=1)
 
-    # Create an object with a BooleanAttribute flag
-    BAModel('pkey', flag=True, value = 'value0').save()
+    # Create objects with a BooleanAttribute flag
+    BAModel('pkey1', flag=True, value = 'value0').save()
+    BAModel('pkey2', flag=False, value = 'value0').save()
+    BAModel('pkey3', flag=None, value = 'value0').save()
 
     # Check we are able to read the flag with LegacyBooleanAttribute
-    assert True == LBAModel.get('pkey').flag
+    assert True == LBAModel.get('pkey1').flag
+    assert False == LBAModel.get('pkey2').flag
+    assert None == LBAModel.get('pkey3').flag
 
     # Update a value in the model causing LegacyBooleanAttribute to be deserialized
-    LBAModel.get('pkey').update_item('value', 'value1', 'PUT')
+    LBAModel.get('pkey1').update_item('value', 'value1', 'PUT')
+    LBAModel.get('pkey2').update_item('value', 'value1', 'PUT')
+    LBAModel.get('pkey3').update_item('value', 'value1', 'PUT')
 
     # Check we are able to read the flag with LegacyBooleanAttribute
-    assert True == LBAModel.get('pkey').flag
+    assert True == LBAModel.get('pkey1').flag
+    assert False == LBAModel.get('pkey2').flag
+    assert None == LBAModel.get('pkey3').flag
 
     # Update a value in the model causing LegacyBooleanAttribute to be deserialized
-    LBAModel.get('pkey').update(actions=[LBAModel.value.set('value2')])
+    LBAModel.get('pkey1').update(actions=[LBAModel.value.set('value2')])
+    LBAModel.get('pkey2').update(actions=[LBAModel.value.set('value2')])
+    LBAModel.get('pkey3').update(actions=[LBAModel.value.set('value2')])
 
     # Check we are able to read the flag with LegacyBooleanAttribute
-    assert True == LBAModel.get('pkey').flag
+    assert True == LBAModel.get('pkey1').flag
+    assert False == LBAModel.get('pkey2').flag
+    assert None == LBAModel.get('pkey3').flag
 
 
 @pytest.mark.ddblocal
@@ -216,19 +228,31 @@ def test_boolean_attribute_deserialization_compatibility(ddb_url):
     LBAModel.create_table(read_capacity_units=1, write_capacity_units=1)
 
     # Create an object with a LegacyBooleanAttribute flag
-    LBAModel('pkey', flag=True, value = 'value0').save()
+    LBAModel('pkey1', flag=True, value = 'value0').save()
+    LBAModel('pkey2', flag=False, value = 'value0').save()
+    LBAModel('pkey3', flag=None, value = 'value0').save()
 
     # Check we are able to read the flag with BooleanAttribute
-    assert True == BAModel.get('pkey').flag
+    assert True == BAModel.get('pkey1').flag
+    assert False == BAModel.get('pkey2').flag
+    assert None == BAModel.get('pkey3').flag
 
     # Update a value in the model causing BooleanAttribute to be deserialized
-    BAModel.get('pkey').update_item('value', 'value1', 'PUT')
+    BAModel.get('pkey1').update_item('value', 'value1', 'PUT')
+    BAModel.get('pkey2').update_item('value', 'value1', 'PUT')
+    BAModel.get('pkey3').update_item('value', 'value1', 'PUT')
 
     # Check we are able to read the flag with BooleanAttribute
-    assert True == BAModel.get('pkey').flag
+    assert True == BAModel.get('pkey1').flag
+    assert False == BAModel.get('pkey2').flag
+    assert None == BAModel.get('pkey3').flag
 
     # Update a value in the model causing BooleanAttribute to be deserialized
-    BAModel.get('pkey').update(actions=[BAModel.value.set('value2')])
+    BAModel.get('pkey1').update(actions=[BAModel.value.set('value2')])
+    BAModel.get('pkey2').update(actions=[BAModel.value.set('value2')])
+    BAModel.get('pkey3').update(actions=[BAModel.value.set('value2')])
 
     # Check we are able to read the flag with BooleanAttribute
-    assert True == BAModel.get('pkey').flag
+    assert True == BAModel.get('pkey1').flag
+    assert False == BAModel.get('pkey2').flag
+    assert None == BAModel.get('pkey3').flag


### PR DESCRIPTION
Change update & update_item to use attr.get_value(value) in deserialization.

The PR https://github.com/pynamodb/PynamoDB/pull/149 introduced ```attr.get_value(value)``` for backward compatibility between LBA and BA, and used it in ```model.from_raw_data ``` but not in ```model.update_item``` (nor ```model.update```) causing code like https://gist.github.com/betamoo/1fb15692d6fa74b9ddacfd4965632b26 to fail