### PR TITLE
Remove PROVISIONED_THROUGHPUT objects for GSIs on PAY_PER_REQUEST tables

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -591,12 +591,15 @@ class Connection(object):
         if global_secondary_indexes:
             global_secondary_indexes_list = []
             for index in global_secondary_indexes:
-                global_secondary_indexes_list.append({
+                index_kwargs = {
                     INDEX_NAME: index.get(pythonic(INDEX_NAME)),
                     KEY_SCHEMA: sorted(index.get(pythonic(KEY_SCHEMA)), key=lambda x: x.get(KEY_TYPE)),
                     PROJECTION: index.get(pythonic(PROJECTION)),
                     PROVISIONED_THROUGHPUT: index.get(pythonic(PROVISIONED_THROUGHPUT))
-                })
+                }
+                if billing_mode == PAY_PER_REQUEST_BILLING_MODE:
+                    del index_kwargs[PROVISIONED_THROUGHPUT]
+                global_secondary_indexes_list.append(index_kwargs)
             operation_kwargs[GLOBAL_SECONDARY_INDEXES] = global_secondary_indexes_list
 
         if key_schema is None:

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -868,7 +868,7 @@ class Model(AttributeContainer):
 
                 }
                 if isinstance(index, GlobalSecondaryIndex):
-                    if cls.Meta.billing_mode != PAY_PER_REQUEST_BILLING_MODE:
+                    if getattr(cls.Meta, 'billing_mode', None) != PAY_PER_REQUEST_BILLING_MODE:
                         idx[pythonic(PROVISIONED_THROUGHPUT)] = {
                             READ_CAPACITY_UNITS: index.Meta.read_capacity_units,
                             WRITE_CAPACITY_UNITS: index.Meta.write_capacity_units

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -33,7 +33,7 @@ from pynamodb.constants import (
     BATCH_WRITE_PAGE_LIMIT,
     META_CLASS_NAME, REGION, HOST, NULL,
     COUNT, ITEM_COUNT, KEY, UNPROCESSED_ITEMS, STREAM_VIEW_TYPE,
-    STREAM_SPECIFICATION, STREAM_ENABLED, BILLING_MODE
+    STREAM_SPECIFICATION, STREAM_ENABLED, BILLING_MODE, PAY_PER_REQUEST_BILLING_MODE
 )
 
 
@@ -868,10 +868,11 @@ class Model(AttributeContainer):
 
                 }
                 if isinstance(index, GlobalSecondaryIndex):
-                    idx[pythonic(PROVISIONED_THROUGHPUT)] = {
-                        READ_CAPACITY_UNITS: index.Meta.read_capacity_units,
-                        WRITE_CAPACITY_UNITS: index.Meta.write_capacity_units
-                    }
+                    if cls.Meta.billing_mode != PAY_PER_REQUEST_BILLING_MODE:
+                        idx[pythonic(PROVISIONED_THROUGHPUT)] = {
+                            READ_CAPACITY_UNITS: index.Meta.read_capacity_units,
+                            WRITE_CAPACITY_UNITS: index.Meta.write_capacity_units
+                        }
                 cls._indexes[pythonic(ATTR_DEFINITIONS)].extend(schema.get(pythonic(ATTR_DEFINITIONS)))
                 if index.Meta.projection.non_key_attributes:
                     idx[pythonic(PROJECTION)][NON_KEY_ATTRIBUTES] = index.Meta.projection.non_key_attributes


### PR DESCRIPTION
Fixes below error + makes GSIs inherit the billing mode of the parent table correctly
```
Traceback (most recent call last):
  File "test_ddb.py", line 25, in <module>
    TestModel.create_table(wait=True)
  File "/Users/ed.holland/repos/PynamoDB/pynamodb/models.py", line 732, in create_table
    **schema
  File "/Users/ed.holland/repos/PynamoDB/pynamodb/connection/table.py", line 283, in create_table
    billing_mode=billing_mode
  File "/Users/ed.holland/repos/PynamoDB/pynamodb/connection/base.py", line 631, in create_table
    raise TableError("Failed to create table: {}".format(e), e)
pynamodb.exceptions.TableError: Failed to create table: An error occurred (ValidationException) on request (78S7ALQ39N25306KJDNBE18LIBVV4KQNSO5AEMVJF66Q9ASUAAJG) on table (test_table) when calling the CreateTable operation: One or more parameter values were invalid: ProvisionedThroughput should not be specified for index: name_index when BillingMode is PAY_PER_REQUEST
```
Resolves #629 and #568 