### PR TITLE
Include license and other files in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include AUTHORS.rst
+include LICENSE
+include mypy.ini
+include requirements-*.txt
+include requirements.txt
+include tox.ini

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The MIT license requires all copies of the program to include a copy of the license.  Also include some other useful files in sdists.