### PR TITLE
Bump dev dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,11 @@
 mock
 pytest
 pytest-mock
+
+# Due to https://github.com/boto/botocore/issues/1872. Remove after botocore fixes.
+python-dateutil==2.8.0
+
 # only used in .travis.yml
 coveralls
-mypy==0.710;python_version>="3.7"
+mypy==0.740;python_version>="3.7"
 pytest-cov


### PR DESCRIPTION
This is mostly to fix the docs build, which is failing due to https://github.com/boto/botocore/issues/1872