### PR TITLE
Model.query: conditions are optional

### DIFF
--- a/pynamodb/models.pyi
+++ b/pynamodb/models.pyi
@@ -48,8 +48,8 @@ class Model(metaclass=MetaModel):
     def query(
         cls: Type[_T],
         hash_key: KeyType,
-        range_key_condition: Condition = ...,
-        filter_condition: Condition = ...,
+        range_key_condition: Optional[Condition] = ...,
+        filter_condition: Optional[Condition] = ...,
         consistent_read: bool = ...,
         index_name: Optional[Text] = ...,
         scan_index_forward: Optional[Any] = ...,

--- a/pynamodb/tests/test_mypy.py
+++ b/pynamodb/tests/test_mypy.py
@@ -9,6 +9,30 @@ pytest.register_assert_rewrite('pynamodb.tests.mypy_helpers')
 from .mypy_helpers import assert_mypy_output  # noqa
 
 
+def test_model_query():
+    assert_mypy_output("""
+    from pynamodb.attributes import NumberAttribute
+    from pynamodb.models import Model
+
+    class MyModel(Model):
+        my_attr = NumberAttribute()
+
+    # test hash key types
+    MyModel.query(123)
+    MyModel.query('123')
+    MyModel.query(12.3)
+    MyModel.query(b'123')
+    MyModel.query((1, 2, 3))
+    MyModel.query({'1': '2'})  # E: Argument 1 to "query" of "Model" has incompatible type "Dict[str, str]"; expected "Union[str, bytes, float, Tuple[Any, ...]]"
+
+    # test conditions
+    MyModel.query(123, range_key_condition=(MyModel.my_attr == 5), filter_condition=(MyModel.my_attr == 5))
+
+    # test conditions are optional
+    MyModel.query(123, range_key_condition=None, filter_condition=None)
+    """)  # noqa: E501
+
+
 def test_number_attribute():
     assert_mypy_output("""
     from pynamodb.attributes import NumberAttribute


### PR DESCRIPTION
This allows constructs like:
```py
def query_with_status(key, status):
  return MyModel.query(
    hash_key=key,
    filter_condition=(MyModel.status == status) if status else None,
  )
```