### PR TITLE
Bypass most unnecessary botocore logic surrounding auth

### DIFF
--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -2515,6 +2515,15 @@ class ConnectionTestCase(TestCase):
         assert c.client._client_config.read_timeout == 10
         assert c.client._client_config.max_pool_connections == 20
 
+    def test_sign_request(self):
+        request = AWSRequest(method='POST', url='http://localhost:8000/', headers={}, data={'foo': 'bar'})
+        c = Connection(region='us-west-1')
+        c._sign_request(request)
+        assert 'X-Amz-Date' in request.headers
+        assert 'Authorization' in request.headers
+        assert 'us-west-1' in request.headers['Authorization']
+        assert request.headers['Authorization'].startswith('AWS4-HMAC-SHA256')
+
     @mock.patch('pynamodb.connection.Connection.client')
     def test_make_api_call___extra_headers(self, client_mock):
         good_response = mock.Mock(spec=AWSResponse, status_code=200, headers={}, text='{}', content=b'{}')

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -2522,10 +2522,10 @@ class ConnectionTestCase(TestCase):
         send_mock = client_mock._endpoint.http_session.send
         send_mock.return_value = good_response
 
-        client_mock._convert_to_request_dict.return_value = {'headers': {}}
+        client_mock._convert_to_request_dict.return_value = {'method': 'POST', 'url': '', 'headers': {}, 'body': '', 'context': {}}
 
         mock_req = mock.Mock(spec=AWSPreparedRequest, headers={})
-        create_request_mock = client_mock._endpoint.create_request
+        create_request_mock = client_mock._endpoint.prepare_request
         create_request_mock.return_value = mock_req
 
         c = Connection(extra_headers={'foo': 'bar'})


### PR DESCRIPTION
Putting this up for discussion to include in the 4.0.0 release. I poked around a little at some performance regressions that I've noticed with recent pynamodb+botocore combinations, and this seems to be mostly due to growing complexity around signing requests. In particular, liberal use of the hook system [1] adds a lot of unnecessary work to the critical path

There may be some other opportunities to optimise here, but this seems like the largest to begin with. The downside of this change is that changes to `RequestSigner` or the owning `BaseClient` in a future `botocore` release may cause breakage, however I don't think this worsens the current state much.

[1] https://github.com/boto/botocore/blob/cf8d3bb149d599eef12ce31c30b21c6fb9ad217b/botocore/hooks.py#L390