### PR TITLE
use importlib instead of deprecated library imp

### DIFF
--- a/pynamodb/_compat.py
+++ b/pynamodb/_compat.py
@@ -7,4 +7,7 @@ else:
     from inspect import getfullargspec
     from importlib.machinery import SourceFileLoader
 
-__all__ = ('getfullargspec',)
+load_source_compat = lambda name, path: load_source(name, path) if six.PY2 else SourceFileLoader(name, path).load_module()
+
+__all__ = ('getfullargspec', 'load_source')
+

--- a/pynamodb/_compat.py
+++ b/pynamodb/_compat.py
@@ -11,9 +11,9 @@ def load_module(name, path):
     if sys.version_info >= (3, 3):
         from imp import load_source
         from importlib.machinery import SourceFileLoader
+        return SourceFileLoader(name, path).load_module()
     else: 
         from imp import load_source
         return load_source(name, path)
-    return SourceFileLoader(name, path).load_module()
 
 __all__ = ('getfullargspec', 'load_module')

--- a/pynamodb/_compat.py
+++ b/pynamodb/_compat.py
@@ -7,11 +7,10 @@ else:
     from inspect import getfullargspec
     from importlib.machinery import SourceFileLoader
 
-def load_source_compat(name, path):
-    """Load module using the Python version compatible function. """
+def load_module(name, path):
+    """Load module using the Python version compatible function."""
     if six.PY2:
         return load_source(name, path)
     return SourceFileLoader(name, path).load_module()
 
-__all__ = ('getfullargspec', 'load_source_compat')
-
+__all__ = ('getfullargspec', 'load_module')

--- a/pynamodb/_compat.py
+++ b/pynamodb/_compat.py
@@ -1,4 +1,5 @@
 import six
+import sys
 
 if six.PY2:
     from inspect import getargspec as getfullargspec

--- a/pynamodb/_compat.py
+++ b/pynamodb/_compat.py
@@ -2,7 +2,9 @@ import six
 
 if six.PY2:
     from inspect import getargspec as getfullargspec
+    from imp import load_source
 else:
     from inspect import getfullargspec
+    from importlib.machinery import SourceFileLoader
 
 __all__ = ('getfullargspec',)

--- a/pynamodb/_compat.py
+++ b/pynamodb/_compat.py
@@ -2,14 +2,16 @@ import six
 
 if six.PY2:
     from inspect import getargspec as getfullargspec
-    from imp import load_source
 else:
     from inspect import getfullargspec
-    from importlib.machinery import SourceFileLoader
 
 def load_module(name, path):
     """Load module using the Python version compatible function."""
-    if six.PY2:
+    if sys.version_info >= (3, 3):
+        from imp import load_source
+        from importlib.machinery import SourceFileLoader
+    else: 
+        from imp import load_source
         return load_source(name, path)
     return SourceFileLoader(name, path).load_module()
 

--- a/pynamodb/_compat.py
+++ b/pynamodb/_compat.py
@@ -7,7 +7,11 @@ else:
     from inspect import getfullargspec
     from importlib.machinery import SourceFileLoader
 
-load_source_compat = lambda name, path: load_source(name, path) if six.PY2 else SourceFileLoader(name, path).load_module()
+def load_source_compat(name, path):
+    """Load module using the Python version compatible function. """
+    if six.PY2:
+        return load_source(name, path)
+    return SourceFileLoader(name, path).load_module()
 
-__all__ = ('getfullargspec', 'load_source')
+__all__ = ('getfullargspec', 'load_source_compat')
 

--- a/pynamodb/settings.py
+++ b/pynamodb/settings.py
@@ -2,7 +2,7 @@ import logging
 import os
 import warnings
 from os import getenv
