### PR TITLE
[Experimental] add asyncio support

### DIFF
--- a/pynamodb/async_util.py
+++ b/pynamodb/async_util.py
@@ -1,0 +1,19 @@
+import functools
+
+
+def run_secretly_sync_async_fn(async_fn, *args, **kwargs):
+    # From https://github.com/python-trio/hip/issues/1#issuecomment-322028457
+    coro = async_fn(*args, **kwargs)
+    try:
+        coro.send(None)
+    except StopIteration as exc:
+        return exc.value
+    else:
+        raise RuntimeError("you lied, this async function is not secretly synchronous")
+
+
+def wrap_secretly_sync_async_fn(async_fn):
+    @functools.wraps(async_fn)
+    def wrap(*args, **kwargs):
+        return run_secretly_sync_async_fn(async_fn, *args, **kwargs)
+    return wrap

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -1,6 +1,7 @@
 """
 Lowest level connection
 """
+import asyncio
 import json
 import logging
 import random
@@ -18,6 +19,13 @@ from botocore.client import ClientError
 from botocore.hooks import first_non_none_response
 from botocore.exceptions import BotoCoreError
 from botocore.session import get_session
+
+if True:
+    # TODO:
+    import aiobotocore.session
+    from aiobotocore.client import AioBaseClient
+    from aiobotocore.session import get_session as get_async_session
+
 
 from pynamodb.constants import (
     RETURN_CONSUMED_CAPACITY_VALUES, RETURN_ITEM_COLL_METRICS_VALUES,
@@ -60,6 +68,18 @@ RATE_LIMITING_ERROR_CODES = ['ProvisionedThroughputExceededException', 'Throttli
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
+
+
+def run_secretly_sync_async_fn(async_fn, *args, **kwargs):
+    # From https://github.com/python-trio/hip/issues/1#issuecomment-322028457
+    print('called with', async_fn, args, kwargs)
+    coro = async_fn(*args, **kwargs)
+    try:
+        coro.send(None)
+    except StopIteration as exc:
+        return exc.value
+    else:
+        raise RuntimeError("you lied, this async function is not secretly synchronous")
 
 
 class MetaTable(object):
@@ -234,7 +254,26 @@ class MetaTable(object):
             }
 
 
-class Connection(object):
+def create_wrapper(async_fn):
+    def wrap(*args, **kwargs):
+        return run_secretly_sync_async_fn(async_fn, *args, **kwargs)
+    return wrap
+
+
+class ConnectionMeta(type):
+    def __init__(self, name, bases, attrs):
+        super().__init__(name, bases, attrs)
+
+        import functools
+        for attr_name, attr_value in attrs.items():
+            if attr_name.endswith('_async') and asyncio.iscoroutinefunction(attr_value):
+                # TODO: use functools.wraps?
+                #setattr(self, attr_name.rstrip("_async"), create_wrapper(attr_value))
+                sync_fn = functools.partial(run_secretly_sync_async_fn, attr_value)
+                setattr(self, attr_name.rstrip("_async"), sync_fn)
+
+
+class Connection(metaclass=ConnectionMeta):
     """
     A higher level abstraction over botocore
     """
@@ -296,26 +335,29 @@ class Connection(object):
         """
         log.debug("Calling %s with arguments %s", operation, kwargs)
 
-    def _sign_request(self, request):
-        auth = self.client._request_signer.get_auth_instance(
-            self.client._request_signer.signing_name,
-            self.client._request_signer.region_name,
-            self.client._request_signer.signature_version)
+    async def _sign_request(self, client, request):
+        auth = client._request_signer.get_auth_instance(
+            client._request_signer.signing_name,
+            client._request_signer.region_name,
+            client._request_signer.signature_version)
+        if asyncio.iscoroutine(auth):
+            auth = await auth
         auth.add_auth(request)
 
-    def _create_prepared_request(
+    async def _create_prepared_request(
         self,
+        client,
         params: Dict,
         operation_model: Optional[Any],
     ) -> AWSPreparedRequest:
         request = create_request_object(params)
-        self._sign_request(request)
-        prepared_request = self.client._endpoint.prepare_request(request)
+        await self._sign_request(client, request)
+        prepared_request = client._endpoint.prepare_request(request)
         if self._extra_headers is not None:
             prepared_request.headers.update(self._extra_headers)
         return prepared_request
 
-    def dispatch(self, operation_name, operation_kwargs):
+    async def dispatch(self, operation_name, operation_kwargs):
         """
         Dispatches `operation_name` with arguments `operation_kwargs`
 
@@ -330,7 +372,11 @@ class Connection(object):
         req_uuid = uuid.uuid4()
 
         self.send_pre_boto_callback(operation_name, req_uuid, table_name)
+
         data = self._make_api_call(operation_name, operation_kwargs)
+        if asyncio.iscoroutine(data):
+            data = await data
+
         self.send_post_boto_callback(operation_name, req_uuid, table_name)
 
         if data and CONSUMED_CAPACITY in data:
@@ -379,7 +425,7 @@ class Connection(object):
                     prepared_request.reset_stream()
 
                 # Create a new request for each retry (including a new signature).
-                prepared_request = self._create_prepared_request(request_dict, operation_model)
+                prepared_request = run_secretly_sync_async_fn(self._create_prepared_request, self.client, request_dict, operation_model)
 
                 # Implement the before-send event from botocore
                 event_name = 'before-send.dynamodb.{}'.format(operation_model.name)
@@ -387,16 +433,13 @@ class Connection(object):
                 event_response = first_non_none_response(event_responses)
 
                 if event_response is None:
+                    # TODO(async): This will need to be awaited
                     http_response = self.client._endpoint.http_session.send(prepared_request)
                 else:
                     http_response = event_response
                     is_last_attempt_for_exceptions = True  # don't retry if we have an event response
 
-                # json.loads accepts bytes in >= 3.6.0
-                if sys.version_info < (3, 6, 0):
-                    data = json.loads(http_response.text)
-                else:
-                    data = json.loads(http_response.content)
+                data = json.loads(http_response.content)
             except (ValueError, botocore.exceptions.HTTPClientError, botocore.exceptions.ConnectionError) as e:
                 if is_last_attempt_for_exceptions:
                     log.debug('Reached the maximum number of retry attempts: %s', attempt_number)
@@ -538,7 +581,7 @@ class Connection(object):
             self._client = self.session.create_client(SERVICE_NAME, self.region, endpoint_url=self.host, config=config)
         return self._client
 
-    def get_meta_table(self, table_name: str, refresh: bool = False):
+    async def get_meta_table_async(self, table_name: str, refresh: bool = False):
         """
         Returns a MetaTable
         """
@@ -547,7 +590,7 @@ class Connection(object):
                 TABLE_NAME: table_name
             }
             try:
