### PR TITLE
Implement exponential backoff for batch writes

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -61,6 +61,7 @@ from pynamodb.signals import pre_dynamodb_send, post_dynamodb_send
 from pynamodb.types import HASH, RANGE
 
 BOTOCORE_EXCEPTIONS = (BotoCoreError, ClientError)
+RATE_LIMITING_EXCEPTIONS = ['ProvisionedThroughputExceededException', 'ThrottlingException']
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -442,7 +443,7 @@ class Connection(object):
                     if is_last_attempt_for_exceptions:
                         log.debug('Reached the maximum number of retry attempts: %s', attempt_number)
                         raise
-                    elif status_code < 500 and code != 'ProvisionedThroughputExceededException':
+                    elif status_code < 500 and code not in RATE_LIMITING_EXCEPTIONS:
                         # We don't retry on a ConditionalCheckFailedException or other 4xx (except for
                         # throughput related errors) because we assume they will fail in perpetuity.
                         # Retrying when there is already contention could cause other problems

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -61,7 +61,7 @@ from pynamodb.signals import pre_dynamodb_send, post_dynamodb_send
 from pynamodb.types import HASH, RANGE
 
 BOTOCORE_EXCEPTIONS = (BotoCoreError, ClientError)
-RATE_LIMITING_EXCEPTIONS = ['ProvisionedThroughputExceededException', 'ThrottlingException']
+RATE_LIMITING_ERROR_CODES = ['ProvisionedThroughputExceededException', 'ThrottlingException']
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -443,7 +443,7 @@ class Connection(object):
                     if is_last_attempt_for_exceptions:
                         log.debug('Reached the maximum number of retry attempts: %s', attempt_number)
                         raise
-                    elif status_code < 500 and code not in RATE_LIMITING_EXCEPTIONS:
+                    elif status_code < 500 and code not in RATE_LIMITING_ERROR_CODES:
                         # We don't retry on a ConditionalCheckFailedException or other 4xx (except for
                         # throughput related errors) because we assume they will fail in perpetuity.
                         # Retrying when there is already contention could cause other problems

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -2,6 +2,7 @@
 DynamoDB Models for PynamoDB
 """
 import json
+import random
 import time
 import six
 import logging
@@ -11,7 +12,7 @@ from inspect import getmembers
 from six import add_metaclass
 
 from pynamodb.expressions.condition import NotExists, Comparison
-from pynamodb.exceptions import DoesNotExist, TableDoesNotExist, TableError, InvalidStateError
+from pynamodb.exceptions import DoesNotExist, TableDoesNotExist, TableError, InvalidStateError, PutError
 from pynamodb.attributes import (
     Attribute, AttributeContainer, AttributeContainerMeta, MapAttribute, TTLAttribute, VersionAttribute
 )
@@ -52,6 +53,7 @@ class ModelContextManager(object):
         self.auto_commit = auto_commit
         self.max_operations = BATCH_WRITE_PAGE_LIMIT
         self.pending_operations = []
+        self.failed_operations = []
 
     def __enter__(self):
         return self
@@ -130,8 +132,15 @@ class BatchWrite(ModelContextManager):
         )
         if data is None:
             return
+        retries = 0
         unprocessed_items = data.get(UNPROCESSED_ITEMS, {}).get(self.model.Meta.table_name)
         while unprocessed_items:
+            sleep_time = random.randint(0, self.model.Meta.base_backoff_ms * (2 ** retries)) / 1000
+            time.sleep(sleep_time)
+            retries += 1
+            if retries >= self.model.Meta.max_retry_attempts:
+                self.failed_operations = unprocessed_items
+                raise PutError("Failed to batch write items: max_retry_attempts exceeded")
             put_items = []
             delete_items = []
             for item in unprocessed_items:
@@ -139,7 +148,8 @@ class BatchWrite(ModelContextManager):
                     put_items.append(item.get(PUT_REQUEST).get(ITEM))
                 elif DELETE_REQUEST in item:
                     delete_items.append(item.get(DELETE_REQUEST).get(KEY))
-            log.info("Resending %s unprocessed keys for batch operation", len(unprocessed_items))
+            log.info("Resending %s unprocessed keys for batch operation after %d seconds sleep",
+                     len(unprocessed_items), sleep_time)
             data = self.model._get_connection().batch_write_item(
                 put_items=put_items,
                 delete_items=delete_items

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -148,7 +148,7 @@ class BatchWrite(ModelContextManager):
                     put_items.append(item.get(PUT_REQUEST).get(ITEM))
                 elif DELETE_REQUEST in item:
                     delete_items.append(item.get(DELETE_REQUEST).get(KEY))
-            log.info("Resending %s unprocessed keys for batch operation after %d seconds sleep",
+            log.info("Resending %d unprocessed keys for batch operation after %d seconds sleep",
                      len(unprocessed_items), sleep_time)
             data = self.model._get_connection().batch_write_item(
                 put_items=put_items,


### PR DESCRIPTION
There is currently a problem with exponential backoff for batch write requests.

This is because a batch that exceeds provisioned capacity does not return an error code that can be caught in https://github.com/pynamodb/PynamoDB/blob/28b3a4589fdc00868e902864d1ab6552f782f545/pynamodb/connection/base.py#L441-L466 code block, but instead returns a success code with an object describing the failing records.

This PR introduces sleep time + a max retry limit to the existing batch write loop.
Additionally it saves the state of failed records when failing so the client can retry these records if needed. This resolves some comments in #218