### PR TITLE
Allow None to be used to bootstrap condition chaining.

### DIFF
--- a/pynamodb/expressions/condition.py
+++ b/pynamodb/expressions/condition.py
@@ -42,13 +42,6 @@ class Condition(object):
                             .format(self.__class__.__name__, other.__class__.__name__))
         return Or(self, other)
 
-    def __ror__(self, other):
-        # special case 'None | condition' to enable better syntax for chaining
-        if other is not None:
-            raise TypeError("unsupported operand type(s) for |: '{}' and '{}'"
-                            .format(other.__class__.__name__, self.__class__.__name__))
-        return self
-
     def __invert__(self):
         return Not(self)
 

--- a/pynamodb/expressions/condition.py
+++ b/pynamodb/expressions/condition.py
@@ -29,11 +29,25 @@ class Condition(object):
                             self.__class__.__name__, other.__class__.__name__)
         return And(self, other)
 
+    def __rand__(self, other):
+        # special case 'None & condition' to enable better syntax for chaining
+        if other is not None:
+            raise TypeError("unsupported operand type(s) for &: '{0}' and '{1}'",
+                            self.__class__.__name__, other.__class__.__name__)
+        return self
+
     def __or__(self, other):
         if not isinstance(other, Condition):
             raise TypeError("unsupported operand type(s) for |: '{0}' and '{1}'",
                             self.__class__.__name__, other.__class__.__name__)
         return Or(self, other)
+
+    def __ror__(self, other):
+        # special case 'None | condition' to enable better syntax for chaining
+        if other is not None:
+            raise TypeError("unsupported operand type(s) for |: '{0}' and '{1}'",
+                            self.__class__.__name__, other.__class__.__name__)
+        return self
 
     def __invert__(self):
         return Not(self)

--- a/pynamodb/expressions/condition.py
+++ b/pynamodb/expressions/condition.py
@@ -25,28 +25,28 @@ class Condition(object):
 
     def __and__(self, other):
         if not isinstance(other, Condition):
-            raise TypeError("unsupported operand type(s) for &: '{0}' and '{1}'",
-                            self.__class__.__name__, other.__class__.__name__)
+            raise TypeError("unsupported operand type(s) for &: '{0}' and '{1}'"
+                            .format(self.__class__.__name__, other.__class__.__name__))
         return And(self, other)
 
     def __rand__(self, other):
         # special case 'None & condition' to enable better syntax for chaining
         if other is not None:
-            raise TypeError("unsupported operand type(s) for &: '{0}' and '{1}'",
-                            self.__class__.__name__, other.__class__.__name__)
+            raise TypeError("unsupported operand type(s) for &: '{0}' and '{1}'"
+                            .format(other.__class__.__name__, self.__class__.__name__))
         return self
 
     def __or__(self, other):
         if not isinstance(other, Condition):
-            raise TypeError("unsupported operand type(s) for |: '{0}' and '{1}'",
-                            self.__class__.__name__, other.__class__.__name__)
+            raise TypeError("unsupported operand type(s) for |: '{0}' and '{1}'"
+                            .format(self.__class__.__name__, other.__class__.__name__))
         return Or(self, other)
 
     def __ror__(self, other):
         # special case 'None | condition' to enable better syntax for chaining
         if other is not None:
-            raise TypeError("unsupported operand type(s) for |: '{0}' and '{1}'",
-                            self.__class__.__name__, other.__class__.__name__)
+            raise TypeError("unsupported operand type(s) for |: '{0}' and '{1}'"
+                            .format(other.__class__.__name__, self.__class__.__name__))
         return self
 
     def __invert__(self):

--- a/pynamodb/expressions/condition.py
+++ b/pynamodb/expressions/condition.py
@@ -25,27 +25,27 @@ class Condition(object):
 
     def __and__(self, other):
         if not isinstance(other, Condition):
