### PR TITLE
Revert "Support removing specific indexes from a ListAttribute (#754)"

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,7 @@ v5.0 (unreleased)
   "'filter_condition' cannot contain key attributes" errors.
 * Replace the internal attribute type constants with their "short" DynamoDB version (#827)
 * Typed list attributes can now support any Attribute subclass (#833)
+* Remove ``ListAttribute.remove_indexes`` (added in v4.3.2) and document usage of remove for list elements (#838)
 
 v4.3.3
 ----------

--- a/docs/updates.rst
+++ b/docs/updates.rst
@@ -37,7 +37,7 @@ Any value provided will be serialized using the serializer defined for that attr
     :header: DynamoDB Action / Operator, PynamoDB Syntax, Example
 
     SET, set( `value` ), Thread.views.set(10)
-    REMOVE, remove(), Thread.subjects.remove()
+    REMOVE, remove(), Thread.notes[0].remove()
     ADD, add( `value` ), "Thread.subjects.add({'A New Subject', 'Another New Subject'})"
     DELETE, delete( `value` ), Thread.subjects.delete({'An Old Subject'})
     `attr_or_value_1` \+ `attr_or_value_2`, `attr_or_value_1` \+ `attr_or_value_2`, Thread.views + 5

--- a/docs/updates.rst
+++ b/docs/updates.rst
@@ -44,5 +44,4 @@ Any value provided will be serialized using the serializer defined for that attr
     `attr_or_value_1` \- `attr_or_value_2`, `attr_or_value_1` \- `attr_or_value_2`, 5 - Thread.views
     "list_append( `attr` , `value` )", append( `value` ), Thread.notes.append(['my last note'])
     "list_append( `value` , `attr` )", prepend( `value` ), Thread.notes.prepend(['my first note'])
-    "REMOVE list[index1], list[index2]", "remove_indexes(`index1`, `index2`)", "Thread.notes.remove_indexes(0, 1)"
     "if_not_exists( `attr`, `value` )", `attr` | `value`, Thread.forum_name | 'Default Forum Name'

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -936,11 +936,6 @@ class ListAttribute(Generic[_T], Attribute[List[_T]]):
                 raise ValueError("'of' must be a subclass of Attribute")
             self.element_type = of
 
-    def remove_indexes(self, *indexes):
-        if not all([isinstance(i, int) for i in indexes]):
-            raise ValueError("Method 'remove_indexes' arguments must be 'int'")
-        return Path(self).remove_list_elements(*indexes)
-
     def serialize(self, values):
         """
         Encode the given list of objects into a list of AttributeValue types.

--- a/pynamodb/expressions/operand.py
+++ b/pynamodb/expressions/operand.py
@@ -8,7 +8,7 @@ from pynamodb.expressions.condition import (
     BeginsWith, Between, Comparison, Contains, Exists, In, IsType, NotExists
 )
 from pynamodb.expressions.update import (
-    AddAction, DeleteAction, RemoveAction, SetAction, ListRemoveAction
+    AddAction, DeleteAction, RemoveAction, SetAction
 )
 from pynamodb.expressions.util import get_path_segments, get_value_placeholder, substitute_names
 
@@ -287,9 +287,6 @@ class Path(_NumericOperand, _ListAppendOperand, _ConditionOperand):
     def remove(self) -> RemoveAction:
         # Returns an update action that removes this attribute from the item
         return RemoveAction(self)
-
-    def remove_list_elements(self, *indexes: int) -> ListRemoveAction:
-        return ListRemoveAction(self, *indexes)
 
     def add(self, *values: Any) -> AddAction:
         # Returns an update action that appends the given values to a set or mathematically adds a value to a number

--- a/pynamodb/expressions/update.py
+++ b/pynamodb/expressions/update.py
@@ -42,15 +42,6 @@ class RemoveAction(Action):
         super(RemoveAction, self).__init__(path)
 
 
-class ListRemoveAction(Action):
-    """
-    The List REMOVE action deletes an element from a list item based on the index.
-    """
-    def __init__(self, path: 'Path', *indexes: int):
-        self.format_string = ", ".join("{{0}}[{}]".format(index) for index in indexes)
-        super(ListRemoveAction, self).__init__(path)
-
-
 class AddAction(Action):
     """
     The ADD action appends elements to a set or mathematically adds to a number attribute.
@@ -80,7 +71,6 @@ class Update(object):
         self.remove_actions: List[RemoveAction] = []
         self.add_actions: List[AddAction] = []
         self.delete_actions: List[DeleteAction] = []
-        self.list_remove_actions: List[ListRemoveAction] = []
         for action in actions:
             self.add_action(action)
 
@@ -89,8 +79,6 @@ class Update(object):
             self.set_actions.append(action)
         elif isinstance(action, RemoveAction):
             self.remove_actions.append(action)
-        elif isinstance(action, ListRemoveAction):
-            self.list_remove_actions.append(action)
         elif isinstance(action, AddAction):
             self.add_actions.append(action)
         elif isinstance(action, DeleteAction):
@@ -102,7 +90,6 @@ class Update(object):
         expression = None
         expression = self._add_clause(expression, 'SET', self.set_actions, placeholder_names, expression_attribute_values)
         expression = self._add_clause(expression, 'REMOVE', self.remove_actions, placeholder_names, expression_attribute_values)
-        expression = self._add_clause(expression, 'REMOVE', self.list_remove_actions, placeholder_names, expression_attribute_values)
         expression = self._add_clause(expression, 'ADD', self.add_actions, placeholder_names, expression_attribute_values)
         expression = self._add_clause(expression, 'DELETE', self.delete_actions, placeholder_names, expression_attribute_values)
         return expression

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -431,7 +431,6 @@ class UpdateExpressionTestCase(TestCase):
 
     def setUp(self):
         self.attribute = UnicodeAttribute(attr_name='foo')
-        self.list_attribute = ListAttribute(attr_name='foo_list', default=[])
 
     def test_set_action(self):
         action = self.attribute.set('bar')
@@ -590,26 +589,3 @@ class UpdateExpressionTestCase(TestCase):
             ':1': {'N': '0'},
             ':2': {'NS': ['0']}
         }
-
-    def test_list_update_remove_by_index(self):
-        update = Update(
-            self.list_attribute.remove_indexes(0),
-        )
-        placeholder_names, expression_attribute_values = {}, {}
-        expression = update.serialize(placeholder_names, expression_attribute_values)
-        assert expression == "REMOVE #0[0]"
-        assert placeholder_names == {'foo_list': '#0'}
-        assert expression_attribute_values == {}
-
-        update = Update(
-            self.list_attribute.remove_indexes(0, 10),
-        )
-        placeholder_names, expression_attribute_values = {}, {}
-        expression = update.serialize(placeholder_names, expression_attribute_values)
-        assert expression == "REMOVE #0[0], #0[10]"
-        assert placeholder_names == {'foo_list': '#0'}
-        assert expression_attribute_values == {}
-
-        with self.assertRaises(ValueError) as e:
-            Update(self.list_attribute.remove_indexes(0, "a"))
-        assert str(e.exception) == "Method 'remove_indexes' arguments must be 'int'"

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -431,6 +431,7 @@ class UpdateExpressionTestCase(TestCase):
 
     def setUp(self):
         self.attribute = UnicodeAttribute(attr_name='foo')
+        self.list_attribute = ListAttribute(attr_name='foo_list')
 
     def test_set_action(self):
         action = self.attribute.set('bar')
@@ -515,6 +516,14 @@ class UpdateExpressionTestCase(TestCase):
         expression = action.serialize(placeholder_names, expression_attribute_values)
         assert expression == "#0"
         assert placeholder_names == {'foo': '#0'}
+        assert expression_attribute_values == {}
+
+    def test_remove_action_list_element(self):
+        action = self.list_attribute[10].remove()
+        placeholder_names, expression_attribute_values = {}, {}
+        expression = action.serialize(placeholder_names, expression_attribute_values)
+        assert expression == "#0[10]"
+        assert placeholder_names == {'foo_list': '#0'}
         assert expression_attribute_values == {}
 
     def test_add_action(self):


### PR DESCRIPTION
This reverts commit a5f2369a3684ca12c1abd16d786ec4f82c6b9a24.

Removal of list elements is already supported using the path expression syntax.