### PR TITLE
Fix a broken link to the examples on github

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,7 +1,7 @@
 PynamoDB Examples
 =================
 
-An directory of examples is available with the PynamoDB source on `GitHub <https://github.com/pynamodb/PynamoDB/tree/devel/examples>`__.
+An directory of examples is available with the PynamoDB source on `GitHub <https://github.com/pynamodb/PynamoDB/tree/master/examples>`__.
 The examples are configured to use `http://localhost:8000` as the DynamoDB endpoint. For information on how to run DynamoDB locally,
 see : :ref:`local`.
 


### PR DESCRIPTION
The previous link pointed to a branch called `devel` which seems to no longer exist.