### PR TITLE
Add Model.record_exists helper method

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -676,6 +676,26 @@ class Model(AttributeContainer):
         )
 
     @classmethod
+    def record_exists(cls, hash_key, range_key=None):
+        """
+        Checks if the given hash_key and optional range_key pair exists in the table.
+
+        This will return true if at least one record matching hash_key and range_key exists
+
+        :param hash_key: The hash key to look up
+        :param range_key: If set, include in lookup
+        """
+        try:
+            if range_key is None:
+                cls.query(hash_key).next()
+            else:
+                cls.query(hash_key, cls._range_key_attribute() == range_key).next()
+        except StopIteration:
+            return False
+
+        return True
+
+    @classmethod
     def exists(cls):
         """
         Returns True if this table exists, False otherwise

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -687,9 +687,9 @@ class Model(AttributeContainer):
         """
         try:
             if range_key is None:
-                cls.query(hash_key).next()
+                next(cls.query(hash_key, page_size=1))
             else:
-                cls.query(hash_key, cls._range_key_attribute() == range_key).next()
+                next(cls.query(hash_key, cls._range_key_attribute() == range_key, page_size=1))
         except StopIteration:
             return False
 

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -676,20 +676,27 @@ class Model(AttributeContainer):
         )
 
     @classmethod
-    def record_exists(cls, hash_key, range_key=None):
+    def record_exists(cls, hash_key, range_key_condition=None, range_key=None):
         """
         Checks if the given hash_key and optional range_key pair exists in the table.
 
-        This will return true if at least one record matching hash_key and range_key exists
+        This will return true if at least one record matching hash_key and range_key_condition exists.
+
+        Note: range_key (direct equality comparison) has priority over range_key_condition
 
         :param hash_key: The hash key to look up
-        :param range_key: If set, include in lookup
+        :param range_key: shortcut for a direct equality condition on the range key. This has priority over
+            range_key_condition
+        :param range_key_condition: Condition for range key
         """
         try:
-            if range_key is None:
+            if range_key_condition is None and range_key is None:
                 next(cls.query(hash_key, page_size=1))
-            else:
+            elif range_key is not None:
                 next(cls.query(hash_key, cls._range_key_attribute() == range_key, page_size=1))
+            else:
+                next(cls.query(hash_key, range_key_condition, page_size=1))
+
         except StopIteration:
             return False
 

--- a/pynamodb/models.pyi
+++ b/pynamodb/models.pyi
@@ -89,6 +89,13 @@ class Model(metaclass=MetaModel):
     ) -> ResultIterator[_T]: ...
 
     @classmethod
+    def record_exists(
+        cls: Type[_T],
+        hash_key: KeyType,
+        range_key_condition: Optional[Condition] = ...,
+        range_key: Optional[KeyType] = ...,
+    ) -> bool: ...
+    @classmethod
     def exists(cls: Type[_T]) -> bool: ...
     @classmethod
     def delete_table(cls): ...

--- a/tests/integration/model_integration_test.py
+++ b/tests/integration/model_integration_test.py
@@ -69,10 +69,12 @@ def test_model_integration(ddb_url):
 
     print("Can check key exists correctly")
     assert TestModel.record_exists('foo') is True
-    assert TestModel.record_exists('foo', range_key_condition=TestModel.thread == 'biz') is True
-    assert TestModel.record_exists('foo', range_key='biz') is True
+    assert TestModel.record_exists('foo', range_key_condition=TestModel.thread == 'bar') is True
+    assert TestModel.record_exists('foo', range_key='bar') is True
     assert TestModel.record_exists('foo', range_key_condition=TestModel.thread == 'not_real') is False
     assert TestModel.record_exists('foo', range_key='not_real') is False
+    # range_key should have priority over range_key_condition
+    assert TestModel.record_exists('foo', range_key='bar', range_key_condition=TestModel.thread == 'not_real') is True
 
     with TestModel.batch_write() as batch:
         items = [TestModel('hash-{}'.format(x), '{}'.format(x)) for x in range(10)]

--- a/tests/integration/model_integration_test.py
+++ b/tests/integration/model_integration_test.py
@@ -67,6 +67,11 @@ def test_model_integration(ddb_url):
     obj3.save()
     obj3.refresh()
 
+    print("Can check key exists correctly")
+    assert TestModel.record_exists('foo') is True
+    assert TestModel.record_exists('foo', 'bar') is True
+    assert TestModel.record_exists('foo', 'biz') is False
+
     with TestModel.batch_write() as batch:
         items = [TestModel('hash-{}'.format(x), '{}'.format(x)) for x in range(10)]
         for item in items:

--- a/tests/integration/model_integration_test.py
+++ b/tests/integration/model_integration_test.py
@@ -69,8 +69,10 @@ def test_model_integration(ddb_url):
 
     print("Can check key exists correctly")
     assert TestModel.record_exists('foo') is True
-    assert TestModel.record_exists('foo', 'bar') is True
-    assert TestModel.record_exists('foo', 'biz') is False
+    assert TestModel.record_exists('foo', range_key_condition=TestModel.thread == 'biz') is True
+    assert TestModel.record_exists('foo', range_key='biz') is True
+    assert TestModel.record_exists('foo', range_key_condition=TestModel.thread == 'not_real') is False
+    assert TestModel.record_exists('foo', range_key='not_real') is False
 
     with TestModel.batch_write() as batch:
         items = [TestModel('hash-{}'.format(x), '{}'.format(x)) for x in range(10)]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1221,7 +1221,8 @@ class ModelTestCase(TestCase):
             items.append(item)
 
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
-            self.assertTrue(UserModel.record_exists('foo', range_key="test_user_id"))
+            self.assertTrue(UserModel.record_exists('foo', range_key_condition=UserModel.user_id == 'test_user_id'))
+            self.assertTrue(UserModel.record_exists('foo', range_key='test_user_id'))
 
     def test_query_limit_greater_than_available_items_single_page(self):
         self.init_table_meta(UserModel, MODEL_TABLE_DATA)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1206,6 +1206,23 @@ class ModelTestCase(TestCase):
             deep_eq(args_one, params_one, _assert=True)
             deep_eq(args_two, params_two, _assert=True)
 
+    def test_record_exists(self):
+        self.init_table_meta(UserModel, MODEL_TABLE_DATA)
+        UserModel('foo', 'bar')
+
+        with patch(PATCH_METHOD) as req:
+            items = []
+
+            req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
+            self.assertFalse(UserModel.record_exists('foo'))
+
+            item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
+            item['user_id'] = {STRING_SHORT: "test_user_id"}
+            items.append(item)
+
+            req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
+            self.assertTrue(UserModel.record_exists('foo', range_key="test_user_id"))
+
     def test_query_limit_greater_than_available_items_single_page(self):
         self.init_table_meta(UserModel, MODEL_TABLE_DATA)
         UserModel('foo', 'bar')


### PR DESCRIPTION
I recently added this helper method in my own project and thought it may be useful upstream. In short, this adds a short form utility to check if a record exists by looking up the hash_key and optional range_key.

I'm less familiar with how the tests are set up here and attempted to add both an integration and unit test. If there is something I could do better here please let me know!
