### PR TITLE
Raise the more useful http error when failing retries.

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -366,6 +366,7 @@ class Connection(object):
                 if is_last_attempt_for_exceptions:
                     log.debug('Reached the maximum number of retry attempts: %s', attempt_number)
                     if response:
+                        response.raise_for_status()
                         e.args += (str(response.content),)
                     raise
                 else:


### PR DESCRIPTION
This aids in comprehension of what's going wrong -- especially when there's a proxy in between such as `envoy` raising its own 503 status which isn't json.

Before:

```
Traceback (most recent call last):
  File "/srv/service/current/manage.py", line 17, in <module>
    manager.run()
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask_script/__init__.py", line 412, in run
    result = self.handle(sys.argv[0], sys.argv[1:])
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask_script/__init__.py", line 383, in handle
    res = handle(*args, **config)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask_script/commands.py", line 216, in __call__
    return self.run(*args, **kwargs)
  File "/code/userpreferences/userpreferences/scripts/create_tables.py", line 46, in run
    self._create_table_given_model(model)
  File "/code/userpreferences/userpreferences/scripts/create_tables.py", line 26, in _create_table_given_model
    wait=True
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/models.py", line 848, in create_table
    **schema
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/connection/table.py", line 286, in create_table
    stream_specification=stream_specification
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/connection/base.py", line 554, in create_table
    data = self.dispatch(CREATE_TABLE, operation_kwargs)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/connection/base.py", line 296, in dispatch
    data = self._make_api_call(operation_name, operation_kwargs)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/connection/base.py", line 342, in _make_api_call
    data = response.json()
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/botocore/vendored/requests/models.py", line 819, in json
    return json.loads(self.text, **kwargs)
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

After:

```
Traceback (most recent call last):
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/connection/base.py", line 344, in _make_api_call
    data = response.json()
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/botocore/vendored/requests/models.py", line 819, in json
    return json.loads(self.text, **kwargs)
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/srv/service/current/manage.py", line 17, in <module>
    manager.run()
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask_script/__init__.py", line 412, in run
    result = self.handle(sys.argv[0], sys.argv[1:])
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask_script/__init__.py", line 383, in handle
    res = handle(*args, **config)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/flask_script/commands.py", line 216, in __call__
    return self.run(*args, **kwargs)
  File "/code/userpreferences/userpreferences/scripts/create_tables.py", line 46, in run
    self._create_table_given_model(model)
  File "/code/userpreferences/userpreferences/scripts/create_tables.py", line 22, in _create_table_given_model
    if not model.exists():
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/models.py", line 794, in exists
    cls._get_connection().describe_table()
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/connection/table.py", line 246, in describe_table
    return self.connection.describe_table(self.table_name)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/connection/base.py", line 634, in describe_table
    tbl = self.get_meta_table(table_name, refresh=True)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/connection/base.py", line 479, in get_meta_table
    data = self.dispatch(DESCRIBE_TABLE, operation_kwargs)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/connection/base.py", line 296, in dispatch
    data = self._make_api_call(operation_name, operation_kwargs)
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/pynamodb/connection/base.py", line 348, in _make_api_call
    response.raise_for_status()
  File "/srv/venvs/service/trusty/service_venv_python3.6/lib/python3.6/site-packages/botocore/vendored/requests/models.py", line 851, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
botocore.vendored.requests.exceptions.HTTPError: 503 Server Error: Service Unavailable
```