-                data = self.dispatch(DESCRIBE_TABLE, operation_kwargs)
+                data = await self.dispatch(DESCRIBE_TABLE, operation_kwargs)
                 self._tables[table_name] = MetaTable(data.get(TABLE_KEY))
             except BotoCoreError as e:
                 raise TableError("Unable to describe table: {}".format(e), e)
@@ -1334,6 +1377,129 @@ class Connection(object):
     @staticmethod
     def _reverse_dict(d):
         return {v: k for k, v in d.items()}
+
+
+# Uses aiobotocore instead of urllib3/botocore
+class AsyncConnection(Connection):
+    @property
+    def session(self) -> aiobotocore.session.AioSession:
+        """
+        Returns a valid async aiobotocore session
+        """
+        # botocore client creation is not thread safe as of v1.2.5+ (see issue #153)
+        if getattr(self._local, 'async_session', None) is None:
+            self._local.async_session = get_async_session()
+        return self._local.async_session
+
+    @property
+    def client(self) -> AioBaseClient:
+        """
+        Returns an aiobotocore dynamodb client
+        """
+        return super().client
+
+    async def _make_api_call(self, operation_name, operation_kwargs):
+        # TODO: dedup with super
+        async with self.client as client:
+            operation_model = client._service_model.operation_model(operation_name)
+            request_dict = await client._convert_to_request_dict(
+                operation_kwargs,
+                operation_model,
+            )
+
+            for i in range(0, self._max_retry_attempts_exception + 1):
+                attempt_number = i + 1
+                is_last_attempt_for_exceptions = i == self._max_retry_attempts_exception
+
+                http_response = None
+                prepared_request = None
+                try:
+                    if prepared_request is not None:
+                        # If there is a stream associated with the request, we need
+                        # to reset it before attempting to send the request again.
+                        # This will ensure that we resend the entire contents of the
+                        # body.
+                        prepared_request.reset_stream()
+
+                    # Create a new request for each retry (including a new signature).
+                    prepared_request = await self._create_prepared_request(client, request_dict, operation_model)
+
+                    # Implement the before-send event from botocore
+                    event_name = 'before-send.dynamodb.{}'.format(operation_model.name)
+                    event_responses = await client._endpoint._event_emitter.emit(event_name, request=prepared_request)
+                    event_response = first_non_none_response(event_responses)
+
+                    if event_response is None:
+                        http_response = await client._endpoint._send(prepared_request)
+                    else:
+                        http_response = event_response
+                        is_last_attempt_for_exceptions = True  # don't retry if we have an event response
+
+                    data = json.loads(http_response.content)
+                except (ValueError, botocore.exceptions.HTTPClientError, botocore.exceptions.ConnectionError) as e:
+                    if is_last_attempt_for_exceptions:
+                        log.debug('Reached the maximum number of retry attempts: %s', attempt_number)
+                        if http_response:
+                            e.args += (http_response.text,)
+                        raise
+                    else:
+                        # No backoff for fast-fail exceptions that likely failed at the frontend
+                        log.debug(
+                            'Retry needed for (%s) after attempt %s, retryable %s caught: %s',
+                            operation_name,
+                            attempt_number,
+                            e.__class__.__name__,
+                            e
+                        )
+                        continue
+
+                status_code = http_response.status_code
+                headers = http_response.headers
+                if status_code >= 300:
+                    # Extract error code from __type
+                    code = data.get('__type', '')
+                    if '#' in code:
+                        code = code.rsplit('#', 1)[1]
+                    botocore_expected_format = {'Error': {'Message': data.get('message', ''), 'Code': code}}
+                    verbose_properties = {
+                        'request_id': headers.get('x-amzn-RequestId')
+                    }
+
+                    if 'RequestItems' in operation_kwargs:
+                        # Batch operations can hit multiple tables, report them comma separated
+                        verbose_properties['table_name'] = ','.join(operation_kwargs['RequestItems'])
+                    else:
+                        verbose_properties['table_name'] = operation_kwargs.get('TableName')
+
+                    try:
+                        raise VerboseClientError(botocore_expected_format, operation_name, verbose_properties)
+                    except VerboseClientError as e:
+                        if is_last_attempt_for_exceptions:
+                            log.debug('Reached the maximum number of retry attempts: %s', attempt_number)
+                            raise
+                        elif status_code < 500 and code not in RATE_LIMITING_ERROR_CODES:
+                            # We don't retry on a ConditionalCheckFailedException or other 4xx (except for
+                            # throughput related errors) because we assume they will fail in perpetuity.
+                            # Retrying when there is already contention could cause other problems
+                            # in part due to unnecessary consumption of throughput.
+                            raise
+                        else:
+                            # We use fully-jittered exponentially-backed-off retries:
+                            #  https://www.awsarchitectureblog.com/2015/03/backoff.html
+                            sleep_time_ms = random.randint(0, self._base_backoff_ms * (2 ** i))
+                            log.debug(
+                                'Retry with backoff needed for (%s) after attempt %s,'
+                                'sleeping for %s milliseconds, retryable %s caught: %s',
+                                operation_name,
+                                attempt_number,
+                                sleep_time_ms,
+                                e.__class__.__name__,
+                                e
+                            )
+                            await asyncio.sleep(sleep_time_ms / 1000.0)
+                            continue
+
+                return self._handle_binary_attributes(data)
 
 
 def _convert_binary(attr):


### PR DESCRIPTION
I will likely break this up into separate PRs if we decide to move ahead, but opening this up as a place to discuss what asyncio support might look like.

The approach is inspired by [this comment](https://github.com/python-trio/hip/issues/1#issuecomment-322028457) in python-trio, which details an interesting way to run async functions in a sync context, so long as they're actually synchronous under the hood. This allows us to write a single async implementation, and then dynamically generate the sync interface.

As far as the public interface goes, this currently leaves the sync interface unchanged and exposes `_async` variants for methods. I've only implemented the base connection so far, so this is far from complete.

I'm interested in any feedback on the approach and the interface in particular.
