### PR TITLE
Add table name to error message for transactional operations

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -437,7 +437,7 @@ class Connection(object):
                     for item in operation_kwargs[TRANSACT_ITEMS]:
                         for op in item.values():
                             table_names.append(op[TABLE_NAME])
-                    verbose_properties['table_name'] = ','.join(items)
+                    verbose_properties['table_name'] = ','.join(table_names)
                 else:
                     verbose_properties['table_name'] = operation_kwargs.get(TABLE_NAME)
 

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -427,11 +427,19 @@ class Connection(object):
                     'request_id': headers.get('x-amzn-RequestId')
                 }
 
-                if 'RequestItems' in operation_kwargs:
+                if REQUEST_ITEMS in operation_kwargs:
                     # Batch operations can hit multiple tables, report them comma separated
-                    verbose_properties['table_name'] = ','.join(operation_kwargs['RequestItems'])
+                    verbose_properties['table_name'] = ','.join(operation_kwargs[REQUEST_ITEMS])
+                elif TRANSACT_ITEMS in operation_kwargs:
+                    # Transactional operations can also hit multiple tables, or have multiple updates within
+                    # the same table
+                    items = []
+                    for item in operation_kwargs[TRANSACT_ITEMS]:
+                        for op in item.keys():
+                            items.append(item[op][TABLE_NAME])
+                    verbose_properties['table_name'] = ','.join(items)
                 else:
-                    verbose_properties['table_name'] = operation_kwargs.get('TableName')
+                    verbose_properties['table_name'] = operation_kwargs.get(TABLE_NAME)
 
                 try:
                     raise VerboseClientError(botocore_expected_format, operation_name, verbose_properties)

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -433,10 +433,10 @@ class Connection(object):
                 elif TRANSACT_ITEMS in operation_kwargs:
                     # Transactional operations can also hit multiple tables, or have multiple updates within
                     # the same table
-                    items = []
+                    table_names = []
                     for item in operation_kwargs[TRANSACT_ITEMS]:
-                        for op in item.keys():
-                            items.append(item[op][TABLE_NAME])
+                        for op in item.values():
+                            table_names.append(op[TABLE_NAME])
                     verbose_properties['table_name'] = ','.join(items)
                 else:
                     verbose_properties['table_name'] = operation_kwargs.get(TABLE_NAME)


### PR DESCRIPTION
The current error messaging does not include table names when an exception is encountered during a transaction. This change provides a sequential list of all tables on which a transactional operation was attempted. Please note that the purpose of including table names is to enable human debugging without causing confusing (like in https://github.com/pynamodb/PynamoDB/issues/816).