### PR TITLE
unfloat versions to expose warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,8 @@ matrix:
 env:
   - AWS_SECRET_ACCESS_KEY=fake_key AWS_ACCESS_KEY_ID=fake_id
 
-before_install:
-  - pip install six==1.9.0
-
 install:
-  - pip install -r requirements-dev.txt
+  - pip install -e .[signals] -r requirements-dev.txt
 
 before_script:
   - wget http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz -O /tmp/dynamodb_local_latest.tar.gz
@@ -30,7 +27,7 @@ before_script:
   - sleep 2
 
 script:
-  - py.test --cov-report term-missing --cov=pynamodb tests
+  - pytest --cov-report term-missing --cov=pynamodb tests
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then mypy .; fi
 
 after_success:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,23 +1,7 @@
-# It turns out we "actually" require >=1.6.0 for folks on Python 3.6 because of:
-#
-#   https://github.com/boto/botocore/issues/1079
-#
-# This was discovered as a result of integration tests that exercised boto. However, until 4.x
-# we didn't want to bump the actual dependency of the library for consumers as it would effectively
-# be a breaking change. As a result, we use the 1.6.0 dependency for development here for the
-# purpose of integration tests, even though requirements.txt still has 1.2.0.
-botocore==1.12.54
-six==1.10.0
-coverage==4.5.3
-mock==2.0.0
-pytest==4.4.0
-pytest-cov==2.6.1
-pytest-mock==1.6.0
-python-coveralls==2.9.1
-tox==3.8.6
-blinker==1.4
-flake8==2.4.1
-pyyaml==5.1
-sphinx==1.8.5
-sphinx-rtd-theme==0.4.3
-mypy==0.710; python_version >= '3.6'
+mock
+pytest
+pytest-mock
+# only used in .travis.yml
+coveralls
+mypy==0.710;python_version>="3.7"
+pytest-cov

--- a/tests/response.py
+++ b/tests/response.py
@@ -1,10 +1,10 @@
 """
 Mock response
 """
-from requests.models import Response
+from urllib3 import HTTPResponse
 
 
-class MockResponse(Response):
+class MockResponse(HTTPResponse):
     """
     A class for mocked responses
     """
@@ -13,22 +13,6 @@ class MockResponse(Response):
         self.status_code = status_code
         self._content = content
         self.reason = 'Test Response'
-
-
-class HttpBadRequest(MockResponse):
-    """
-    A response class that returns status 400
-    """
-    def __init__(self):
-        super(HttpBadRequest, self).__init__(status_code=400)
-
-
-class HttpUnavailable(MockResponse):
-    """
-    A response that returns status code 502
-    """
-    def __init__(self):
-        super(HttpUnavailable, self).__init__(status_code=502)
 
 
 class HttpOK(MockResponse):

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
-[flake8]
-exclude = .tox,docs,build
-
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,pypy
+envlist = py27,py36,py37,pypy,pypy3
 
 [testenv]
 deps = -rrequirements-dev.txt
-; To include integration tests that require DynamoDB Local,
-; use this instead:
-;commands = py.test tests
-commands = py.test -m 'not ddblocal' tests
+extras = signals
+commands = pytest -m 'not ddblocal' tests
+
+[testenv:int]
+commands = pytest tests -m ddblocal
+
+[pytest]
+markers =
+    ddblocal: this test requires a local dynamodb


### PR DESCRIPTION
this does a couple of important things:
- upgrade `pytest` so the `imp` warning is visible
- unpin direct dependencies (this ensures testing against the latest versions possible to expose breakages as soon as possible)
- replace `requests` with `urllib3` (`botocore` doesn't use `requests` any more)