### PR TITLE
Fix Python 3 compatibility of PageIterator#key_names

### DIFF
--- a/pynamodb/pagination.py
+++ b/pynamodb/pagination.py
@@ -1,4 +1,5 @@
 import time
+import six
 from pynamodb.constants import (CAMEL_COUNT, ITEMS, LAST_EVALUATED_KEY, SCANNED_COUNT,
                                 CONSUMED_CAPACITY, TOTAL, CAPACITY_UNITS)
 
@@ -119,7 +120,7 @@ class PageIterator(object):
             return self._last_evaluated_key.keys()
 
         # Use the table meta data to determine the key attributes
-        table_meta = self._operation.im_self.get_meta_table()
+        table_meta = six.get_method_self(self._operation).get_meta_table()
         return table_meta.get_key_names(self._kwargs.get('index_name'))
 
     @property


### PR DESCRIPTION
Hello, 

 `im_self` doesn't exists anymore in python 3 (https://docs.python.org/2/reference/datamodel.html). So using six to fix this.

Saw this happen multiple times in production. Sorry though I can't seem to redo it in unit test without messing with the internal state of the ResultIterator (e.g. by making `results_iter._index=1` so it is different from count after the iterator is fully consumed).

Thanks for this package !
 
