### PR TITLE
Fix faulty documentation example

### DIFF
--- a/docs/updates.rst
+++ b/docs/updates.rst
@@ -20,9 +20,9 @@ Suppose that you have defined a `Thread` Model for the examples below.
             table_name = 'Thread'
 
         forum_name = UnicodeAttribute(hash_key=True)
-        subjects = UnicodeSetAttribute(default={})
+        subjects = UnicodeSetAttribute(default=dict)
         views = NumberAttribute(default=0)
-        notes = ListAttribute(default=[])
+        notes = ListAttribute(default=list)
 
 
 .. _updates:


### PR DESCRIPTION
It is important that the default is not mutable, because that would cause the default value to be modified when the first instance of the object is modified.  

The current example results in following behaviour
```python
thread = Thread()
thread.notes.append('First note')
empty_thread = Thread()
empty_thread.notes
>>> ['First note']
```