### PR TITLE
Update attributes.py

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -935,6 +935,7 @@ DESERIALIZE_CLASS_MAP = {
 SERIALIZE_CLASS_MAP = {
     dict: MapAttribute(),
     list: ListAttribute(),
+    tuple: ListAttribute(),
     set: ListAttribute(),
     bool: BooleanAttribute(),
     float: NumberAttribute(),
@@ -946,6 +947,7 @@ SERIALIZE_CLASS_MAP = {
 SERIALIZE_KEY_MAP = {
     dict: MAP_SHORT,
     list: LIST_SHORT,
+    tuple: LIST_SHORT,
     set: LIST_SHORT,
     bool: BOOLEAN,
     float: NUMBER_SHORT,


### PR DESCRIPTION
I noticed this issue when `_serialize` is called- while appending a dictionary with a list inside of it to a ListAttribute. Somewhere along the way the dictionary values are being returned as tuple, and is raising a ValueError- `ValueError: Unknown value: <class 'tuple'>` inside of `_get_class_for_serialize`, since it is not in `SERIALIZE_CLASS_MAP`. Folding tuple behavior right into list behavior seems like a catch-all, but it would be nice if there was a way to handle this tedious exception.