### PR TITLE
Add the ability to abort transactions

### DIFF
--- a/pynamodb/transactions.py
+++ b/pynamodb/transactions.py
@@ -18,15 +18,22 @@ class Transaction:
     def __init__(self, connection: Connection, return_consumed_capacity: Optional[str] = None) -> None:
         self._connection = connection
         self._return_consumed_capacity = return_consumed_capacity
+        self._aborted = False
 
     def _commit(self):
         raise NotImplementedError()
+
+    def abort(self):
+        """
+        Cancels the current transaction.
+        """
+        self._aborted = True
 
     def __enter__(self) -> 'Transaction':
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is None and exc_val is None and exc_tb is None:
+        if (not self._aborted) and exc_type is None and exc_val is None and exc_tb is None:
             self._commit()
 
 

--- a/pynamodb/transactions.py
+++ b/pynamodb/transactions.py
@@ -25,7 +25,7 @@ class Transaction:
 
     def abort(self):
         """
-        Cancels the current transaction.
+        Aborts the current transaction.
         """
         self._aborted = True
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=4.6
 pytest-env
 pytest-mock
 


### PR DESCRIPTION
Currently when we want to abort a transaction, we raise an exception that we catch immediately outside of the transaction context:
```
try:
  with TransactWrite(...) as txn:
    if should_skip_txn():
      raise TransactionAbort()
except TransactionAbort:
  pass
```
instead, adding an `abort` method makes this clearer:
```
with TransactWrite(...) as txn:
  if should_skip_txn():
    txn.abort()
```
  