### PR TITLE
Remove conditional APIs from indexes

### DIFF
--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -50,7 +50,8 @@ class Index(with_metaclass(IndexMeta)):
               range_key_condition=None,
               filter_condition=None,
               consistent_read=False,
-              **filters):
+              limit=None,
+              rate_limit=None):
         """
         Count on an index
         """
@@ -60,7 +61,8 @@ class Index(with_metaclass(IndexMeta)):
             filter_condition=filter_condition,
             index_name=cls.Meta.index_name,
             consistent_read=consistent_read,
-            **filters
+            limit=limit,
+            rate_limit=rate_limit,
         )
 
     @classmethod
@@ -68,12 +70,13 @@ class Index(with_metaclass(IndexMeta)):
               hash_key,
               range_key_condition=None,
               filter_condition=None,
-              scan_index_forward=None,
               consistent_read=False,
+              scan_index_forward=None,
               limit=None,
               last_evaluated_key=None,
               attributes_to_get=None,
-              **filters):
+              page_size=None,
+              rate_limit=None):
         """
         Queries an index
         """
@@ -81,13 +84,14 @@ class Index(with_metaclass(IndexMeta)):
             hash_key,
             range_key_condition=range_key_condition,
             filter_condition=filter_condition,
+            consistent_read=consistent_read,
             index_name=self.Meta.index_name,
             scan_index_forward=scan_index_forward,
-            consistent_read=consistent_read,
             limit=limit,
             last_evaluated_key=last_evaluated_key,
             attributes_to_get=attributes_to_get,
-            **filters
+            page_size=page_size,
+            rate_limit=rate_limit,
         )
 
     @classmethod
@@ -99,8 +103,8 @@ class Index(with_metaclass(IndexMeta)):
              last_evaluated_key=None,
              page_size=None,
              consistent_read=None,
-             attributes_to_get=None,
-             **filters):
+             rate_limit=None,
+             attributes_to_get=None):
         """
         Scans an index
         """
@@ -113,8 +117,8 @@ class Index(with_metaclass(IndexMeta)):
             page_size=page_size,
             consistent_read=consistent_read,
             index_name=self.Meta.index_name,
+            rate_limit=rate_limit,
             attributes_to_get=attributes_to_get,
-            **filters
         )
 
     @classmethod

--- a/pynamodb/indexes.pyi
+++ b/pynamodb/indexes.pyi
@@ -5,24 +5,37 @@ from pynamodb.pagination import ResultIterator
 
 _T = TypeVar('_T', bound='Index')
 
+
 class IndexMeta(type):
     def __init__(cls, name, bases, attrs) -> None: ...
+
 
 class Index(metaclass=IndexMeta):
     Meta: Any
     def __init__(self) -> None: ...
     @classmethod
-    def count(cls, hash_key, consistent_read: bool = ..., **filters) -> int: ...
+    def count(
+        cls,
+        hash_key,
+        range_key_condition: Optional[Condition] = ...,
+        filter_condition: Optional[Condition] = ...,
+        consistent_read: bool = ...,
+        limit: Optional[int] = ...,
+        rate_limit: Optional[float] = ...,
+    ) -> int: ...
     @classmethod
     def query(
         cls: Type[_T],
         hash_key,
+        range_key_condition: Optional[Condition] = ...,
+        filter_condition: Optional[Condition] = ...,
         scan_index_forward: Optional[Any] = ...,
         consistent_read: Optional[bool] = ...,
-        limit: Optional[Any] = ...,
+        limit: Optional[int] = ...,
         last_evaluated_key: Optional[Dict[Text, Dict[Text, Any]]] = ...,
         attributes_to_get: Optional[Any] = ...,
-        **filters,
+        page_size: Optional[int] = ...,
+        rate_limit: Optional[float] = ...,
     ) -> ResultIterator[_T]: ...
     @classmethod
     def scan(
@@ -34,8 +47,8 @@ class Index(metaclass=IndexMeta):
         last_evaluated_key: Optional[Dict[str, Dict[str, Any]]] = ...,
         page_size: Optional[int] = ...,
         consistent_read: Optional[bool] = ...,
+        rate_limit: Optional[float] = ...,
         attributes_to_get: Optional[List[str]] = ...,
-        **filters,
     ) -> ResultIterator[_T]: ...
 
 class GlobalSecondaryIndex(Index): ...


### PR DESCRIPTION
This was accidentally missed in https://github.com/pynamodb/PynamoDB/pull/632, but passing `**filters` would currently raise an error since the `Model` functions don't take **kwargs anymore. Also cleaned up stubs and made sure the indexes are compatible with the model function signatures