### PR TITLE
Catch IndexError when trying to fast parse a date time  string value

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -565,6 +565,8 @@ class UTCDateTimeAttribute(Attribute):
                 return datetime.strptime(value, DATETIME_FORMAT)
             except ValueError:
                 return parse(value)
+        except IndexError:
+            return parse(value)
 
 
 class NullAttribute(Attribute):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -557,7 +557,7 @@ class UTCDateTimeAttribute(Attribute):
         """
         try:
             return _fast_parse_utc_datestring(value)
-        except ValueError:
+        except (ValueError, IndexError):
             try:
                 # Attempt to parse the datetime with the datetime format used
                 # by default when storing UTCDateTimeAttributes.  This is signifantly
@@ -565,8 +565,6 @@ class UTCDateTimeAttribute(Attribute):
                 return datetime.strptime(value, DATETIME_FORMAT)
             except ValueError:
                 return parse(value)
-        except IndexError:
-            return parse(value)
 
 
 class NullAttribute(Attribute):


### PR DESCRIPTION
When creating models for a already existing database, The ```UTCDateTimeAttribute``` fails to deserialise a date in the format ```2019-07-01T00:00:00``` because it doesn't have the tzinfo, example:

```
File “.../versions/3.7.0/lib/python3.7/site-packages/pynamodb/attributes.py”, line 897, in _fast_parse_utc_datestring
   datestring[13] != ‘:’ or datestring[16] != ‘:’ or datestring[19] != ‘.’ or
IndexError: string index out of range
```

In previous versions of pynamodb it was working, so I'm proposing this fix.