### PR TITLE
Allow passing of a session token to the model metaclass

### DIFF
--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -19,7 +19,8 @@ class TableConnection(object):
                  max_retry_attempts=None,
                  base_backoff_ms=None,
                  aws_access_key_id=None,
-                 aws_secret_access_key=None):
+                 aws_secret_access_key=None,
+                 aws_session_token=None):
         self._hash_keyname = None
         self._range_keyname = None
         self.table_name = table_name
@@ -29,10 +30,34 @@ class TableConnection(object):
                                      request_timeout_seconds=request_timeout_seconds,
                                      max_retry_attempts=max_retry_attempts,
                                      base_backoff_ms=base_backoff_ms)
+        if aws_access_key_id:
+            self.connection.requests_session.aws_access_key_id = (
+                aws_access_key_id)
 
+        if aws_secret_access_key:
+            self.connection.requests_session.aws_secret_access_key = (
+                    aws_secret_access_key)
+
+        if aws_session_token:
+            self.connection.requests_session.aws_session_token = (
+                    aws_session_token)
+
+        session_args = []
         if aws_access_key_id and aws_secret_access_key:
-            self.connection.session.set_credentials(aws_access_key_id,
-                                                    aws_secret_access_key)
+            session_args.append(aws_access_key_id)
+            session_args.append(aws_secret_access_key)
+
+            if aws_session_token:
+                session_args.append(aws_session_token)
+
+            session_args = tuple(session_args)
+            self.connection.session.set_credentials(*session_args)
+
+    def get_meta_table(self, refresh=False):
+        """
+        Returns a MetaTable
+        """
+        return self.connection.get_meta_table(self.table_name, refresh=refresh)
 
     def get_meta_table(self, refresh=False):
         """

--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -59,12 +59,6 @@ class TableConnection(object):
         """
         return self.connection.get_meta_table(self.table_name, refresh=refresh)
 
-    def get_meta_table(self, refresh=False):
-        """
-        Returns a MetaTable
-        """
-        return self.connection.get_meta_table(self.table_name, refresh=refresh)
-
     def delete_item(self, hash_key,
                     range_key=None,
                     condition=None,

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -188,6 +188,8 @@ class MetaModel(AttributeContainerMeta):
                         setattr(attr_obj, 'aws_access_key_id', None)
                     if not hasattr(attr_obj, 'aws_secret_access_key'):
                         setattr(attr_obj, 'aws_secret_access_key', None)
+                    if not hasattr(attr_obj, 'aws_session_token'):
+                        setattr(attr_obj, 'aws_session_token', None)
                 elif issubclass(attr_obj.__class__, (Index, )):
                     attr_obj.Meta.model = cls
                     if not hasattr(attr_obj.Meta, "index_name"):
@@ -1292,7 +1294,8 @@ class Model(AttributeContainer):
                                               max_retry_attempts=cls.Meta.max_retry_attempts,
                                               base_backoff_ms=cls.Meta.base_backoff_ms,
                                               aws_access_key_id=cls.Meta.aws_access_key_id,
-                                              aws_secret_access_key=cls.Meta.aws_secret_access_key)
+                                              aws_secret_access_key=cls.Meta.aws_secret_access_key,
+                                              aws_session_token=cls.Meta.aws_session_token)
         return cls._connection
 
     def _deserialize(self, attrs):


### PR DESCRIPTION
This allows temporary credentials to be used such as those returned by
assuming an IAM role

Resolves #501 