### PR TITLE
Only add custom attribute names to the mapping.

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -237,10 +237,10 @@ class AttributeContainerMeta(GenericMeta):
                 initialized = attribute._make_attribute()
 
             cls._attributes[name] = attribute
-            if attribute.attr_name is not None:
-                cls._dynamo_to_python_attrs[attribute.attr_name] = name
-            else:
+            if attribute.attr_name is None:
                 attribute.attr_name = name
+            if attribute.attr_name != name:
+                cls._dynamo_to_python_attrs[attribute.attr_name] = name
 
             if initialized and isinstance(attribute, MapAttribute):
                 # To support creating expressions from nested attributes, MapAttribute instances


### PR DESCRIPTION
This fixes a "bug" where attributes without custom names are added to the mapping in MapAttribute sub-subclasses.
```
MyMap(MapAttribute):
    foo = StringAttribute()

MySubMap(MyMap):
    pass
```
With this change `foo` is no longer added to `MySubMap._dynamo_to_python_attrs`