### PR TITLE
Show that BinaryAttributes cannot be used with `update`.

### DIFF
--- a/pynamodb/tests/integration/binary_update_test.py
+++ b/pynamodb/tests/integration/binary_update_test.py
@@ -1,0 +1,25 @@
+import pytest
+
+from pynamodb.attributes import UnicodeAttribute, BinaryAttribute
+from pynamodb.models import Model
+
+
+@pytest.mark.ddblocal
+def test_update(ddb_url):
+    class DataModel(Model):
+        class Meta:
+            table_name = 'binary_attr_update'
+            host = ddb_url
+        pkey = UnicodeAttribute(hash_key=True)
+        data = BinaryAttribute()
+
+    DataModel.create_table(read_capacity_units=1, write_capacity_units=1)
+    data = b'\x00hey\xfb'
+    pkey = 'pkey'
+    DataModel(pkey, data=data).save()
+    m = DataModel.get(pkey)
+    assert m.data == data
+
+    new_data = b'\xff'
+    m.update(actions=[DataModel.data.set(new_data)])
+    assert new_data == m.data

--- a/pynamodb/tests/integration/conftest.py
+++ b/pynamodb/tests/integration/conftest.py
@@ -1,0 +1,19 @@
+import os
+
+import pytest
+
+
+@pytest.fixture
+def ddb_url():
+    """Obtain the URL of a local DynamoDB instance.
+
+    This is meant to be used with something like DynamoDB Local:
+
+      http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html
+
+    It must be set up "out of band"; we merely assume it exists on
+    http://localhost:8000 or a URL specified though the
+    PYNAMODB_INTEGRATION_TEST_DDB_URL environment variable.
+    """
+    ddb_url = os.getenv("PYNAMODB_INTEGRATION_TEST_DDB_URL")
+    return "http://localhost:8000" if ddb_url is None else ddb_url

--- a/pynamodb/tests/integration/test_migration.py
+++ b/pynamodb/tests/integration/test_migration.py
@@ -1,26 +1,9 @@
-import os
 import pytest
 
 from pynamodb.attributes import BooleanAttribute, LegacyBooleanAttribute, UnicodeAttribute
 from pynamodb.expressions.operand import Path
 from pynamodb.migration import migrate_boolean_attributes
 from pynamodb.models import Model
-
-
-@pytest.fixture()
-def ddb_url():
-    """Obtain the URL of a local DynamoDB instance.
-
-    This is meant to be used with something like DynamoDB Local:
-
-      http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html
-
-    It must be set up "out of band"; we merely assume it exists on
-    http://localhost:8000 or a URL specified though the
-    PYNAMODB_INTEGRATION_TEST_DDB_URL environment variable.
-    """
-    ddb_url = os.getenv("PYNAMODB_INTEGRATION_TEST_DDB_URL")
-    return "http://localhost:8000" if ddb_url is None else ddb_url
 
 
 @pytest.mark.ddblocal


### PR DESCRIPTION
The response data is double base64 encoded.