### PR TITLE
Updates setup.py and tox.ini to reflect supported python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'Programming Language :: Python',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: MIT License',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 exclude = .tox,docs,build
 
 [tox]
-envlist = py26,py27,py33,py34,py35,pypy
+envlist = py26,py27,py33,py34,py35,py36,pypy
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
This small PR updates the python versions in the `tox.ini` file and `setup.py` file. 

I noticed some inconsistencies between the versions supported in the files with the current supported versions in the `.travis.yml` content (which seems to support `py36` unless I'm missing something). I'm not sure if that's intended or not. I think this would bring more consistency to the code base. 

Any comments more than welcome ! 