### PR TITLE
Allow MapAttribute instances to be used as the RHS in expressions.

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -89,11 +89,15 @@ class Attribute(object):
 
     # Condition Expression Support
     def __eq__(self, other):
+        if isinstance(other, MapAttribute) and other._is_attribute_container():
+            return Path(self).__eq__(other)
         if other is None or isinstance(other, Attribute):  # handle object identity comparison
             return self is other
         return Path(self).__eq__(other)
 
     def __ne__(self, other):
+        if isinstance(other, MapAttribute) and other._is_attribute_container():
+            return Path(self).__ne__(other)
         if other is None or isinstance(other, Attribute):  # handle object identity comparison
             return self is not other
         return Path(self).__ne__(other)
@@ -256,6 +260,14 @@ class AttributeContainer(object):
             if attr_name not in self._get_attributes():
                 raise ValueError("Attribute {0} specified does not exist".format(attr_name))
             setattr(self, attr_name, attr_value)
+
+    def __eq__(self, other):
+        # This is required for python 2 support so that MapAttribute can call this method.
+        return self is other
+
+    def __ne__(self, other):
+        # This is required for python 2 support so that MapAttribute can call this method.
+        return self is not other
 
 
 class SetMixin(object):
@@ -660,6 +672,16 @@ class MapAttribute(Attribute, AttributeContainer):
             local_attr.attr_path.insert(0, path_segment)
             if isinstance(local_attr, MapAttribute):
                 local_attr._update_attribute_paths(path_segment)
+
+    def __eq__(self, other):
+        if self._is_attribute_container():
+            return AttributeContainer.__eq__(self, other)
+        return Attribute.__eq__(self, other)
+
+    def __ne__(self, other):
+        if self._is_attribute_container():
+            return AttributeContainer.__ne__(self, other)
+        return Attribute.__ne__(self, other)
 
     def __iter__(self):
         if self._is_attribute_container():

--- a/pynamodb/expressions/operand.py
+++ b/pynamodb/expressions/operand.py
@@ -35,7 +35,9 @@ class _Operand(object):
     def _to_operand(self, value):
         if isinstance(value, _Operand):
             return value
-        from pynamodb.attributes import Attribute  # prevent circular import -- Attribute imports Path
+        from pynamodb.attributes import Attribute, MapAttribute  # prevent circular import -- Attribute imports Path
+        if isinstance(value, MapAttribute) and value._is_attribute_container():
+            return self._to_value(value)
         return Path(value) if isinstance(value, Attribute) else self._to_value(value)
 
     def _to_value(self, value):

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -314,6 +314,19 @@ class ConditionExpressionTestCase(TestCase):
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S' : 'bar'}}
 
+    def test_map_comparison(self):
+        # Simulate initialization from inside an AttributeContainer
+        my_map_attribute = MapAttribute(attr_name='foo')
+        my_map_attribute._make_attribute()
+        my_map_attribute._update_attribute_paths(my_map_attribute.attr_name)
+
+        condition = my_map_attribute == MapAttribute(bar='baz')
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0 = :0"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'M': {'bar': {'S': 'baz'}}}}
+
     def test_list_comparison(self):
         condition = ListAttribute(attr_name='foo') == ['bar', 'baz']
         placeholder_names, expression_attribute_values = {}, {}
@@ -401,6 +414,19 @@ class UpdateExpressionTestCase(TestCase):
         assert expression == "#0 = :0"
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S': 'bar'}}
+
+    def test_set_action_attribute_container(self):
+        # Simulate initialization from inside an AttributeContainer
+        my_map_attribute = MapAttribute(attr_name='foo')
+        my_map_attribute._make_attribute()
+        my_map_attribute._update_attribute_paths(my_map_attribute.attr_name)
+
+        action = my_map_attribute.set(MapAttribute(bar='baz'))
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = action.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0 = :0"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'M': {'bar': {'S': 'baz'}}}}
 
     def test_increment_action(self):
         action = self.attribute.set(Path('bar') + 0)


### PR DESCRIPTION
The expression classes assume that whenever an attribute appears in the right hand side argument that the resulting expression should use the attribute's path. That allows users to compare two attributes of an item or to update one attribute of the item based on another. For example:

```
>>> class MyModel(Model):
...     foo = UnicodeAttribute()
...     bar = UnicodeAttribute()
...
>>> MyModel.foo > MyModel.bar
foo > bar
>>> MyModel.foo.set(MyModel.bar)
foo = bar
```

However, the code failed to consider that some attribute classes, specifically MapAttribute and its subclasses, can sometime act as AttributeContainer objects depending on the context. When instantiated as an attribute container, the instance should behave as a Value in the right hand side of an expression:

```
>>> class MyMap(MapAttribute):
...     foo = UnicodeAttribute()
...
>>> class MyModel(Model):
...     my_map = MyMap()
...
>>> my_map_instance = MyMap(foo='bar')
>>> MyModel.my_map.set(my_map_instance)
my_map = {'M': {'foo': {'S': u'bar'}}}
```

