### PR TITLE
Allow using system requests

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -16,9 +16,14 @@ import six
 from botocore.client import ClientError
 from botocore.exceptions import BotoCoreError
 from botocore.session import get_session
-from botocore.vendored import requests
-from botocore.vendored.requests import Request
 from six.moves import range
+
+try:
+    from botocore.vendored import requests
+    from botocore.vendored.requests import Request
+except ImportError:
+    import requests
+    from requests import Request
 
 from pynamodb.compat import NullHandler
 from pynamodb.connection.util import pythonic

--- a/pynamodb/settings.py
+++ b/pynamodb/settings.py
@@ -3,7 +3,10 @@ import logging
 import os
 from os import getenv
 
-from botocore.vendored import requests
+try:
+    from botocore.vendored import requests
+except ImportError:
+    import requests
 
 log = logging.getLogger(__name__)
 

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -7,7 +7,6 @@ import six
 from pynamodb.compat import CompatTestCase as TestCase
 from pynamodb.connection import Connection
 from pynamodb.connection.base import MetaTable
-from botocore.vendored import requests
 from pynamodb.exceptions import (VerboseClientError,
     TableError, DeleteError, UpdateError, PutError, GetError, ScanError, QueryError, TableDoesNotExist)
 from pynamodb.constants import (
@@ -23,6 +22,10 @@ if six.PY3:
 else:
     from mock import patch
     import mock
+try:
+    from botocore.vendored import requests
+except ImportError:
+    import requests
 
 PATCH_METHOD = 'pynamodb.connection.Connection._make_api_call'
 

--- a/pynamodb/tests/test_model.py
+++ b/pynamodb/tests/test_model.py
@@ -9,8 +9,12 @@ from datetime import datetime
 
 import six
 from botocore.client import ClientError
-from botocore.vendored import requests
 import pytest
+
+try:
+    from botocore.vendored import requests
+except ImportError:
+    import requests
 
 from pynamodb.compat import CompatTestCase as TestCase
 from pynamodb.tests.deep_eq import deep_eq


### PR DESCRIPTION
Some downstreams change botocore to use the system's built-in requests rather than the vendored version.