### PR TITLE
Enable polymorphism by serializing all attributes in subclasses.

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -878,12 +878,6 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
             result[key] = value.as_dict() if isinstance(value, MapAttribute) else value
         return result
 
-    @classmethod
-    def _get_serialize_class(cls, key, value):
-        if not cls.is_raw():
-            return cls.get_attributes().get(key)
-        return _get_class_for_serialize(value)
-
 
 def _get_class_for_serialize(value):
     if value is None:

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -825,18 +825,20 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
         return all(self.is_correctly_typed(k, v) for k, v in self.get_attributes().items())
 
     def serialize(self, values):
-        if isinstance(values, type(self)) and not values.is_raw():
-            return values._serialize()
-
         if not self.is_raw():
-            # Need to serialized based on the attributes in the class; however,
-            # the value passed in was not an instance of the class.
-            instance = type(self)()
-            instance.attribute_values = {}  # clear any defaults
-            for name in values:
-                if name in self.get_attributes():
-                    setattr(instance, name, values[name])
-            return instance._serialize()
+            # This is a subclassed MapAttribute that acts as an AttributeContainer.
+            # Serialize the values based on the attributes in the class.
+
+            if not isinstance(values, type(self)):
+                # Copy the values onto an instance of the class for serialization.
+                instance = type(self)()
+                instance.attribute_values = {}  # clear any defaults
+                for name in values:
+                    if name in self.get_attributes():
+                        setattr(instance, name, values[name])
+                values = instance
+
+            return values._serialize()
 
         # Continue to serialize NULL values in "raw" map attributes for backwards compatibility.
         # This special case behavior for "raw" attributes should be removed in the future.

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -828,25 +828,29 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
         if isinstance(values, type(self)) and not values.is_raw():
             return values._serialize()
 
+        if not self.is_raw():
+            # Need to serialized based on the attributes in the class; however,
+            # the value passed in was not an instance of the class.
+            instance = type(self)()
+            instance.attribute_values = {}  # clear any defaults
+            for name in values:
+                if name in self.get_attributes():
+                    setattr(instance, name, values[name])
+            return instance._serialize()
+
+        # Continue to serialize NULL values in "raw" map attributes for backwards compatibility.
+        # This special case behavior for "raw" attributes should be removed in the future.
         rval = {}
-        for k in values:
-            v = values[k]
-            if self._should_skip(v):
-                continue
-            attr_class = self._get_serialize_class(k, v)
-            if attr_class is None:
-                continue
-
-            # If this is a subclassed MapAttribute, there may be an alternate attr name
-            attr_name = attr_class.attr_name if not self.is_raw() else k
-
-            serialized = attr_class.serialize(v)
-            if self._should_skip(serialized):
-                # Check after we serialize in case the serialized value is null
-                continue
-
-            rval[attr_name] = {attr_class.attr_type: serialized}
-
+        for attr_name in values:
+            v = values[attr_name]
+            attr_class = _get_class_for_serialize(v)
+            attr_type = attr_class.attr_type
+            attr_value = attr_class.serialize(v)
+            if attr_value is None:
+                # When attribute values serialize to "None" (e.g. empty sets) we store {"NULL": True} in DynamoDB.
+                attr_type = NULL
+                attr_value = True
+            rval[attr_name] = {attr_type: attr_value}
         return rval
 
     def deserialize(self, values):
@@ -873,11 +877,6 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
         for key, value in self.attribute_values.items():
             result[key] = value.as_dict() if isinstance(value, MapAttribute) else value
         return result
-
-    def _should_skip(self, value):
-        # Continue to serialize NULL values in "raw" map attributes for backwards compatibility.
-        # This special case behavior for "raw" attributes should be removed in the future.
-        return not self.is_raw() and value is None
 
     @classmethod
     def _get_serialize_class(cls, key, value):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -327,7 +327,7 @@ class AttributeContainer(metaclass=AttributeContainerMeta):
             if null_check and attr_value is None and not attr.null:
                 raise ValueError("Attribute '{}' cannot be None".format(name))
 
-            if attr_value:
+            if attr_value is not None:
                 attribute_values[attr.attr_name] = {attr.attr_type: attr_value}
         return attribute_values
 

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -995,7 +995,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
                 actions.append(version_attribute.add(1))
             elif snake_to_camel_case(ATTRIBUTES) in serialized_attributes:
                 serialized_attributes[snake_to_camel_case(ATTRIBUTES)][version_attribute.attr_name] = self._serialize_value(
-                    version_attribute, version_attribute_value + 1, null_check=True
+                    version_attribute, version_attribute_value + 1
                 )
         else:
             version_condition = version_attribute.does_not_exist()
