### PR TITLE
More context in exception on attr deserialization failure

### DIFF
--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -122,7 +122,7 @@ class AttributeDeserializationError(TypeError):
     """
     Raised when attribute type is invalid
     """
-    def __init__(self, attr_name: Optional[str]):
+    def __init__(self, attr_name: str):
         msg = "Deserialization error on `{}`".format(attr_name)
         super(AttributeDeserializationError, self).__init__(msg)
 

--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -118,6 +118,15 @@ class InvalidStateError(PynamoDBException):
     msg = "Operation in invalid state"
 
 
+class AttributeDeserializationError(TypeError):
+    """
+    Raised when attribute type is invalid
+    """
+    def __init__(self, attr_name: str):
+        msg = "Deserialization error on `{}`".format(attr_name)
+        super(AttributeDeserializationError, self).__init__(msg)
+
+
 class VerboseClientError(botocore.exceptions.ClientError):
     def __init__(self, error_response: Any, operation_name: str, verbose_properties: Optional[Any] = None):
         """ Modify the message template to include the desired verbose properties """

--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -122,7 +122,7 @@ class AttributeDeserializationError(TypeError):
     """
     Raised when attribute type is invalid
     """
-    def __init__(self, attr_name: str):
+    def __init__(self, attr_name: Optional[str]):
         msg = "Deserialization error on `{}`".format(attr_name)
         super(AttributeDeserializationError, self).__init__(msg)
 

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -553,8 +553,8 @@ class Model(AttributeContainer, metaclass=MetaModel):
             if attr:
                 try:
                     attributes[attr_name] = attr.deserialize(attr.get_value(value))  # type: ignore
-                except TypeError:
-                    raise TypeError(f'attribute: {attr_name}')
+                except TypeError as e:
+                    raise ValueError(f'attribute: {attr_name}') from e
         return cls(_user_instantiated=False, **attributes)
 
     @classmethod

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Generic, Iterable, Iterator, List, Optional, Seque
     Tuple, Union, cast
 
 from pynamodb.expressions.update import Action
-from pynamodb.exceptions import DoesNotExist, TableDoesNotExist, TableError, InvalidStateError, PutError
+from pynamodb.exceptions import DoesNotExist, TableDoesNotExist, TableError, InvalidStateError, PutError, AttributeDeserializationError
 from pynamodb.attributes import (
     Attribute, AttributeContainer, AttributeContainerMeta, MapAttribute, TTLAttribute, VersionAttribute
 )
@@ -554,7 +554,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
                 try:
                     attributes[attr_name] = attr.deserialize(attr.get_value(value))  # type: ignore
                 except TypeError as e:
-                    raise ValueError(f'attribute: {attr_name}') from e
+                    raise AttributeDeserializationError(attr_name=attr_name) from e
         return cls(_user_instantiated=False, **attributes)
 
     @classmethod

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -554,7 +554,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
                 try:
                     attributes[attr_name] = attr.deserialize(attr.get_value(value))  # type: ignore
                 except TypeError as e:
-                    raise AttributeDeserializationError(attr_name=attr_name) from e
+                    raise AttributeDeserializationError(attr_name=attr_name) from e  # type: ignore
         return cls(_user_instantiated=False, **attributes)
 
     @classmethod

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -551,7 +551,10 @@ class Model(AttributeContainer, metaclass=MetaModel):
             attr_name = cls._dynamo_to_python_attr(name)
             attr = cls.get_attributes().get(attr_name, None)  # type: ignore
             if attr:
-                attributes[attr_name] = attr.deserialize(attr.get_value(value))  # type: ignore
+                try:
+                    attributes[attr_name] = attr.deserialize(attr.get_value(value))  # type: ignore
+                except TypeError:
+                    raise TypeError(f'attribute: {attr_name}')
         return cls(_user_instantiated=False, **attributes)
 
     @classmethod

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,7 +14,7 @@ from dateutil.tz import tzutc
 
 from .deep_eq import deep_eq
 from pynamodb.util import snake_to_camel_case
-from pynamodb.exceptions import DoesNotExist, TableError, PutError
+from pynamodb.exceptions import DoesNotExist, TableError, PutError, AttributeDeserializationError
 from pynamodb.types import RANGE
 from pynamodb.constants import (
     ITEM, STRING_SHORT, ALL, KEYS_ONLY, INCLUDE, REQUEST_ITEMS, UNPROCESSED_KEYS, CAMEL_COUNT,
@@ -3301,6 +3301,9 @@ class ModelInitTestCase(TestCase):
             req.return_value = SIMPLE_MODEL_TABLE_DATA
             m = TTLModel.from_raw_data({'user_name': {'S': 'mock'}, 'my_ttl': {'N': '1546300800'}})
         assert m.my_ttl == datetime(2019, 1, 1, tzinfo=tzutc())
+
+    def test_deserialized_with_invalid_type(self):
+        self.assertRaises(AttributeDeserializationError, TTLModel.from_raw_data, {'my_ttl': {'S': '1546300800'}})
 
     def test_multiple_version_attributes(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
When deserialization error occurs in `from_raw_data`, it's unclear which attribute it is failing on. Add attribute name in exception