### PR TITLE
Fix re-use of indexes and refresh method on null attributes

### DIFF
--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -55,9 +55,8 @@ class Index(Generic[_M], metaclass=IndexMeta):
         if not hasattr(self.Meta, "projection"):
             raise ValueError("No projection defined, define a projection for this class")
 
-    @classmethod
     def count(
-        cls,
+        self,
         hash_key: _KeyType,
         range_key_condition: Optional[Condition] = None,
         filter_condition: Optional[Condition] = None,
@@ -68,11 +67,11 @@ class Index(Generic[_M], metaclass=IndexMeta):
         """
         Count on an index
         """
-        return cls.Meta.model.count(
+        return self._model.count(
             hash_key,
             range_key_condition=range_key_condition,
             filter_condition=filter_condition,
-            index_name=cls.Meta.index_name,
+            index_name=self.Meta.index_name,
             consistent_read=consistent_read,
             limit=limit,
             rate_limit=rate_limit,

--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -78,9 +78,8 @@ class Index(Generic[_M], metaclass=IndexMeta):
             rate_limit=rate_limit,
         )
 
-    @classmethod
     def query(
-        cls,
+        self,
         hash_key: _KeyType,
         range_key_condition: Optional[Condition] = None,
         filter_condition: Optional[Condition] = None,
@@ -95,12 +94,12 @@ class Index(Generic[_M], metaclass=IndexMeta):
         """
         Queries an index
         """
-        return cls.Meta.model.query(
+        return self._model.query(
             hash_key,
             range_key_condition=range_key_condition,
             filter_condition=filter_condition,
             consistent_read=consistent_read,
-            index_name=cls.Meta.index_name,
+            index_name=self.Meta.index_name,
             scan_index_forward=scan_index_forward,
             limit=limit,
             last_evaluated_key=last_evaluated_key,
@@ -109,9 +108,8 @@ class Index(Generic[_M], metaclass=IndexMeta):
             rate_limit=rate_limit,
         )
 
-    @classmethod
     def scan(
-        cls,
+        self,
         filter_condition: Optional[Condition] = None,
         segment: Optional[int] = None,
         total_segments: Optional[int] = None,
@@ -125,7 +123,7 @@ class Index(Generic[_M], metaclass=IndexMeta):
         """
         Scans an index
         """
-        return cls.Meta.model.scan(
+        return self._model.scan(
             filter_condition=filter_condition,
             segment=segment,
             total_segments=total_segments,
@@ -133,7 +131,7 @@ class Index(Generic[_M], metaclass=IndexMeta):
             last_evaluated_key=last_evaluated_key,
             page_size=page_size,
             consistent_read=consistent_read,
-            index_name=cls.Meta.index_name,
+            index_name=self.Meta.index_name,
             rate_limit=rate_limit,
             attributes_to_get=attributes_to_get,
         )

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -243,7 +243,7 @@ class MetaModel(AttributeContainerMeta):
                     if not hasattr(attr_obj, 'aws_session_token'):
                         setattr(attr_obj, 'aws_session_token', None)
                 elif isinstance(attr_obj, Index):
-                    attr_obj.Meta.model = cls
+                    attr_obj._model = cls
                     if not hasattr(attr_obj.Meta, "index_name"):
                         attr_obj.Meta.index_name = attr_name
                 elif isinstance(attr_obj, Attribute):

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -452,7 +452,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
         :param consistent_read: If True, then a consistent read is performed.
         :raises ModelInstance.DoesNotExist: if the object to be updated does not exist
         """
-        args, kwargs = self._get_save_args(attributes=False)
+        args, kwargs = self._get_save_args(attributes=False, null_check=False)
         kwargs.setdefault('consistent_read', consistent_read)
         attrs = self._get_connection().get_item(*args, **kwargs)
         item_data = attrs.get(ITEM, None)


### PR DESCRIPTION
I'd like to contribute a fix for what I think is a bug (but may be intended design) for re-use of indexes. If you define an index class and use it in two different models, the object returned will always be the object type of the last-bound model. This is due to the fact that `.model` is being bound to the `Meta` class of the index, and not an instance of the class. To solve this, I bind the model to the instance of the index and change the methods to be bound to the index instance rather than class.

Also, there's a fix in here for calling `Object.refresh()`, where if the object has a null value for a non-nullable field, it won't ever refresh, even though the DB may have fresh data.

I wasn't able to figure out how to run integration tests (seems to be hitting a DynamoDB AWS table) or signal tests, but the model tests pass.

Comments welcome! Thanks.