### PR TITLE
feat(Base): Add region when scan exception occures

### DIFF
--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '4.3.2'
+__version__ = '4.3.3'

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -1182,7 +1182,7 @@ class Connection(object):
         try:
             return self.dispatch(SCAN, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            six.raise_from(ScanError("Failed to scan table: {}".format(e), e), None)
+            six.raise_from(ScanError("Failed to scan table: {} [on region {}]".format(e, self.region), e), None)
 
     def query(self,
               table_name,


### PR DESCRIPTION
Hi PynamoDB team!

First, thanks for your great work!

This PR comes after a painful debug session to catch a "table not found" issue. In the end, it turned out that the region had been change in our config file.

A few day ago, the issue occurred again, and even if this time, it took me only a few minutes to remember this issue, I thought it would be great to display the region which is currently used for scanning, and then help people catching a potential region misconfiguration, especially since the region is defaulted in `settings.py`. 

Hope you like the idea,
Thanks