### PR TITLE
correct error will now be raised when no key_schema is provided

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -547,7 +547,7 @@ class Connection(object):
                 })
             operation_kwargs[GLOBAL_SECONDARY_INDEXES] = global_secondary_indexes_list
 
-        if key_schema is None:
+        if not key_schema:
             raise ValueError("key_schema is required")
         key_schema_list = []
         for item in key_schema:


### PR DESCRIPTION
key_schema is a list so when an empty list is compared to None it is still false.
Resolves #527.