### PR TITLE
update mypy tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ python-dateutil==2.8.0
 
 # only used in .travis.yml
 coveralls
-mypy==0.761;python_version>="3.7"
+mypy==0.770;python_version>="3.7"
 pytest-cov
 sphinx
 sphinx-rtd-theme

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.fixture
+def assert_mypy_output(pytestconfig):
+    pytest.importorskip('mypy')  # we only install mypy in python>=3.6 tests
+    pytest.register_assert_rewrite('tests.mypy_helpers')
+
+    from tests.mypy_helpers import assert_mypy_output
+    return lambda program: assert_mypy_output(program, use_pdb=pytestconfig.getoption('usepdb'))

--- a/tests/mypy_helpers.py
+++ b/tests/mypy_helpers.py
@@ -1,4 +1,6 @@
+import os
 import re
+import shutil
 import sys
 from collections import defaultdict
 from tempfile import TemporaryDirectory
@@ -6,43 +8,57 @@ from textwrap import dedent
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Tuple
 
-import mypy.api
 
+def _run_mypy(program: str, *, use_pdb: bool) -> Iterable[str]:
+    import mypy.api
 
-def _run_mypy(program: str) -> Iterable[str]:
     with TemporaryDirectory() as tempdirname:
-        with open(f'{tempdirname}/__main__.py', 'w') as f:
+        with open('{}/__main__.py'.format(tempdirname), 'w') as f:
             f.write(program)
-        error_pattern = re.compile(fr'^{re.escape(f.name)}:(\d+): (?:error|note): (.*)$')
-        stdout, stderr, exit_status = mypy.api.run([
+        error_pattern = re.compile(fr'^{re.escape(f.name)}:'
+                                   r'(?P<line>\d+): (?P<level>note|warning|error): (?P<message>.*)$')
+        mypy_args = [
             f.name,
             '--show-traceback',
-        ])
+            '--raise-exceptions',
+            '--show-error-codes',
+        ]
+        src_config_file_path = os.path.dirname(__file__) + '/mypy.ini'
+        if os.path.exists(src_config_file_path):
+            dest_config_file_path = tempdirname + '/mypy.ini'
+            shutil.copyfile(src_config_file_path, dest_config_file_path)
+            mypy_args += ['--config-file', dest_config_file_path]
+        if use_pdb:
+            mypy_args += ['--pdb']
+        stdout, stderr, exit_status = mypy.api.run(mypy_args)
         if stderr:
             print(stderr, file=sys.stderr)  # allow "printf debugging" of the plugin
 
         # Group errors by line
-        errors_by_line: Dict[int, List[str]] = defaultdict(list)
+        messages_by_line: Dict[int, List[Tuple[str, str]]] = defaultdict(list)
         for line in stdout.split('\n'):
             m = error_pattern.match(line)
             if m:
-                errors_by_line[int(m.group(1))].append(m.group(2))
+                messages_by_line[int(m.group('line'))].append((m.group('level'), m.group('message')))
             elif line:
-                print('x', repr(line))  # allow "printf debugging" of the plugin
+                # print(line)  # allow "printf debugging"
+                pass
 
         # Reconstruct the "actual" program with "error" comments
-        error_comment_pattern = re.compile(r'(\s+# E: .*)?$')
+        error_comment_pattern = re.compile(r'(\s+# (N|W|E): .*)?$')
         for line_no, line in enumerate(program.split('\n'), start=1):
             line = error_comment_pattern.sub('', line)
-            errors = errors_by_line.get(line_no)
-            if errors:
-                yield line + ''.join(f'  # E: {error}' for error in errors)
+            messages = messages_by_line.get(line_no)
+            if messages:
+                messages_str = ''.join(f'  # {level[0].upper()}: {message}' for level, message in messages)
+                yield f'{line}{messages_str}'
             else:
                 yield line
 
 
-def assert_mypy_output(program: str) -> None:
-    program = dedent(program).strip()
-    actual = '\n'.join(_run_mypy(program))
-    assert actual == program
+def assert_mypy_output(program: str, *, use_pdb: bool) -> None:
+    expected = dedent(program).strip()
+    actual = '\n'.join(_run_mypy(expected, use_pdb=use_pdb))
+    assert actual == expected

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -2,14 +2,9 @@
 Note: The expected error strings may change in a future version of mypy.
       Please update as needed.
 """
-import pytest
-
-pytest.importorskip('mypy')  # we only install mypy in python>=3.6 tests
-pytest.register_assert_rewrite('tests.mypy_helpers')
-from .mypy_helpers import assert_mypy_output  # noqa
 
 
-def test_model():
+def test_model(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.models import Model
     from pynamodb.expressions.operand import Path
@@ -17,11 +12,11 @@ def test_model():
     class MyModel(Model):
         pass
 
-    reveal_type(MyModel.count('hash', Path('a').between(1, 3)))  # E: Revealed type is 'builtins.int'
+    reveal_type(MyModel.count('hash', Path('a').between(1, 3)))  # N: Revealed type is 'builtins.int'
     """)
 
 
