### PR TITLE
UTCDateTimeAttribute now requires the date string format '%Y-%m-%dT%H:%M:%S.%f%z'.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,6 +13,12 @@ This is major release and contains breaking changes. Please read the notes below
 This release introduces :ref:`polymorphism` support via :py:class:`DiscriminatorAttribute <pynamodb.attributes.DiscriminatorAttribute>`.
 Discriminator values are written to DynamoDB and used during deserialization to instantiate the desired class.
 
+** UTCDateTimeAttribute **
+
+The UTCDateTimeAttribute now strictly requires the date string format '%Y-%m-%dT%H:%M:%S.%f%z' to ensure proper ordering.
+PynamoDB has always written values with this format but previously would accept reading other formats.
+Items written using other formats must be rewritten before upgrading.
+
 Other changes in this release:
 
 * Python 2 is no longer supported. Python 3.6 or greater is now required.

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -670,7 +670,7 @@ class UTCDateTimeAttribute(Attribute[datetime]):
         return self._fast_parse_utc_date_string(value)
 
     @staticmethod
-    def _fast_parse_utc_date_string(date_string):
+    def _fast_parse_utc_date_string(date_string: str) -> datetime:
         # Method to quickly parse strings formatted with '%Y-%m-%dT%H:%M:%S.%f+0000'.
         # This is ~5.8x faster than using strptime and 38x faster than dateutil.parser.parse.
         _int = int  # Hack to prevent global lookups of int, speeds up the function ~10%

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,9 +2,6 @@ pytest>=5
 pytest-env
 pytest-mock
 
-# Due to https://github.com/boto/botocore/issues/1872. Remove after botocore fixes.
-python-dateutil==2.8.0
-
 # only used in .travis.yml
 coveralls
 mypy==0.770;python_version>="3.7"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'botocore>=1.12.54',
-    'python-dateutil>=2.1,<3.0.0',
 ]
 
 setup(


### PR DESCRIPTION
This removes the dependency on `python-dateutil`.