### PR TITLE
Add a fastpath parser to UTC formatted datestrings

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -892,7 +892,7 @@ def _fast_parse_utc_datestring(datestring):
         if (datestring[4] != '-' or datestring[7] != '-' or datestring[10] != 'T' or
                 datestring[13] != ':' or datestring[16] != ':' or datestring[19] != '.' or
                 datestring[-5:] != '+0000'):
-            raise ValueError("time data '{}' does not match format "
+            raise ValueError("Datetime string '{}' does not match format "
                             "'%Y-%m-%dT%H:%M:%S.%f+0000'".format(datestring))
         return datetime(
             _int(datestring[0:4]), _int(datestring[5:7]), _int(datestring[8:10]),
@@ -900,8 +900,8 @@ def _fast_parse_utc_datestring(datestring):
             _int(round(float(datestring[19:-5]) * 1e6)), tzutc()
         )
     except (TypeError, ValueError):
-        raise ValueError("time data '{}' does not match format "
-                         "'%Y-%m-%d %H:%M:%S.%f+0000'".format(datestring))
+        raise ValueError("Datetime string '{}' does not match format "
+                         "'%Y-%m-%dT%H:%M:%S.%f+0000'".format(datestring))
 
 
 class ListAttribute(Attribute):

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -192,31 +192,27 @@ class TestUTCDateTimeAttribute:
         expected_value = datetime(2047, 1, 6, 8, 21, tzinfo=tzutc())
         assert _fast_parse_utc_datestring('2047-01-06T08:21:00.0+0000') == expected_value
 
-    def test__fast_parse_utc_datestring_invalid_input(self):
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-01-06T08:21:00.+0000')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-01-06T08:21:00.0')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-01-06 08:21:00.0+0000')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('abcd-01-06T08:21:00.0+0000')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-ab-06T08:21:00.0+0000')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-01-abT08:21:00.0+0000')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-01-06Tab:21:00.0+0000')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-01-06T08:ab:00.0+0000')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-01-06T08:21:ab.0+0000')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-01-06T08:21:00.a+0000')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-01-06T08:21:00.0.1+0000')
-        with pytest.raises(ValueError):
-            _fast_parse_utc_datestring('2047-01-06T08:21:00.0+00000')
+    @pytest.mark.parametrize(
+        "invalid_string",
+        [
+            '2.47-01-06T08:21:00.0+0000',
+            '2047-01-06T08:21:00.+0000',
+            '2047-01-06T08:21:00.0',
+            '2047-01-06 08:21:00.0+0000',
+            'abcd-01-06T08:21:00.0+0000',
+            '2047-ab-06T08:21:00.0+0000',
+            '2047-01-abT08:21:00.0+0000',
+            '2047-01-06Tab:21:00.0+0000',
+            '2047-01-06T08:ab:00.0+0000',
+            '2047-01-06T08:ab:00.0+0000',
+            '2047-01-06T08:21:00.a+0000',
+            '2047-01-06T08:21:00.0.1+0000',
+            '2047-01-06T08:21:00.0+00000'
+        ]
+    )
+    def test__fast_parse_utc_datestring_invalid_input(self, invalid_string):
+        with pytest.raises(ValueError, match="does not match format"):
+            _fast_parse_utc_datestring(invalid_string)
 
 
 

--- a/pynamodb/tests/test_attributes.py
+++ b/pynamodb/tests/test_attributes.py
@@ -17,6 +17,7 @@ from pynamodb.attributes import (
     BinarySetAttribute, BinaryAttribute, NumberSetAttribute, NumberAttribute,
     UnicodeAttribute, UnicodeSetAttribute, UTCDateTimeAttribute, BooleanAttribute, LegacyBooleanAttribute,
     MapAttribute, MapAttributeMeta, ListAttribute, JSONAttribute, _get_value_for_deserialize,
+    _fast_parse_utc_datestring,
 )
 from pynamodb.constants import (
     DATETIME_FORMAT, DEFAULT_ENCODING, NUMBER, STRING, STRING_SET, NUMBER_SET, BINARY_SET,
@@ -172,7 +173,7 @@ class TestUTCDateTimeAttribute:
         attr.deserialize(tstamp_str)
 
         parse_mock.assert_not_called()
-        datetime_mock.strptime.assert_called_once_with(tstamp_str, DATETIME_FORMAT)
+        datetime_mock.strptime.assert_not_called()
 
     def test_utc_date_time_serialize(self):
         """
@@ -181,6 +182,42 @@ class TestUTCDateTimeAttribute:
         tstamp = datetime.now()
         attr = UTCDateTimeAttribute()
         assert attr.serialize(tstamp) == tstamp.replace(tzinfo=UTC).strftime(DATETIME_FORMAT)
+
+    def test__fast_parse_utc_datestring_roundtrips(self):
+        tstamp = datetime.now(UTC)
+        tstamp_str = tstamp.strftime(DATETIME_FORMAT)
+        assert _fast_parse_utc_datestring(tstamp_str) == tstamp
+
+    def test__fast_parse_utc_datestring_no_microseconds(self):
+        expected_value = datetime(2047, 1, 6, 8, 21, tzinfo=tzutc())
+        assert _fast_parse_utc_datestring('2047-01-06T08:21:00.0+0000') == expected_value
+
+    def test__fast_parse_utc_datestring_invalid_input(self):
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-01-06T08:21:00.+0000')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-01-06T08:21:00.0')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-01-06 08:21:00.0+0000')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('abcd-01-06T08:21:00.0+0000')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-ab-06T08:21:00.0+0000')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-01-abT08:21:00.0+0000')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-01-06Tab:21:00.0+0000')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-01-06T08:ab:00.0+0000')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-01-06T08:21:ab.0+0000')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-01-06T08:21:00.a+0000')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-01-06T08:21:00.0.1+0000')
+        with pytest.raises(ValueError):
+            _fast_parse_utc_datestring('2047-01-06T08:21:00.0+00000')
+
 
 
 class TestBinaryAttribute:


### PR DESCRIPTION
This optimization speeds up parsing UTCDateTimeAttribute's written by Pynamodb (the vast majority of cases) 5x in Python 3, 38x in Python 2 (Python 2 doesn't support `%z`).

While this code is a bit of a hack, it will significantly speed up what is our long poll in deserialization.