### PR TITLE
Change `KeyType` to use `Any`

### DIFF
--- a/pynamodb/models.pyi
+++ b/pynamodb/models.pyi
@@ -21,7 +21,7 @@ class MetaModel(type):
     def __init__(self, name: Text, bases: Tuple[type, ...], attrs: Dict[Any, Any]) -> None: ...
 
 _T = TypeVar('_T', bound='Model')
-KeyType = Union[Text, bytes, float, int, Tuple]
+KeyType = Any
 
 class Model(metaclass=MetaModel):
     DoesNotExist = DoesNotExist

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -29,14 +29,6 @@ def test_model_query():
     class MyModel(Model):
         my_attr = NumberAttribute()
 
-    # test hash key types
-    MyModel.query(123)
-    MyModel.query('123')
-    MyModel.query(12.3)
-    MyModel.query(b'123')
-    MyModel.query((1, 2, 3))
-    MyModel.query({'1': '2'})  # E: Argument 1 to "query" of "Model" has incompatible type "Dict[str, str]"; expected "Union[str, bytes, float, int, Tuple[Any, ...]]"
-
     # test conditions
     MyModel.query(123, range_key_condition=(MyModel.my_attr == 5), filter_condition=(MyModel.my_attr == 5))
 


### PR DESCRIPTION
This is needed to correctly type lookups for keys that use `UTCDateTimeAttribute`, and future-proof further changes