-def test_model_query():
+def test_model_query(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.attributes import NumberAttribute
     from pynamodb.models import Model
@@ -37,7 +32,7 @@ def test_model_query():
     """)
 
 
-def test_pagination():
+def test_pagination(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.attributes import NumberAttribute
     from pynamodb.models import Model
@@ -47,13 +42,13 @@ def test_pagination():
 
     result_iterator = MyModel.query(123)
     for model in result_iterator:
-        reveal_type(model)  # E: Revealed type is '__main__.MyModel*'
+        reveal_type(model)  # N: Revealed type is '__main__.MyModel*'
     if result_iterator.last_evaluated_key:
-        reveal_type(result_iterator.last_evaluated_key['my_attr'])  # E: Revealed type is 'builtins.dict*[builtins.str, Any]'
+        reveal_type(result_iterator.last_evaluated_key['my_attr'])  # N: Revealed type is 'builtins.dict*[builtins.str, Any]'
     """)
 
 
-def test_model_update():
+def test_model_update(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.attributes import NumberAttribute
     from pynamodb.models import Model
@@ -73,7 +68,7 @@ def test_model_update():
     """)  # noqa: E501
 
 
-def test_number_attribute():
+def test_number_attribute(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.attributes import NumberAttribute
     from pynamodb.models import Model
@@ -81,12 +76,12 @@ def test_number_attribute():
     class MyModel(Model):
         my_attr = NumberAttribute()
 
-    reveal_type(MyModel.my_attr)  # E: Revealed type is 'pynamodb.attributes.NumberAttribute*'
-    reveal_type(MyModel().my_attr)  # E: Revealed type is 'builtins.float'
+    reveal_type(MyModel.my_attr)  # N: Revealed type is 'pynamodb.attributes.NumberAttribute*'
+    reveal_type(MyModel().my_attr)  # N: Revealed type is 'builtins.float'
     """)
 
 
-def test_unicode_attribute():
+def test_unicode_attribute(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.attributes import UnicodeAttribute
     from pynamodb.models import Model
@@ -94,12 +89,12 @@ def test_unicode_attribute():
     class MyModel(Model):
         my_attr = UnicodeAttribute()
 
-    reveal_type(MyModel.my_attr)  # E: Revealed type is 'pynamodb.attributes.UnicodeAttribute*'
-    reveal_type(MyModel().my_attr)  # E: Revealed type is 'builtins.str'
+    reveal_type(MyModel.my_attr)  # N: Revealed type is 'pynamodb.attributes.UnicodeAttribute*'
+    reveal_type(MyModel().my_attr)  # N: Revealed type is 'builtins.str'
     """)
 
 
-def test_map_attribute():
+def test_map_attribute(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.attributes import MapAttribute, UnicodeAttribute
     from pynamodb.models import Model
@@ -113,22 +108,22 @@ def test_map_attribute():
     class MyModel(Model):
         m1 = MyMap()
 
-    reveal_type(MyModel.m1)  # E: Revealed type is '__main__.MyMap'
-    reveal_type(MyModel().m1)  # E: Revealed type is '__main__.MyMap'
-    reveal_type(MyModel.m1.m2)  # E: Revealed type is '__main__.MySubMap'
-    reveal_type(MyModel().m1.m2)  # E: Revealed type is '__main__.MySubMap'
-    reveal_type(MyModel.m1.m2.s)  # E: Revealed type is 'builtins.str'
-    reveal_type(MyModel().m1.m2.s)  # E: Revealed type is 'builtins.str'
+    reveal_type(MyModel.m1)  # N: Revealed type is '__main__.MyMap'
+    reveal_type(MyModel().m1)  # N: Revealed type is '__main__.MyMap'
+    reveal_type(MyModel.m1.m2)  # N: Revealed type is '__main__.MySubMap'
+    reveal_type(MyModel().m1.m2)  # N: Revealed type is '__main__.MySubMap'
+    reveal_type(MyModel.m1.m2.s)  # N: Revealed type is 'builtins.str'
+    reveal_type(MyModel().m1.m2.s)  # N: Revealed type is 'builtins.str'
 
-    reveal_type(MyMap.m2)  # E: Revealed type is '__main__.MySubMap'
-    reveal_type(MyMap().m2)  # E: Revealed type is '__main__.MySubMap'
+    reveal_type(MyMap.m2)  # N: Revealed type is '__main__.MySubMap'
+    reveal_type(MyMap().m2)  # N: Revealed type is '__main__.MySubMap'
 
-    reveal_type(MySubMap.s)  # E: Revealed type is 'pynamodb.attributes.UnicodeAttribute*'
-    reveal_type(MySubMap().s)  # E: Revealed type is 'builtins.str'
+    reveal_type(MySubMap.s)  # N: Revealed type is 'pynamodb.attributes.UnicodeAttribute*'
+    reveal_type(MySubMap().s)  # N: Revealed type is 'builtins.str'
     """)
 
 
