### PR TITLE
Created a new optional setting to control whether there should be an …

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -210,6 +210,8 @@ class MetaModel(AttributeContainerMeta):
                         setattr(attr_obj, 'aws_secret_access_key', None)
                     if not hasattr(attr_obj, 'aws_session_token'):
                         setattr(attr_obj, 'aws_session_token', None)
+                    if not hasattr(attr_obj, 'auto_version_condition'):
+                        setattr(attr_obj, 'auto_version_condition', get_settings_value('auto_version_condition'))
                 elif isinstance(attr_obj, Index):
                     attr_obj.Meta.model = cls
                     if not hasattr(attr_obj.Meta, "index_name"):
@@ -349,7 +351,7 @@ class Model(AttributeContainer):
         """
         args, kwargs = self._get_save_args(attributes=False, null_check=False)
         version_condition = self._handle_version_attribute(kwargs)
-        if version_condition is not None:
+        if self.Meta.auto_version_condition and version_condition is not None:
             condition &= version_condition
 
         kwargs.update(condition=condition)
@@ -367,7 +369,7 @@ class Model(AttributeContainer):
 
         args, save_kwargs = self._get_save_args(null_check=False)
         version_condition = self._handle_version_attribute(save_kwargs, actions=actions)
-        if version_condition is not None:
+        if self.Meta.auto_version_condition and version_condition is not None:
             condition &= version_condition
         kwargs = {
             pythonic(RETURN_VALUES):  ALL_NEW,
@@ -393,7 +395,7 @@ class Model(AttributeContainer):
         """
         args, kwargs = self._get_save_args()
         version_condition = self._handle_version_attribute(serialized_attributes=kwargs)
-        if version_condition is not None:
+        if self.Meta.auto_version_condition and version_condition is not None:
             condition &= version_condition
         kwargs.update(condition=condition)
         data = self._get_connection().put_item(*args, **kwargs)
@@ -427,7 +429,7 @@ class Model(AttributeContainer):
             serialized_attributes={} if is_delete else save_kwargs,
             actions=actions
         )
-        if version_condition is not None:
+        if self.Meta.auto_version_condition and version_condition is not None:
             condition &= version_condition
 
         kwargs = dict(
@@ -935,20 +937,15 @@ class Model(AttributeContainer):
 
         if version_attribute_value:
             version_condition = version_attribute == version_attribute_value
-            if actions:
-                actions.append(version_attribute.add(1))
-            elif pythonic(ATTRIBUTES) in serialized_attributes:
-                serialized_attributes[pythonic(ATTRIBUTES)][version_attribute.attr_name] = self._serialize_value(
-                    version_attribute, version_attribute_value + 1, null_check=True
-                )
         else:
             version_condition = version_attribute.does_not_exist()
-            if actions:
-                actions.append(version_attribute.set(1))
-            elif pythonic(ATTRIBUTES) in serialized_attributes:
-                serialized_attributes[pythonic(ATTRIBUTES)][version_attribute.attr_name] = self._serialize_value(
-                    version_attribute, 1, null_check=True
-                )
+
+        if actions:
+            actions.append(version_attribute.add(1))
+        elif pythonic(ATTRIBUTES) in serialized_attributes:
+            serialized_attributes[pythonic(ATTRIBUTES)][version_attribute.attr_name] = self._serialize_value(
+                version_attribute, (version_attribute_value or 0) + 1, null_check=True
+            )
 
         return version_condition
 

--- a/pynamodb/settings.py
+++ b/pynamodb/settings.py
@@ -14,6 +14,7 @@ default_settings_dict = {
     'region': 'us-east-1',
     'max_pool_connections': 10,
     'extra_headers': None,
+    'auto_version_condition': True
 }
 
 OVERRIDE_SETTINGS_PATH = getenv('PYNAMODB_CONFIG', '/etc/pynamodb/global_default_settings.py')

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3047,6 +3047,57 @@ class ModelTestCase(TestCase):
 
             deep_eq(args, params, _assert=True)
 
+    def test_model_version_attribute_save_no_auto_version_condition(self):
+        self.init_table_meta(VersionedModel, VERSIONED_TABLE_DATA)
+        old_auto_version_condition = VersionedModel.Meta.auto_version_condition
+        VersionedModel.Meta.auto_version_condition = False
+        item = VersionedModel('test_user_name', email='test_user@email.com')
+
+        with patch(PATCH_METHOD) as req:
+            req.return_value = {}
+            item.save()
+            args = req.call_args[0][1]
+            params = {
+                'Item': {
+                    'name': {
+                        'S': 'test_user_name'
+                    },
+                    'email': {
+                        'S': 'test_user@email.com'
+                    },
+                    'version': {
+                        'N': '1'
+                    },
+                },
+                'ReturnConsumedCapacity': 'TOTAL',
+                'TableName': 'VersionedModel'
+            }
+
+            deep_eq(args, params, _assert=True)
+            item.version = 1
+            item.name = "test_new_username"
+            item.save()
+            args = req.call_args[0][1]
+
+            params = {
+                'Item': {
+                    'name': {
+                        'S': 'test_new_username'
+                    },
+                    'email': {
+                        'S': 'test_user@email.com'
+                    },
+                    'version': {
+                        'N': '2'
+                    },
+                },
+                'ReturnConsumedCapacity': 'TOTAL',
+                'TableName': 'VersionedModel'
+            }
+
+            deep_eq(args, params, _assert=True)
+        VersionedModel.Meta.auto_version_condition = old_auto_version_condition
+
     def test_version_attribute_increments_on_update(self):
         self.init_table_meta(VersionedModel, VERSIONED_TABLE_DATA)
         item = VersionedModel('test_user_name', email='test_user@email.com')
@@ -3089,7 +3140,7 @@ class ModelTestCase(TestCase):
                 'ReturnConsumedCapacity': 'TOTAL',
                 'ReturnValues': 'ALL_NEW',
                 'TableName': 'VersionedModel',
-                'UpdateExpression': 'SET #1 = :0, #0 = :1'
+                'UpdateExpression': 'SET #1 = :0 ADD #0 :1'
             }
 
             deep_eq(args, params, _assert=True)


### PR DESCRIPTION
Once a model contains version attribute pynamodb automatically creates a condition constraint for all operations related to the model (e.g. update() or delete()). This default behavior requires a read operation before a write operation can take place because you need to know the current version.

I've run into a situation were such a read is technically not required as demonstrated by the following pseudo-code:

```
UserProfile(Model):
  user_id = UnicodeAttribute(hash_key=True)
  own_groups = ListAttribute()
  [..]
  version = VersionAttribute()

Group(Model):
  group_id = UnicodeAttribute(hash_key=True)
  [..]
```

If I want to create a new group for a given user I am performing a TransactWrite that contains of an update to the UserProfile-Table and a save to the Group-Table. Given the current implementation I would be forced to first perform a read of the UserProfile to obtain the current version and then include this value into the transaction. There is no benefit in doing this for the given example.

Therefore I am proposing to include a new Model.Meta- and Settings-Property that controls whether there should be a automatically generated version-condition.