### PR TITLE
Improve error handling for invalid range key conditions

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -7,6 +7,7 @@ import random
 import sys
 import time
 import uuid
+import warnings
 from base64 import b64decode
 from threading import local
 from typing import Any, Dict, List, Mapping, Optional, Sequence
@@ -40,9 +41,9 @@ from pynamodb.constants import (
     TRANSACT_WRITE_ITEMS, TRANSACT_GET_ITEMS, CLIENT_REQUEST_TOKEN, TRANSACT_ITEMS, TRANSACT_CONDITION_CHECK,
     TRANSACT_GET, TRANSACT_PUT, TRANSACT_DELETE, TRANSACT_UPDATE, UPDATE_EXPRESSION,
     RETURN_VALUES_ON_CONDITION_FAILURE_VALUES, RETURN_VALUES_ON_CONDITION_FAILURE,
-    AVAILABLE_BILLING_MODES, DEFAULT_BILLING_MODE,  BILLING_MODE, PAY_PER_REQUEST_BILLING_MODE,
+    AVAILABLE_BILLING_MODES, DEFAULT_BILLING_MODE, BILLING_MODE, PAY_PER_REQUEST_BILLING_MODE,
     PROVISIONED_BILLING_MODE,
-    TIME_TO_LIVE_SPECIFICATION, ENABLED, UPDATE_TIME_TO_LIVE
+    TIME_TO_LIVE_SPECIFICATION, ENABLED, UPDATE_TIME_TO_LIVE, BETWEEN
 )
 from pynamodb.exceptions import (
     TableError, QueryError, PutError, DeleteError, UpdateError, GetError, ScanError, TableDoesNotExist,
@@ -1278,13 +1279,22 @@ class Connection(object):
         key_condition = getattr(Path([hash_keyname]), '__eq__')(hash_condition_value)
 
         if range_key_condition is not None:
-            if range_key_condition.is_valid_range_key_condition(range_keyname):
-                key_condition = key_condition & range_key_condition
+            if str(range_key_condition.values[0]) == range_keyname:
+                # http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-KeyConditionExpression
+                if range_key_condition.operator in ['=', '<', '<=', '>', '>=', BETWEEN, 'begins_with']:
+                    key_condition &= range_key_condition
+                else:
+                    raise ValueError(f'Invalid range key condition "{range_key_condition}": '
+                                     f'operator "{range_key_condition.operator}" is not supported for range key conditions')
             elif filter_condition is None:
                 # Try to gracefully handle the case where a user passed in a filter as a range key condition
+                warnings.warn(f'Using range key condition "{range_key_condition}" as a filter condition '
+                              f'since it does not operate on the range key "{range_keyname}"; '
+                              'fix query to use "filter_condition"')
                 (filter_condition, range_key_condition) = (range_key_condition, None)
             else:
-                raise ValueError("{} is not a valid range key condition".format(range_key_condition))
+                raise ValueError(f'Invalid range key condition "{range_key_condition}": '
+                                 f'operand is "{range_key_condition.values[0]}"; expected "{range_keyname}"')
 
         operation_kwargs[KEY_CONDITION_EXPRESSION] = key_condition.serialize(
             name_placeholders, expression_attribute_values)

--- a/pynamodb/expressions/condition.py
+++ b/pynamodb/expressions/condition.py
@@ -14,10 +14,6 @@ class Condition(object):
         self.operator = operator
         self.values = values
 
-    # http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-KeyConditionExpression
-    def is_valid_range_key_condition(self, path):
-        return self.operator in ['=', '<', '<=', '>', '>=', BETWEEN, 'begins_with'] and str(self.values[0]) == path
-
     def serialize(self, placeholder_names, expression_attribute_values):
         values = [value.serialize(placeholder_names, expression_attribute_values) for value in self.values]
         return self.format_string.format(*values, operator=self.operator)


### PR DESCRIPTION
For a condition to be a valid range key condition, it must:
1. operate on the range key
2. use one of the supported operators

Filter conditions cannot use range key attributes, so a condition whose only problem is an unsupported operator cannot be "demoted" to be a filter condition: we'd simply fail a few statements later with:
```
raise ValueError("'filter_condition' cannot contain key attributes")
```
Moreover, that message would've caught the user by suprirse, since the user passed it as a `range_key_condition`.

Changes:
1. The error messages now indicates the reason for the condition being invalid.
2. We only demote to a filter condition when permissible.
3. We now issue a warning in this case. Key conditions have different cost and this demotion could be harmful. We should consider deprecating it.
4. Removing the `Condition.is_valid_range_key_condition` method. It probably never served any purpose except to be used in this code, and I think it's a good candidate for deprecation in pynamodb 5.x.