### PR TITLE
Make (GS,LS)Index a Generic in runtime

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v4.3.2
+----------
+
+* Fix discrepancy between runtime and type-checker's perspective of Index and derived types
+
 v4.3.1
 ----------
 

--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '4.3.1'
+__version__ = '4.3.2'

--- a/pynamodb/_compat.py
+++ b/pynamodb/_compat.py
@@ -7,6 +7,12 @@ else:
     from inspect import getfullargspec
 
 
+class FakeGenericMeta(type):
+    """Poor man's Generic[T] that doesn't depend on typing. The real generics are in the type stubs."""
+    def __getitem__(self, item):
+        return self
+
+
 def load_module(name, path):
     """Load module using the Python version compatible function."""
     if sys.version_info >= (3, 3):
@@ -23,4 +29,5 @@ def load_module(name, path):
         from imp import load_source
         return load_source(name, path)
 
-__all__ = ('getfullargspec', 'load_module')
+
+__all__ = ('getfullargspec', 'FakeGenericMeta', 'load_module')

--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -41,7 +41,7 @@ class IndexMeta(type):
                         attr_obj.attr_name = attr_name
 
 
-class Index(with_metaclass(IndexMeta), _Generic[_M] if _Generic else object):
+class Index(with_metaclass(IndexMeta, *([_Generic[_M]] if _Generic else []))):
     """
     Base class for secondary indexes
     """

--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -3,6 +3,7 @@ PynamoDB Indexes
 """
 from inspect import getmembers
 
+from pynamodb._compat import FakeGenericMeta
 from pynamodb.constants import (
     INCLUDE, ALL, KEYS_ONLY, ATTR_NAME, ATTR_TYPE, KEY_TYPE, ATTR_TYPE_MAP, KEY_SCHEMA,
     ATTR_DEFINITIONS, META_CLASS_NAME
@@ -13,16 +14,7 @@ from pynamodb.connection.util import pythonic
 from six import with_metaclass
 
 
-try:
-    import typing
-    from typing import Generic as _Generic
-except ImportError:  # keep 'typing' optional
-    _Generic = None
-else:
-    _M = typing.TypeVar('_M')
-
-
-class IndexMeta(type):
+class IndexMeta(FakeGenericMeta):
     """
     Index meta class
 
@@ -41,7 +33,7 @@ class IndexMeta(type):
                         attr_obj.attr_name = attr_name
 
 
-class Index(with_metaclass(IndexMeta, *([_Generic[_M]] if _Generic else []))):
+class Index(with_metaclass(IndexMeta)):
     """
     Base class for secondary indexes
     """
@@ -178,14 +170,14 @@ class Index(with_metaclass(IndexMeta, *([_Generic[_M]] if _Generic else []))):
         return cls.Meta.attributes
 
 
-class GlobalSecondaryIndex(Index[_M] if _Generic else Index):
+class GlobalSecondaryIndex(Index):
     """
     A global secondary index
     """
     pass
 
 
-class LocalSecondaryIndex(Index[_M] if _Generic else Index):
+class LocalSecondaryIndex(Index):
     """
     A local secondary index
     """

--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -13,6 +13,15 @@ from pynamodb.connection.util import pythonic
 from six import with_metaclass
 
 
+try:
+    import typing
+    from typing import Generic as _Generic
+except ImportError:  # keep 'typing' optional
+    _Generic = None
+else:
+    _M = typing.TypeVar('_M')
+
+
 class IndexMeta(type):
     """
     Index meta class
@@ -32,7 +41,7 @@ class IndexMeta(type):
                         attr_obj.attr_name = attr_name
 
 
-class Index(with_metaclass(IndexMeta)):
+class Index(with_metaclass(IndexMeta), _Generic[_M] if _Generic else object):
     """
     Base class for secondary indexes
     """
@@ -169,14 +178,14 @@ class Index(with_metaclass(IndexMeta)):
         return cls.Meta.attributes
 
 
-class GlobalSecondaryIndex(Index):
+class GlobalSecondaryIndex(Index[_M] if _Generic else Index):
     """
     A global secondary index
     """
     pass
 
 
-class LocalSecondaryIndex(Index):
+class LocalSecondaryIndex(Index[_M] if _Generic else Index):
     """
     A local secondary index
     """


### PR DESCRIPTION
Following 5426ed9081e91316b214d6c10b447cfa1da8b0af, users found themselves having to write some rather unergonomic code to reconcile Python's and a type-checker's perspectives:
```python
if TYPE_CHECKING:
    _MyModelGSI = GlobalSecondaryIndex["MyModel"]
else:
    _MyModelGSI = GlobalSecondaryIndex

class MyModelUserIdGSI(_MyModelGSI):
    """A GSI for looking up by user ID."""
   ...

class MyModelEmailGSI(_MyModelGSI):
    """A GSI for looking up by email."""
   ...
```

This addresses it by allowing users to rewrite this as:
```python
class MyModelUserIdGSI(GlobalSecondaryIndex["MyModel"]):
    """A GSI for looking up by user ID."""
   ...

class MyModelEmailGSI(GlobalSecondaryIndex["MyModel"]):
    """A GSI for looking up by email."""
   ...
```

Since we maintain Python 2 compatibility, we cannot assume the typing module is available so we're making a mock Generic class instead.