### PR TITLE
Make get_attributes public

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -7,6 +7,7 @@ import json
 from base64 import b64encode, b64decode
 from copy import deepcopy
 from datetime import datetime
+import warnings
 from dateutil.parser import parse
 from dateutil.tz import tzutc
 from inspect import getargspec
@@ -216,6 +217,16 @@ class AttributeContainer(object):
         self.attribute_values = {}
         self._set_defaults()
         self._set_attributes(**attributes)
+
+    @classmethod
+    def _get_attributes(cls):
+        """
+        Returns the attributes of this class as a mapping from `python_attr_name` => `attribute`.
+
+        :rtype: dict[str, Attribute]
+        """
+        warnings.warn("`Model._get_attributes` is deprecated in favor of `Model.get_attributes` now")
+        return cls.get_attributes()
 
     @classmethod
     def get_attributes(cls):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -218,7 +218,7 @@ class AttributeContainer(object):
         self._set_attributes(**attributes)
 
     @classmethod
-    def _get_attributes(cls):
+    def get_attributes(cls):
         """
         Returns the attributes of this class as a mapping from `python_attr_name` => `attribute`.
 
@@ -239,7 +239,7 @@ class AttributeContainer(object):
         """
         Sets and fields that provide a default value
         """
-        for name, attr in self._get_attributes().items():
+        for name, attr in self.get_attributes().items():
             default = attr.default
             if callable(default):
                 value = default()
@@ -253,7 +253,7 @@ class AttributeContainer(object):
         Sets the attributes for this object
         """
         for attr_name, attr_value in six.iteritems(attributes):
-            if attr_name not in self._get_attributes():
+            if attr_name not in self.get_attributes():
                 raise ValueError("Attribute {0} specified does not exist".format(attr_name))
             setattr(self, attr_name, attr_value)
 
@@ -621,7 +621,7 @@ class MapAttribute(Attribute, AttributeContainer):
         #     cannot raise a ValueError (if this assumption is wrong, calling `_make_attribute` removes them)
         #   - the names of all attributes in self.attribute_kwargs match attributes defined on the class
         if self.attribute_kwargs and (
-                attributes or self.is_raw() or all(arg in self._get_attributes() for arg in self.attribute_kwargs)):
+                attributes or self.is_raw() or all(arg in self.get_attributes() for arg in self.attribute_kwargs)):
             self._set_attributes(**self.attribute_kwargs)
 
     def _is_attribute_container(self):
@@ -640,7 +640,7 @@ class MapAttribute(Attribute, AttributeContainer):
         del self.attribute_kwargs
         del self.attribute_values
         Attribute.__init__(self, **kwargs)
-        for name, attr in self._get_attributes().items():
+        for name, attr in self.get_attributes().items():
             # Set a local attribute with the same name that shadows the class attribute.
             # Because attr is a data descriptor and the attribute already exists on the class,
             # we have to store the local copy directly into __dict__ to prevent calling attr.__set__.
@@ -652,7 +652,7 @@ class MapAttribute(Attribute, AttributeContainer):
         # WARNING! This function is only intended to be called from the AttributeContainerMeta metaclass.
         if self._is_attribute_container():
             raise AssertionError("MapAttribute._update_attribute_paths called before MapAttribute._make_attribute")
-        for name in self._get_attributes().keys():
+        for name in self.get_attributes().keys():
             local_attr = self.__dict__[name]
             local_attr.attr_path.insert(0, path_segment)
             if isinstance(local_attr, MapAttribute):
@@ -729,7 +729,7 @@ class MapAttribute(Attribute, AttributeContainer):
         return True  # TODO: check that the actual type of `value` meets requirements of `attr`
 
     def validate(self):
-        return all(self.is_correctly_typed(k, v) for k, v in six.iteritems(self._get_attributes()))
+        return all(self.is_correctly_typed(k, v) for k, v in six.iteritems(self.get_attributes()))
 
     def serialize(self, values):
         rval = {}
@@ -748,7 +748,7 @@ class MapAttribute(Attribute, AttributeContainer):
                 attr_key = _get_key_for_serialize(v)
 
             # If this is a subclassed MapAttribute, there may be an alternate attr name
-            attr = self._get_attributes().get(k)
+            attr = self.get_attributes().get(k)
             attr_name = attr.attr_name if attr else k
 
             rval[attr_name] = {attr_key: attr_class.serialize(v)}
@@ -791,13 +791,13 @@ class MapAttribute(Attribute, AttributeContainer):
     @classmethod
     def _get_serialize_class(cls, key, value):
         if not cls.is_raw():
-            return cls._get_attributes().get(key)
+            return cls.get_attributes().get(key)
         return _get_class_for_serialize(value)
 
     @classmethod
     def _get_deserialize_class(cls, key, value):
         if not cls.is_raw():
-            return cls._get_attributes().get(key)
+            return cls.get_attributes().get(key)
         return _get_class_for_deserialize(value)
 
 


### PR DESCRIPTION
Being able to dynamically introspect Model classes is valuable for tasks
such as validation. This commit converts the underscore-prefixed private
method `_get_attributes` into a public method.