### PR TITLE
parsing errors from transaction

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -1012,21 +1012,22 @@ class Connection(object):
         try:
             return self.dispatch(TRANSACT_WRITE_ITEMS, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise TransactWriteError("Failed to write transaction items", e)
+            raise TransactWriteError(transact_items=transact_items, msg="Failed to write transaction items", cause=e)
 
     def transact_get_items(self, get_items, return_consumed_capacity=None):
         """
         Performs the TransactGet operation and returns the result
         """
         operation_kwargs = self._get_transact_operation_kwargs(return_consumed_capacity=return_consumed_capacity)
-        operation_kwargs[TRANSACT_ITEMS] = [
+        transact_items = [
             {TRANSACT_GET: item} for item in get_items
         ]
+        operation_kwargs[TRANSACT_ITEMS] = transact_items
 
         try:
             return self.dispatch(TRANSACT_GET_ITEMS, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise TransactGetError("Failed to get transaction items", e)
+            raise TransactGetError(transact_items=transact_items, msg="Failed to get transaction items", cause=e)
 
     def batch_write_item(self,
                          table_name,

--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -119,7 +119,7 @@ class TransactError(PynamoDBException):
         if self.cause_response_code != 'TransactionCanceledException':
             return None
         reason_list = self._get_reason_list_from_message(self.cause_response_message)
-        return [item for item in zip(transact_items, reason_list)]
+        return list(zip(transact_items, reason_list))
 
 
 class TransactWriteError(TransactError):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,6 @@
 from botocore.exceptions import ClientError
 
-from pynamodb.exceptions import PutError
+from pynamodb.exceptions import PutError, TransactError
 
 
 def test_get_cause_response_code():
@@ -40,3 +40,44 @@ def test_get_cause_response_message__no_message():
     error = PutError()
     assert error.cause_response_message is None
 
+
+def test_transact_error__get_reason_list_from_message():
+    message = 'Transaction cancelled, please refer cancellation reasons for specific reasons [None, None, None, ConditionalCheckFailed]'
+    assert TransactError._get_reason_list_from_message(message) == ['None', 'None', 'None', 'ConditionalCheckFailed']
+
+
+def test_transact_error__get_reason_list_from_message__no_match():
+    assert TransactError._get_reason_list_from_message('nope') is None
+
+
+def test_transact_error__parse_cancel_reason():
+    error = TransactError(
+        transact_items=[{'TableName': 'toot'}, {'TableName': 'boot'}],
+        msg='TransactionCanceledException',
+        cause=ClientError(
+            error_response={
+                'Error': {
+                    'Code': 'TransactionCanceledException',
+                    'Message': 'Transaction cancelled, please refer cancellation reasons for specific reasons [None, ConditionalCheckFailed]'
+                }
+            },
+            operation_name='test'
+        )
+    )
+    assert error.cancel_reasons == [({'TableName': 'toot'}, 'None'), ({'TableName': 'boot'}, 'ConditionalCheckFailed')]
+
+
+def test_transact_error__parse_cancel_reason__not_canceled():
+    error = TransactError(
+        transact_items=[],
+        msg='NotCanceled',
+        cause=ClientError(
+            error_response={
+                'Error': {
+                    'Code': 'NotCanceled'
+                }
+            },
+            operation_name='test'
+        )
+    )
+    assert error.cancel_reasons is None


### PR DESCRIPTION
Trying to make it easier to understand which item(s) caused the transaction to be canceled. Current approach is to return list of tuples with format `({item}, 'reason')`, but may make more sense to do
```
{
    'reason1': [{}, {}],
    'reason2': [{}]
}
```
or adding a `failure_reason` key to each item in the list