### PR TITLE
requirements-dev: pin PyYAML fo Python 2.6

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ tox==2.1.1
 blinker==1.4
 flake8==2.4.1
 requests==2.7.0
+pyyaml<5  # for Python 2.6 support -- remove once we bump
 # Pinned because latest version requires Python 2.7+ (https://github.com/sphinx-doc/sphinx/issues/2919).
 sphinx==1.5.6
 sphinx-rtd-theme==0.1.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ tox==2.1.1
 blinker==1.4
 flake8==2.4.1
 requests==2.7.0
-pyyaml<5  # for Python 2.6 support -- remove once we bump
+pyyaml<5  # for Python 2.6 support -- remove once we cease Python 2.6 support
 # Pinned because latest version requires Python 2.7+ (https://github.com/sphinx-doc/sphinx/issues/2919).
 sphinx==1.5.6
 sphinx-rtd-theme==0.1.8


### PR DESCRIPTION
pyyaml 5.1 deprecated Python 2.6 support: https://pyyaml.org/wiki/PyYAML