### PR TITLE
Do not pass BillingMode: ‘PROVISIONED’ to CreateTable

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -45,6 +45,7 @@ from pynamodb.constants import (
     TRANSACT_GET, TRANSACT_PUT, TRANSACT_DELETE, TRANSACT_UPDATE, UPDATE_EXPRESSION,
     RETURN_VALUES_ON_CONDITION_FAILURE_VALUES, RETURN_VALUES_ON_CONDITION_FAILURE,
     AVAILABLE_BILLING_MODES, DEFAULT_BILLING_MODE,  BILLING_MODE, PAY_PER_REQUEST_BILLING_MODE,
+    PROVISIONED_BILLING_MODE,
     TIME_TO_LIVE_SPECIFICATION, ENABLED, UPDATE_TIME_TO_LIVE
 )
 from pynamodb.exceptions import (
@@ -588,6 +589,8 @@ class Connection(object):
             raise ValueError("incorrect value for billing_mode, available modes: {}".format(AVAILABLE_BILLING_MODES))
         if billing_mode == PAY_PER_REQUEST_BILLING_MODE:
             del operation_kwargs[PROVISIONED_THROUGHPUT]
+        elif billing_mode == PROVISIONED_BILLING_MODE:
+            del operation_kwargs[BILLING_MODE]
 
         if global_secondary_indexes:
             global_secondary_indexes_list = []

--- a/tests/test_base_connection.py
+++ b/tests/test_base_connection.py
@@ -145,7 +145,6 @@ class ConnectionTestCase(TestCase):
         ]
         params = {
             'TableName': 'ci-table',
-            'BillingMode': PROVISIONED_BILLING_MODE,
             'ProvisionedThroughput': {
                 'WriteCapacityUnits': 1,
                 'ReadCapacityUnits': 1

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -607,7 +607,6 @@ class ModelTestCase(TestCase):
                     'ReadCapacityUnits': 25, 'WriteCapacityUnits': 25
                 },
                 'TableName': 'UserModel',
-                'BillingMode': 'PROVISIONED'
             }
             actual = req.call_args_list[1][0][1]
             self.assertEqual(sorted(actual.keys()), sorted(params.keys()))

--- a/tests/test_table_connection.py
+++ b/tests/test_table_connection.py
@@ -91,7 +91,6 @@ class ConnectionTestCase(TestCase):
         ]
         params = {
             'TableName': 'ci-table',
-            'BillingMode': PROVISIONED_BILLING_MODE,
             'ProvisionedThroughput': {
                 'WriteCapacityUnits': 1,
                 'ReadCapacityUnits': 1


### PR DESCRIPTION
DynamoDB in some AZs (e.g. ap-northeast-3) does not support the BillingMode parameter (and any billing modes other than 'provisioned'). We'll avoid sending BillingMode if it is 'provisioned'.