### PR TITLE
Allow creation of tables with Encryption enabled at rest (#518)

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -39,7 +39,7 @@ from pynamodb.constants import (
     ITEMS, DEFAULT_ENCODING, BINARY_SHORT, BINARY_SET_SHORT, LAST_EVALUATED_KEY, RESPONSES, UNPROCESSED_KEYS,
     UNPROCESSED_ITEMS, STREAM_SPECIFICATION, STREAM_VIEW_TYPE, STREAM_ENABLED, UPDATE_EXPRESSION,
     EXPRESSION_ATTRIBUTE_NAMES, EXPRESSION_ATTRIBUTE_VALUES, KEY_CONDITION_OPERATOR_MAP,
-    CONDITION_EXPRESSION, FILTER_EXPRESSION, FILTER_EXPRESSION_OPERATOR_MAP, NOT_CONTAINS, AND)
+    CONDITION_EXPRESSION, FILTER_EXPRESSION, FILTER_EXPRESSION_OPERATOR_MAP, NOT_CONTAINS, AND, ENCRYPT_SPECIFICATION, ENCRYPT_ENABLED)
 from pynamodb.exceptions import (
     TableError, QueryError, PutError, DeleteError, UpdateError, GetError, ScanError, TableDoesNotExist,
     VerboseClientError
@@ -515,7 +515,8 @@ class Connection(object):
                      write_capacity_units=None,
                      global_secondary_indexes=None,
                      local_secondary_indexes=None,
-                     stream_specification=None):
+                     stream_specification=None,
+                     encryption_enabled=False):
         """
         Performs the CreateTable operation
         """
@@ -571,6 +572,11 @@ class Connection(object):
             operation_kwargs[STREAM_SPECIFICATION] = {
                 STREAM_ENABLED: stream_specification[pythonic(STREAM_ENABLED)],
                 STREAM_VIEW_TYPE: stream_specification[pythonic(STREAM_VIEW_TYPE)]
+            }
+
+        if encryption_enabled:
+            operation_kwargs[ENCRYPT_SPECIFICATION] = {
+                ENCRYPT_ENABLED: encryption_enabled
             }
 
         try:

--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -288,7 +288,8 @@ class TableConnection(object):
                      write_capacity_units=None,
                      global_secondary_indexes=None,
                      local_secondary_indexes=None,
-                     stream_specification=None):
+                     stream_specification=None,
+                     encryption_enabled=False):
         """
         Performs the CreateTable operation and returns the result
         """
@@ -300,5 +301,6 @@ class TableConnection(object):
             write_capacity_units=write_capacity_units,
             global_secondary_indexes=global_secondary_indexes,
             local_secondary_indexes=local_secondary_indexes,
-            stream_specification=stream_specification
+            stream_specification=stream_specification,
+            encryption_enabled=encryption_enabled
         )

--- a/pynamodb/constants.py
+++ b/pynamodb/constants.py
@@ -149,6 +149,11 @@ STREAM_OLD_IMAGE = 'OLD_IMAGE'
 STREAM_NEW_AND_OLD_IMAGE = 'NEW_AND_OLD_IMAGES'
 STREAM_KEYS_ONLY = 'KEYS_ONLY'
 
+# Constants for DynamoDB create table with Encryption enabled
+ENCRYPT_META_ATTRIBUTE = 'EncryptionEnabled'
+ENCRYPT_SPECIFICATION = 'SSESpecification'
+ENCRYPT_ENABLED = 'Enabled'
+
 # These are constants used in the KeyConditionExpression parameter
 # http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-KeyConditionExpression
 EXCLUSIVE_START_KEY = 'ExclusiveStartKey'

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -32,7 +32,7 @@ from pynamodb.constants import (
     CAPACITY_UNITS, META_CLASS_NAME, REGION, HOST, EXISTS, NULL,
     DELETE_FILTER_OPERATOR_MAP, UPDATE_FILTER_OPERATOR_MAP, PUT_FILTER_OPERATOR_MAP,
     COUNT, ITEM_COUNT, KEY, UNPROCESSED_ITEMS, STREAM_VIEW_TYPE, STREAM_SPECIFICATION,
-    STREAM_ENABLED, EQ, NE, BINARY_SET, STRING_SET, NUMBER_SET)
+    STREAM_ENABLED, EQ, NE, BINARY_SET, STRING_SET, NUMBER_SET, ENCRYPT_META_ATTRIBUTE)
 
 
 log = logging.getLogger(__name__)
@@ -842,7 +842,7 @@ class Model(AttributeContainer):
         return cls._get_connection().describe_table()
 
     @classmethod
-    def create_table(cls, wait=False, read_capacity_units=None, write_capacity_units=None):
+    def create_table(cls, wait=False, read_capacity_units=None, write_capacity_units=None, encryption_enabled=None):
         """
         Create the table for this model
 
@@ -865,6 +865,8 @@ class Model(AttributeContainer):
                 schema[pythonic(READ_CAPACITY_UNITS)] = read_capacity_units
             if write_capacity_units is not None:
                 schema[pythonic(WRITE_CAPACITY_UNITS)] = write_capacity_units
+            if encryption_enabled is not None:
+                schema[pythonic(ENCRYPT_META_ATTRIBUTE)] = encryption_enabled
             index_data = cls._get_indexes()
             schema[pythonic(GLOBAL_SECONDARY_INDEXES)] = index_data.get(pythonic(GLOBAL_SECONDARY_INDEXES))
             schema[pythonic(LOCAL_SECONDARY_INDEXES)] = index_data.get(pythonic(LOCAL_SECONDARY_INDEXES))


### PR DESCRIPTION
https://github.com/pynamodb/PynamoDB/issues/518

encryption_enabled argument can be passed to Model.create_table
`Model.create_table(wait=True, encryption_enabled=True)`