### PR TITLE
Remove invocation of botocore's vendor code

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -6,6 +6,7 @@ from __future__ import division
 import logging
 import math
 import random
+import requests
 import time
 import uuid
 import warnings
@@ -16,8 +17,6 @@ import six
 from botocore.client import ClientError
 from botocore.exceptions import BotoCoreError
 from botocore.session import get_session
-from botocore.vendored import requests
-from botocore.vendored.requests import Request
 from six.moves import range
 
 from pynamodb.compat import NullHandler
@@ -286,7 +285,7 @@ class Connection(object):
         # part of the request session. In order to include the requests session headers inside
         # the request, we create a new request object, and call prepare_request with the newly
         # created request object
-        raw_request_with_params = Request(
+        raw_request_with_params = requests.Request(
             boto_prepared_request.method,
             boto_prepared_request.url,
             data=boto_prepared_request.body,

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -3,11 +3,11 @@ Tests for the base connection class
 """
 import base64
 import json
+import requests
 import six
 from pynamodb.compat import CompatTestCase as TestCase
 from pynamodb.connection import Connection
 from pynamodb.connection.base import MetaTable
-from botocore.vendored import requests
 from pynamodb.exceptions import (VerboseClientError,
     TableError, DeleteError, UpdateError, PutError, GetError, ScanError, QueryError, TableDoesNotExist)
 from pynamodb.constants import (

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ install_requires = [
     'six',
     'botocore>=1.2.0',
     'python-dateutil>=2.1,<3.0.0',
+    'requests',
 ]
 
 setup(


### PR DESCRIPTION
Seems like the use of vendor code is causing exceptions like these:
OpenSSL/SSL.py", line 1993, in shutdown self._raise_ssl_error(self._ssl, result)
OpenSSL/SSL.py", line 1631, in _raise_ssl_error
raise SysCallError(errno, errorcode.get(errno))
SysCallError: (32, 'EPIPE')

botocore no longer uses this vendor code. So, probably a good time to remove from pynamodb too.