### PR TITLE
ensure Model.update accounts for REMOVE expressions on in memory object

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -390,11 +390,7 @@ class Model(AttributeContainer):
         kwargs.update(actions=actions)
 
         data = self._get_connection().update_item(*args, **kwargs)
-        for name, value in data[ATTRIBUTES].items():
-            attr_name = self._dynamo_to_python_attr(name)
-            attr = self.get_attributes().get(attr_name)
-            if attr:
-                setattr(self, attr_name, attr.deserialize(attr.get_value(value)))
+        self._deserialize(data[ATTRIBUTES])
         return data
 
     def save(self, condition=None):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -837,7 +837,7 @@ class ModelTestCase(TestCase):
         """
         mock_time.side_effect = [1559692800]  # 2019-06-05 00:00:00 UTC
         self.init_table_meta(SimpleUserModel, SIMPLE_MODEL_TABLE_DATA)
-        item = SimpleUserModel('foo', is_active=True, email='foo@example.com', signature='foo')
+        item = SimpleUserModel(user_name='foo', is_active=True, email='foo@example.com', signature='foo', views=100)
 
         with patch(PATCH_METHOD) as req:
             req.return_value = {}
@@ -848,10 +848,16 @@ class ModelTestCase(TestCase):
         with patch(PATCH_METHOD) as req:
             req.return_value = {
                 ATTRIBUTES: {
+                    "user_name": {
+                        "S": "foo",
+                    },
                     "email": {
                         "S": "foo@example.com",
                     },
                     "is_active": {
+                        "NULL": None,
+                    },
+                    "signature": {
                         "NULL": None,
                     },
                     "aliases": {


### PR DESCRIPTION
If an `UpdateItem` removes an attribute on an item in the db, this update is not reflected on the in memory object after the request succeeds.

We request `RETURN_VALUES` as `ALL_NEW` during an [update](https://github.com/pynamodb/PynamoDB/blob/master/pynamodb/models.py#L383). DynamoDB will return the current state of all attributes as `Attributes` in the response.

Before this PR, we iterate over all of the returned attributes and assign them to the in memory copy of the item. This fails to account for an attribute that was removed via the `UpdateItem` request e.g.
```python
>>> item = SomeModel.get('foo')
>>> print(item.some_attribute)
'attribute_value'
>>> item.update(actions=[SomeModel.some_attribute.remove()]
>>> print(item.some_attribute)
'attribute_value'
```

In this PR, we leverage `Model._deserialize` to iterate over the model's attributes, and pull each attribute out of the response `Attributes`. We expect the above example to execute as:
```python
>>> item = SomeModel.get('foo')
>>> print(item.some_attribute)
'attribute_value'
>>> item.update(actions=[SomeModel.some_attribute.remove()]
>>> print(item.some_attribute)
None
```