-from pynamodb._compat import load_source_compat
+from pynamodb._compat import load_module
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ OVERRIDE_SETTINGS_PATH = getenv('PYNAMODB_CONFIG', '/etc/pynamodb/global_default
 
 override_settings = {}
 if os.path.isfile(OVERRIDE_SETTINGS_PATH):
-    override_settings = load_source_compat('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH)
+    override_settings = load_module('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH)
     if hasattr(override_settings, 'session_cls') or hasattr(override_settings, 'request_timeout_seconds'):
         warnings.warn("The `session_cls` and `request_timeout_second` options are no longer supported")
     log.info('Override settings for pynamo available {}'.format(OVERRIDE_SETTINGS_PATH))

--- a/pynamodb/settings.py
+++ b/pynamodb/settings.py
@@ -1,8 +1,8 @@
-import imp
 import logging
 import os
 import warnings
 from os import getenv
+from importlib.machinery import SourceFileLoader
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ OVERRIDE_SETTINGS_PATH = getenv('PYNAMODB_CONFIG', '/etc/pynamodb/global_default
 
 override_settings = {}
 if os.path.isfile(OVERRIDE_SETTINGS_PATH):
-    override_settings = imp.load_source('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH)
+    override_settings = SourceFileLoader('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH).load_module()
     if hasattr(override_settings, 'session_cls') or hasattr(override_settings, 'request_timeout_seconds'):
         warnings.warn("The `session_cls` and `request_timeout_second` options are no longer supported")
     log.info('Override settings for pynamo available {}'.format(OVERRIDE_SETTINGS_PATH))

--- a/pynamodb/settings.py
+++ b/pynamodb/settings.py
@@ -20,8 +20,11 @@ OVERRIDE_SETTINGS_PATH = getenv('PYNAMODB_CONFIG', '/etc/pynamodb/global_default
 
 override_settings = {}
 if os.path.isfile(OVERRIDE_SETTINGS_PATH):
-    override_settings = load_source('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH)
-        if six.PY2 else SourceFileLoader('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH).load_module()
+    override_settings = load_source(
+            '__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH
+        ) if six.PY2 else SourceFileLoader(
+            '__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH
+        ).load_module()
     if hasattr(override_settings, 'session_cls') or hasattr(override_settings, 'request_timeout_seconds'):
         warnings.warn("The `session_cls` and `request_timeout_second` options are no longer supported")
     log.info('Override settings for pynamo available {}'.format(OVERRIDE_SETTINGS_PATH))

--- a/pynamodb/settings.py
+++ b/pynamodb/settings.py
@@ -2,7 +2,7 @@ import logging
 import os
 import warnings
 from os import getenv
-from importlib.machinery import SourceFileLoader
+import six
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +20,8 @@ OVERRIDE_SETTINGS_PATH = getenv('PYNAMODB_CONFIG', '/etc/pynamodb/global_default
 
 override_settings = {}
 if os.path.isfile(OVERRIDE_SETTINGS_PATH):
-    override_settings = SourceFileLoader('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH).load_module()
+    override_settings = load_source('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH)
+        if six.PY2 else SourceFileLoader('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH).load_module()
     if hasattr(override_settings, 'session_cls') or hasattr(override_settings, 'request_timeout_seconds'):
         warnings.warn("The `session_cls` and `request_timeout_second` options are no longer supported")
     log.info('Override settings for pynamo available {}'.format(OVERRIDE_SETTINGS_PATH))

--- a/pynamodb/settings.py
+++ b/pynamodb/settings.py
@@ -2,7 +2,7 @@ import logging
 import os
 import warnings
 from os import getenv
-import six
+from pynamodb._compat import load_source_compat
 
 log = logging.getLogger(__name__)
 
@@ -20,12 +20,7 @@ OVERRIDE_SETTINGS_PATH = getenv('PYNAMODB_CONFIG', '/etc/pynamodb/global_default
 
 override_settings = {}
 if os.path.isfile(OVERRIDE_SETTINGS_PATH):
-    print("v2", six.PY2)
-    override_settings = load_source(
-            '__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH
-        ) if six.PY2 else SourceFileLoader(
-            '__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH
-        ).load_module()
+    override_settings = load_source_compat('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH)
     if hasattr(override_settings, 'session_cls') or hasattr(override_settings, 'request_timeout_seconds'):
         warnings.warn("The `session_cls` and `request_timeout_second` options are no longer supported")
     log.info('Override settings for pynamo available {}'.format(OVERRIDE_SETTINGS_PATH))

--- a/pynamodb/settings.py
+++ b/pynamodb/settings.py
@@ -20,6 +20,7 @@ OVERRIDE_SETTINGS_PATH = getenv('PYNAMODB_CONFIG', '/etc/pynamodb/global_default
 
 override_settings = {}
 if os.path.isfile(OVERRIDE_SETTINGS_PATH):
+    print("v2", six.PY2)
     override_settings = load_source(
             '__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH
         ) if six.PY2 else SourceFileLoader(


### PR DESCRIPTION
This PR uses `importlib` rather than the deprecated module `imp` for loading modules from a path. 

The error that this PR addresses is a pytest DeprecationWarning:
`
/lib/python3.7/site-packages/pynamodb/settings.py:1: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp
`