-            raise TypeError("unsupported operand type(s) for &: '{0}' and '{1}'"
+            raise TypeError("unsupported operand type(s) for &: '{}' and '{}'"
                             .format(self.__class__.__name__, other.__class__.__name__))
         return And(self, other)
 
     def __rand__(self, other):
         # special case 'None & condition' to enable better syntax for chaining
         if other is not None:
-            raise TypeError("unsupported operand type(s) for &: '{0}' and '{1}'"
+            raise TypeError("unsupported operand type(s) for &: '{}' and '{}'"
                             .format(other.__class__.__name__, self.__class__.__name__))
         return self
 
     def __or__(self, other):
         if not isinstance(other, Condition):
-            raise TypeError("unsupported operand type(s) for |: '{0}' and '{1}'"
+            raise TypeError("unsupported operand type(s) for |: '{}' and '{}'"
                             .format(self.__class__.__name__, other.__class__.__name__))
         return Or(self, other)
 
     def __ror__(self, other):
         # special case 'None | condition' to enable better syntax for chaining
         if other is not None:
-            raise TypeError("unsupported operand type(s) for |: '{0}' and '{1}'"
+            raise TypeError("unsupported operand type(s) for |: '{}' and '{}'"
                             .format(other.__class__.__name__, self.__class__.__name__))
         return self
 

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -303,20 +303,6 @@ class ConditionExpressionTestCase(TestCase):
         with self.assertRaises(TypeError):
             condition |= None
 
-    def test_ror(self):
-        condition = None
-        condition |= self.attribute < 'bar'
-        placeholder_names, expression_attribute_values = {}, {}
-        expression = condition.serialize(placeholder_names, expression_attribute_values)
-        assert expression == "#0 < :0"
-        assert placeholder_names == {'foo': '#0'}
-        assert expression_attribute_values == {':0': {'S': 'bar'}}
-
-    def test_invalid_ror(self):
-        condition = 42
-        with self.assertRaises(TypeError):
-            condition |= self.attribute < 'bar'
-
     def test_not(self):
         condition = ~(self.attribute < 'bar')
         placeholder_names, expression_attribute_values = {}, {}

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -276,7 +276,7 @@ class ConditionExpressionTestCase(TestCase):
         condition &= self.attribute < 'bar'
         placeholder_names, expression_attribute_values = {}, {}
         expression = condition.serialize(placeholder_names, expression_attribute_values)
-        assert expression == "(#0 < :0)"
+        assert expression == "#0 < :0"
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S': 'bar'}}
 
@@ -293,7 +293,7 @@ class ConditionExpressionTestCase(TestCase):
         condition |= self.attribute < 'bar'
         placeholder_names, expression_attribute_values = {}, {}
         expression = condition.serialize(placeholder_names, expression_attribute_values)
-        assert expression == "(#0 < :0)"
+        assert expression == "#0 < :0"
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S': 'bar'}}
 

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -271,6 +271,15 @@ class ConditionExpressionTestCase(TestCase):
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S': 'bar'}, ':1': {'S': 'baz'}}
 
+    def test_rand(self):
+        condition = None
+        condition &= self.attribute < 'bar'
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "(#0 < :0)"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S': 'bar'}}
+
     def test_or(self):
         condition = (self.attribute < 'bar') | (self.attribute > 'baz')
         placeholder_names, expression_attribute_values = {}, {}
@@ -278,6 +287,15 @@ class ConditionExpressionTestCase(TestCase):
         assert expression == "(#0 < :0 OR #0 > :1)"
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S': 'bar'}, ':1': {'S': 'baz'}}
+
+    def test_ror(self):
+        condition = None
+        condition |= self.attribute < 'bar'
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = condition.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "(#0 < :0)"
+        assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {':0': {'S': 'bar'}}
 
     def test_not(self):
         condition = ~(self.attribute < 'bar')

--- a/pynamodb/tests/test_expressions.py
+++ b/pynamodb/tests/test_expressions.py
@@ -271,6 +271,11 @@ class ConditionExpressionTestCase(TestCase):
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S': 'bar'}, ':1': {'S': 'baz'}}
 
+    def test_invalid_and(self):
+        condition = self.attribute < 'bar'
+        with self.assertRaises(TypeError):
+            condition &= None
+
     def test_rand(self):
         condition = None
         condition &= self.attribute < 'bar'
@@ -280,6 +285,11 @@ class ConditionExpressionTestCase(TestCase):
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S': 'bar'}}
 
+    def test_invalid_rand(self):
+        condition = 42
+        with self.assertRaises(TypeError):
+            condition &= self.attribute < 'bar'
+
     def test_or(self):
         condition = (self.attribute < 'bar') | (self.attribute > 'baz')
         placeholder_names, expression_attribute_values = {}, {}
@@ -287,6 +297,11 @@ class ConditionExpressionTestCase(TestCase):
         assert expression == "(#0 < :0 OR #0 > :1)"
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S': 'bar'}, ':1': {'S': 'baz'}}
+
+    def test_invalid_or(self):
+        condition = self.attribute < 'bar'
+        with self.assertRaises(TypeError):
+            condition |= None
 
     def test_ror(self):
         condition = None
@@ -296,6 +311,11 @@ class ConditionExpressionTestCase(TestCase):
         assert expression == "#0 < :0"
         assert placeholder_names == {'foo': '#0'}
         assert expression_attribute_values == {':0': {'S': 'bar'}}
+
+    def test_invalid_ror(self):
+        condition = 42
+        with self.assertRaises(TypeError):
+            condition |= self.attribute < 'bar'
 
     def test_not(self):
         condition = ~(self.attribute < 'bar')


### PR DESCRIPTION
This change attempts to allow users to more easily chain condition statements:
```
condition = None
if (foo):
    condition &= foo_condition
if (bar):
    condition &= bar_condition
if (baz):
    condition &= baz_condition
```