### PR TITLE
Fix botocore > 1.11.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,13 @@ python:
   - "pypy"
 
 env:
-  - AWS_SECRET_ACCESS_KEY=fake_key AWS_ACCESS_KEY_ID=fake_id UPDATE_BOTOCORE=0
-  - AWS_SECRET_ACCESS_KEY=fake_key AWS_ACCESS_KEY_ID=fake_id UPDATE_BOTOCORE=1
+  - AWS_SECRET_ACCESS_KEY=fake_key AWS_ACCESS_KEY_ID=fake_id
 
 before_install:
   - pip install six==1.9.0
 
 install:
   - pip install -r requirements-dev.txt
-  - if [ "${UPDATE_BOTOCORE}" = "1" ]; then pip install botocore -U; fi
 
 before_script:
   - wget http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz -O /tmp/dynamodb_local_latest.tar.gz

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -352,6 +352,7 @@ class Connection(object):
             response = None
             try:
                 proxies = getattr(self.client._endpoint, "proxies", None)
+                # After the version 1.11.0 of botocore this field is no longer available here
                 if proxies is None:
                     proxies = self.client._endpoint.http_session._proxy_config._proxies
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 # we didn't want to bump the actual dependency of the library for consumers as it would effectively
 # be a breaking change. As a result, we use the 1.6.0 dependency for development here for the
 # purpose of integration tests, even though requirements.txt still has 1.2.0.
-botocore==1.6.0
+botocore==1.11.4
 six==1.9.0
 coverage==3.7.1
 mock==2.0.0


### PR DESCRIPTION
Related to #529 

I don't think it's a good idea to rely on protected parameters here (but was already the case before)