### PR TITLE
raise better error message when index does not exist

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -121,15 +121,8 @@ class MetaTable(object):
         """
         global_indexes = self.data.get(GLOBAL_SECONDARY_INDEXES)
         local_indexes = self.data.get(LOCAL_SECONDARY_INDEXES)
-        indexes = []
-        if local_indexes:
-            indexes += local_indexes
-        if global_indexes:
-            indexes += global_indexes
-        for index in indexes:
-            if index.get(INDEX_NAME) == index_name:
-                return True
-        return False
+        indexes = (global_indexes or []) + (local_indexes or [])
+        return any(index.get(INDEX_NAME) == index_name for index in indexes)
 
     def get_index_hash_keyname(self, index_name):
         """
@@ -1100,7 +1093,7 @@ class Connection(object):
             raise TableError("No such table: {}".format(table_name))
         if index_name:
             if not tbl.has_index_name(index_name):
-                raise ValueError("Table {0} has no index: {1}".format(table_name, index_name))
+                raise ValueError("Table {} has no index: {}".format(table_name, index_name))
             hash_keyname = tbl.get_index_hash_keyname(index_name)
             if not hash_keyname:
                 raise ValueError("No hash key attribute for index: {}".format(index_name))

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -115,6 +115,22 @@ class MetaTable(object):
                 key_names.append(index_range_keyname)
         return key_names
 
+    def has_index_name(self, index_name):
+        """
+        Returns True if the base table has a global or local secondary index with index_name
+        """
+        global_indexes = self.data.get(GLOBAL_SECONDARY_INDEXES)
+        local_indexes = self.data.get(LOCAL_SECONDARY_INDEXES)
+        indexes = []
+        if local_indexes:
+            indexes += local_indexes
+        if global_indexes:
+            indexes += global_indexes
+        for index in indexes:
+            if index.get(INDEX_NAME) == index_name:
+                return True
+        return False
+
     def get_index_hash_keyname(self, index_name):
         """
         Returns the name of the hash key for a given index
@@ -1083,6 +1099,8 @@ class Connection(object):
         if tbl is None:
             raise TableError("No such table: {}".format(table_name))
         if index_name:
+            if not tbl.has_index_name(index_name):
+                raise ValueError("Table {0} has no index: {1}".format(table_name, index_name))
             hash_keyname = tbl.get_index_hash_keyname(index_name)
             if not hash_keyname:
                 raise ValueError("No hash key attribute for index: {}".format(index_name))

--- a/pynamodb/tests/test_base_connection.py
+++ b/pynamodb/tests/test_base_connection.py
@@ -56,6 +56,10 @@ class MetaTableTestCase(TestCase):
         with pytest.raises(ValueError):
             self.meta_table.get_attribute_type('wrongone')
 
+    def test_has_index_name(self):
+        self.assertTrue(self.meta_table.has_index_name("LastPostIndex"))
+        self.assertFalse(self.meta_table.has_index_name("NonExistentIndexName"))
+
 
 class ConnectionTestCase(TestCase):
     """
@@ -1172,6 +1176,15 @@ class ConnectionTestCase(TestCase):
             Path('Subject').startswith('thread'),
             Path('Subject').startswith('thread'),  # filter containing range key
             return_consumed_capacity='TOTAL'
+        )
+
+        self.assertRaises(
+            ValueError,
+            conn.query,
+            table_name,
+            "FooForum",
+            limit=1,
+            index_name='NonExistentIndexName'
         )
 
         with patch(PATCH_METHOD) as req:


### PR DESCRIPTION
`Connection.query` raises `ValueError("No hash key attribute for index: {}".format(index_name))` if it cannot find the hash key name for a given index. I interpret this error as the index exists, but there is an issue with the hash key. What is really happening is either 1. the index does not exist 2. the index exists, but it does not have a hash key attribute. In case 1, we should raise an exception that is explicit about the fact the index does not exist.