### PR TITLE
Add _NullableAttributeWrapper type stub

### DIFF
--- a/pynamodb/attributes.pyi
+++ b/pynamodb/attributes.pyi
@@ -157,6 +157,7 @@ class ListAttribute(Generic[_T], Attribute[List[_T]]):
     def __get__(self, instance: Any, owner: Any) -> List[_T]: ...
 
 class _NullableAttributeWrapper(Generic[_A, _T]):
+    """Used internally by pynamodb-mypy for nullable attributes"""
     @overload
     def __get__(self, instance: None, owner: Any) -> _A: ...
     @overload

--- a/pynamodb/attributes.pyi
+++ b/pynamodb/attributes.pyi
@@ -9,6 +9,7 @@ from pynamodb.expressions.operand import _ListAppend
 from pynamodb.expressions.update import (
     AddAction, DeleteAction, RemoveAction, SetAction
 )
+from pynamodb.models import Model
 
 
 _T = TypeVar('_T')
@@ -16,7 +17,7 @@ _KT = TypeVar('_KT')
 _VT = TypeVar('_VT')
 _MT = TypeVar('_MT', bound='MapAttribute')
 
-_A = TypeVar('_A')
+_A = TypeVar('_A', bound='Attribute')
 
 
 class Attribute(Generic[_T]):
@@ -154,6 +155,12 @@ class ListAttribute(Generic[_T], Attribute[List[_T]]):
     def __get__(self: _A, instance: None, owner: Any) -> _A: ...
     @overload
     def __get__(self, instance: Any, owner: Any) -> List[_T]: ...
+
+class _NullableAttributeWrapper(Generic[_A, _T]):
+    @overload
+    def __get__(self, instance: None, owner: Any) -> _A: ...
+    @overload
+    def __get__(self, instance: Model, owner: Any) -> Optional[_T]: ...
 
 DESERIALIZE_CLASS_MAP: Dict[Text, Attribute]
 SERIALIZE_CLASS_MAP: Dict[Type, Attribute]


### PR DESCRIPTION
This type will be used internally by [pynamodb-mypy](https://github.com/lyft/pynamodb-mypy) to wrap existing attributes in optionality.