### PR TITLE
Fix deserializing a None value for a JSONAttribute

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -436,6 +436,9 @@ class JSONAttribute(Attribute):
         """
         Deserializes JSON
         """
+        if value is None:
+            return None
+
         return json.loads(value, strict=False)
 
 


### PR DESCRIPTION
If another user has written a JSONAttribute from a separate language/lib: `{NULL: true}` to a table PynamoDB also queries then it will fail to deserialize the JSON value is `None` was passed in.

This adds a conditional check for None and acts accordingly for JSONAttribute