@@ -1003,7 +1003,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
                 actions.append(version_attribute.set(1))
             elif snake_to_camel_case(ATTRIBUTES) in serialized_attributes:
                 serialized_attributes[snake_to_camel_case(ATTRIBUTES)][version_attribute.attr_name] = self._serialize_value(
-                    version_attribute, 1, null_check=True
+                    version_attribute, 1
                 )
 
         return version_condition
@@ -1129,7 +1129,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
         return attrs
 
     @classmethod
-    def _serialize_value(cls, attr, value, null_check=True):
+    def _serialize_value(cls, attr, value):
         """
         Serializes a value for use with DynamoDB
 
@@ -1137,13 +1137,10 @@ class Model(AttributeContainer, metaclass=MetaModel):
         :param value: a value to be serialized
         :param null_check: If True, then attributes are checked for null
         """
-        if value is None:
-            serialized = None
-        else:
-            serialized = attr.serialize(value)
+        serialized = attr.serialize(value)
 
         if serialized is None:
-            if not attr.null and null_check:
+            if not attr.null:
                 raise ValueError("Attribute '{}' cannot be None".format(attr.attr_name))
             return {NULL: True}
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -889,6 +889,29 @@ class TestMapAttribute:
         assert mid_map_b_map_attr.attr_name == 'dyn_map_attr'
         assert mid_map_b_map_attr.attr_path == ['dyn_out_map', 'mid_map_b', 'dyn_in_map_b', 'dyn_map_attr']
 
+    def test_required_elements(self):
+        class InnerMapAttribute(MapAttribute):
+            foo = UnicodeAttribute()
+
+        class OuterMapAttribute(MapAttribute):
+            inner_map = InnerMapAttribute()
+
+        outer_map_attribute = OuterMapAttribute()
+        with pytest.raises(ValueError):
+            outer_map_attribute.serialize(outer_map_attribute)
+
+        outer_map_attribute = OuterMapAttribute(inner_map={})
+        with pytest.raises(ValueError):
+            outer_map_attribute.serialize(outer_map_attribute)
+
+        outer_map_attribute = OuterMapAttribute(inner_map=MapAttribute())
+        with pytest.raises(ValueError):
+            outer_map_attribute.serialize(outer_map_attribute)
+
+        outer_map_attribute = OuterMapAttribute(inner_map={'foo': 'bar'})
+        serialized = outer_map_attribute.serialize(outer_map_attribute)
+        assert serialized == {'inner_map': {'M': {'foo': {'S': 'bar'}}}}
+
 
 class TestListAttribute:
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -614,19 +614,21 @@ class TestMapAttribute:
 
     def test_null_attribute_subclassed_map(self):
         null_attribute = {
-            'map_field': None
+            'map_field': {},
+            'string_set_field': None
         }
         attr = DefaultsMap()
         serialized = attr.serialize(null_attribute)
-        assert serialized == {}
+        assert serialized == {'map_field': {'M': {}}}
 
     def test_null_attribute_map_after_serialization(self):
         null_attribute = {
+            'map_field': {},
             'string_set_field': {},
         }
         attr = DefaultsMap()
         serialized = attr.serialize(null_attribute)
-        assert serialized == {}
+        assert serialized == {'map_field': {'M': {}}}
 
     def test_map_of_map(self):
         attribute = {


### PR DESCRIPTION
Currently when serializing MapAttribute subclasses, only attributes defined in the type being serialized are written.
```
>>> from pynamodb.attributes import ListAttribute, MapAttribute, UnicodeAttribute
>>> from pynamodb.models import Model
>>> class SuperclassMap(MapAttribute):
...     bar = UnicodeAttribute()
... 
>>> class SubclassMap(SuperclassMap):
...     baz = UnicodeAttribute()
... 
>>> class MyModel(Model):
...     foo = UnicodeAttribute(hash_key=True)
...     map = SuperclassMap()
...     list = ListAttribute(of=SuperclassMap)
... 
>>> subclass_map = SubclassMap(bar='bar', baz='baz')
>>> MyModel(foo='foo', map=subclass_map, list=[subclass_map])._serialize()
{'attributes': {'list': {'L': [{'M': {'bar': {'S': 'bar'}, 'baz': {'S': 'baz'}}}]}, 'map': {'M': {'bar': {'S': 'bar'}}}}, 'HASH': 'foo'}
```
(note `mm.list[0]` serialize `baz` but `mm.map` does not)

With this change (needed for discriminator support) all attributes in the subclass are written to dynamo.
```
>>> subclass_map = SubclassMap(bar='bar', baz='baz')
>>> MyModel(foo='foo', map=subclass_map, list=[subclass_map])._serialize()
{'attributes': {'list': {'L': [{'M': {'bar': {'S': 'bar'}, 'baz': {'S': 'baz'}}}]}, 'map': {'M': {'bar': {'S': 'bar'}, 'baz': {'S': 'baz'}}}}, 'HASH': 'foo'}
```

In addition, this commit fixes a bug where required elements in inner maps were not correctly validated (see added test).