### PR TITLE
require pytest>=5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=5
 pytest-env
 pytest-mock
 


### PR DESCRIPTION
travis-ci's venv seems to come with pytest installed (?!) which causes a newer version not to be installed, and pytest-cov recently bumped their min pytest version.