### PR TITLE
Issue #757 - fix for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
 setup(
     name='pynamodb',
     version=__import__('pynamodb').__version__,
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=('tests', 'tests.integration',)),
     url='http://jlafon.io/pynamodb.html',
     author='Jharrod LaFon',
     author_email='jlafon@eyesopen.com',


### PR DESCRIPTION
This change adds `tests.integration` to the excluded packages