### PR TITLE
Add a UUID attribute

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -18,6 +18,7 @@ from pynamodb.constants import (
 from pynamodb.compat import getmembers_issubclass
 from pynamodb.expressions.operand import Path
 import collections
+import uuid
 
 
 class Attribute(object):
@@ -551,6 +552,27 @@ class UTCDateTimeAttribute(Attribute):
             return datetime.strptime(value, DATETIME_FORMAT)
         except ValueError:
             return parse(value)
+
+
+class UUIDAttribute(Attribute):
+    """
+    An attribute for storing UUIDs.
+    """
+    attr_type = STRING
+
+    def serialize(self, value):
+        """
+        Takes an uuid as UUID-object or as string and returns a string.
+        """
+        if not isinstance(value, uuid.UUID):
+            value = uuid.UUID(value)
+        return six.u(str(value))
+
+    def deserialize(self, value):
+        """
+        Takes a UUID string and returns a UUID-object.
+        """
+        return uuid.UUID(value)
 
 
 class NullAttribute(Attribute):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -556,13 +556,13 @@ class UTCDateTimeAttribute(Attribute):
 
 class UUIDAttribute(Attribute):
     """
-    An attribute for storing UUIDs.
+    An attribute for storing a UUID
     """
     attr_type = STRING
 
     def serialize(self, value):
         """
-        Takes an uuid as UUID-object or as string and returns a string.
+        Takes a UUID as UUID-object or as string and returns a string
         """
         if not isinstance(value, uuid.UUID):
             value = uuid.UUID(value)
@@ -570,7 +570,7 @@ class UUIDAttribute(Attribute):
 
     def deserialize(self, value):
         """
-        Takes a UUID string and returns a UUID-object.
+        Takes a UUID string and returns a UUID-object
         """
         return uuid.UUID(value)
 

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -3,6 +3,7 @@ pynamodb attributes tests
 """
 import json
 import six
+import uuid
 
 from base64 import b64encode
 from datetime import datetime
@@ -18,8 +19,8 @@ from pynamodb.models import Model
 
 from pynamodb.attributes import (
     BinarySetAttribute, BinaryAttribute, NumberSetAttribute, NumberAttribute,
-    UnicodeAttribute, UnicodeSetAttribute, UTCDateTimeAttribute, BooleanAttribute, LegacyBooleanAttribute,
-    MapAttribute, MapAttributeMeta, ListAttribute, Attribute,
+    UnicodeAttribute, UnicodeSetAttribute, UTCDateTimeAttribute, UUIDAttribute, BooleanAttribute,
+    LegacyBooleanAttribute, MapAttribute, MapAttributeMeta, ListAttribute, Attribute,
     JSONAttribute, DEFAULT_ENCODING, NUMBER, STRING, STRING_SET, NUMBER_SET, BINARY_SET,
     BINARY, MAP, LIST, BOOLEAN, _get_value_for_deserialize)
 
@@ -179,6 +180,41 @@ class TestUTCDateTimeAttribute:
         tstamp = datetime.now()
         attr = UTCDateTimeAttribute()
         assert attr.serialize(tstamp) == tstamp.replace(tzinfo=UTC).strftime(DATETIME_FORMAT)
+
+
+class TestUUIDAttribute:
+    """
+    Tests UUID attributes.
+    """
+    def test_uuid_attribute(self):
+        """
+        UUIDAttribute.default
+        """
+        attr = UUIDAttribute()
+        assert attr is not None
+        assert attr.attr_type == STRING
+
+        sample_uuid = uuid.UUID('db38ff5b-1e90-41df-8cfa-e0839727bd93')
+        attr = UUIDAttribute(default=sample_uuid)
+        assert attr.default == sample_uuid
+
+    def test_uuid_serialize(self):
+        """
+        UUIDAttribute.serialize
+        """
+        sample = 'db38ff5b-1e90-41df-8cfa-e0839727bd93'
+        sample_uuid = uuid.UUID(sample)
+        attr = UUIDAttribute()
+        assert attr.serialize(sample) == sample
+        assert attr.serialize(sample_uuid) == sample
+
+    def test_uuid_deserialize(self):
+        """
+        UUIDAttribute.deserialize
+        """
+        sample = 'db38ff5b-1e90-41df-8cfa-e0839727bd93'
+        attr = UUIDAttribute()
+        assert attr.deserialize(sample) == uuid.UUID(sample)
 
 
 class TestBinaryAttribute:


### PR DESCRIPTION
An attribute to store UUID-objects as strings in DynamoDB.

When a UUID is provided as string for serializing it is converted to a
UUID-object first to ensure it's a valid UUID.