### PR TITLE
Pass null datetimes through deserializer

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -544,6 +544,8 @@ class UTCDateTimeAttribute(Attribute):
         """
         Takes a UTC datetime string and returns a datetime object
         """
+        if value is None:
+            return None
         # First attempt to parse the datetime with the datetime format used
         # by default when storing UTCDateTimeAttributes.  This is signifantly
         # faster than always going through dateutil.

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -151,6 +151,9 @@ class TestUTCDateTimeAttribute:
         attr = UTCDateTimeAttribute()
         assert attr.deserialize(tstamp.strftime(DATETIME_FORMAT)) == tstamp
 
+    def test_utc_date_time_desrialize_none(self):
+        assert UTCDateTimeAttribute().deserialize(None) == None
+
     def test_dateutil_parser_fallback(self):
         """
         UTCDateTimeAttribute.deserialize


### PR DESCRIPTION
This prevents a crash when a UTCDateTimeAttribute is nullable and is explicitly
set to None through Model.update