-def test_list_attribute():
+def test_list_attribute(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.attributes import ListAttribute, MapAttribute, UnicodeAttribute
     from pynamodb.models import Model
@@ -138,18 +133,18 @@ def test_list_attribute():
 
     class MyModel(Model):
         my_list = ListAttribute(of=MyMap)
-        my_untyped_list = ListAttribute()  # E: Need type annotation for 'my_untyped_list'
+        my_untyped_list = ListAttribute()  # E: Need type annotation for 'my_untyped_list'  [var-annotated]
 
-    reveal_type(MyModel.my_list)  # E: Revealed type is 'pynamodb.attributes.ListAttribute[__main__.MyMap]'
-    reveal_type(MyModel().my_list)  # E: Revealed type is 'builtins.list[__main__.MyMap*]'
-    reveal_type(MyModel().my_list[0].my_sub_attr)  # E: Revealed type is 'builtins.str'
+    reveal_type(MyModel.my_list)  # N: Revealed type is 'pynamodb.attributes.ListAttribute[__main__.MyMap]'
+    reveal_type(MyModel().my_list)  # N: Revealed type is 'builtins.list[__main__.MyMap*]'
+    reveal_type(MyModel().my_list[0].my_sub_attr)  # N: Revealed type is 'builtins.str'
 
     # Untyped lists are not well supported yet
-    reveal_type(MyModel().my_untyped_list[0].my_sub_attr)  # E: Revealed type is 'Any'
+    reveal_type(MyModel().my_untyped_list[0].my_sub_attr)  # N: Revealed type is 'Any'
     """)
 
 
-def test_paths():
+def test_paths(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.attributes import ListAttribute, MapAttribute, UnicodeAttribute
     from pynamodb.models import Model
@@ -161,14 +156,14 @@ def test_paths():
         my_list = ListAttribute(of=MyMap)
         my_map = MyMap()
 
-    reveal_type(MyModel.my_list[0])  # E: Revealed type is 'pynamodb.expressions.operand.Path'
-    reveal_type(MyModel.my_list[0] == MyModel())  # E: Revealed type is 'pynamodb.expressions.condition.Comparison'
+    reveal_type(MyModel.my_list[0])  # N: Revealed type is 'pynamodb.expressions.operand.Path'
+    reveal_type(MyModel.my_list[0] == MyModel())  # N: Revealed type is 'pynamodb.expressions.condition.Comparison'
     # the following string indexing is not type checked - not by mypy nor in runtime
-    reveal_type(MyModel.my_list[0]['my_sub_attr'] == 'foobar')  # E: Revealed type is 'pynamodb.expressions.condition.Comparison'
+    reveal_type(MyModel.my_list[0]['my_sub_attr'] == 'foobar')  # N: Revealed type is 'pynamodb.expressions.condition.Comparison'
     """)
 
 
-def test_index_query_scan():
+def test_index_query_scan(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.attributes import NumberAttribute
     from pynamodb.models import Model
@@ -196,7 +191,7 @@ def test_index_query_scan():
     # Allow users to specify which model their indices return
     typed_result: ResultIterator[MyModel] = MyModel.typed_index.query(123)
     my_model = next(typed_result)
-    not_model = next(typed_result)  # E: Incompatible types in assignment (expression has type "MyModel", variable has type "int")
+    not_model = next(typed_result)  # E: Incompatible types in assignment (expression has type "MyModel", variable has type "int")  [assignment]
 
     # Ensure old code keeps working
     untyped_result = MyModel.untyped_index.scan()
@@ -206,5 +201,5 @@ def test_index_query_scan():
     # Allow users to specify which model their indices return
     untyped_result = MyModel.typed_index.scan()
     model = next(untyped_result)
-    not_model = next(untyped_result)  # E: Incompatible types in assignment (expression has type "MyModel", variable has type "int")
+    not_model = next(untyped_result)  # E: Incompatible types in assignment (expression has type "MyModel", variable has type "int")  [assignment]
     """)


### PR DESCRIPTION
- improved mypy-testing integration:
  (a) mypy crashes and failed assertions now result in a stack trace
  (b) `pytest --pdb` now propagates to `mypy --pdb`
  (c) turning on type error codes for even more fidelity

- 'reveal_type' now results in NOTICE-level messages so updating tests accordingly 

- turned on type error codes, updated tests accordingly

- `assert_mypy_output` is now available (and used) as a fixture so it could rely on the `pytestconfig` fixture to get pytest config state