### PR TITLE
use f-strings

### DIFF
--- a/examples/attributes.py
+++ b/examples/attributes.py
@@ -14,7 +14,7 @@ class Color(object):
         self.name = name
 
     def __str__(self):
-        return "<Color: {}>".format(self.name)
+        return f"<Color: {self.name}>"
 
 
 class PickleAttribute(BinaryAttribute):

--- a/examples/indexes.py
+++ b/examples/indexes.py
@@ -47,7 +47,7 @@ item.save()
 
 # Indexes can be queried easily using the index's hash key
 for item in TestModel.view_index.query(1):
-    print("Item queried from index: {0}".format(item))
+    print(f"Item queried from index: {item}")
 
 
 class GamePlayerOpponentIndex(LocalSecondaryIndex):
@@ -96,7 +96,7 @@ item.save()
 
 # Indexes can be queried easily using the index's hash key
 for item in GameModel.player_opponent_index.query('1234'):
-    print("Item queried from index: {0}".format(item))
+    print(f"Item queried from index: {item}")
 
 # Count on an index
 print(GameModel.player_opponent_index.count('1234'))

--- a/examples/model.py
+++ b/examples/model.py
@@ -59,7 +59,7 @@ thread_item.save()
 with Thread.batch_write() as batch:
     threads = []
     for x in range(100):
-        thread = Thread('forum-{0}'.format(x), 'subject-{0}'.format(x))
+        thread = Thread(f'forum-{x}', f'subject-{x}')
         thread.tags = ['tag1', 'tag2']
         thread.last_post_datetime = datetime.now()
         threads.append(thread)
@@ -74,7 +74,7 @@ print(Thread.count())
 print(Thread.count('forum-1'))
 
 # Batch get
-item_keys = [('forum-{0}'.format(x), 'subject-{0}'.format(x)) for x in range(100)]
+item_keys = [(f'forum-{x}', f'subject-{x}') for x in range(100)]
 for item in Thread.batch_get(item_keys):
     print(item)
 
@@ -121,7 +121,7 @@ thread_item.save()
 with AliasedModel.batch_write() as batch:
     threads = []
     for x in range(100):
-        thread = AliasedModel('forum-{0}'.format(x), 'subject-{0}'.format(x))
+        thread = AliasedModel(f'forum-{x}', f'subject-{x}')
         thread.tags = ['tag1', 'tag2']
         thread.last_post_datetime = datetime.now()
         threads.append(thread)
@@ -130,30 +130,30 @@ with AliasedModel.batch_write() as batch:
         batch.save(thread)
 
 # Batch get
-item_keys = [('forum-{0}'.format(x), 'subject-{0}'.format(x)) for x in range(100)]
+item_keys = [(f'forum-{x}', f'subject-{x}') for x in range(100)]
 for item in AliasedModel.batch_get(item_keys):
-    print("Batch get item: {0}".format(item))
+    print(f"Batch get item: {item}")
 
 # Scan
 for item in AliasedModel.scan():
-    print("Scanned item: {0}".format(item))
+    print(f"Scanned item: {item}")
 
 # Query
 for item in AliasedModel.query('forum-1', AliasedModel.subject.startswith('subject')):
-    print("Query using aliased attribute: {0}".format(item))
+    print(f"Query using aliased attribute: {item}")
 
 # Query with filters
 for item in Thread.query('forum-1', (Thread.views == 0) | (Thread.replies == 0)):
-    print("Query result: {0}".format(item))
+    print(f"Query result: {item}")
 
 
 # Scan with filters
 for item in Thread.scan(Thread.subject.startswith('subject') & (Thread.views == 0)):
-    print("Scanned item: {0} {1}".format(item.subject, item.views))
+    print(f"Scanned item: {item.subject} {item.views}")
 
 # Scan with null filter
 for item in Thread.scan(Thread.subject.startswith('subject') & Thread.last_post_datetime.does_not_exist()):
-    print("Scanned item: {0} {1}".format(item.subject, item.views))
+    print(f"Scanned item: {item.subject} {item.views}")
 
 # Conditionally save an item
 thread_item = Thread(
@@ -204,7 +204,7 @@ print(thread_item.update(actions=[
 
 # Backup/restore example
 # Print the size of the table
-print("Table size: {}".format(Thread.describe_table().get('ItemCount')))
+print(f"Table size: {Thread.describe_table().get('ItemCount')}")
 
 # Dump the entire table to a file
 Thread.dump('thread.json')
@@ -213,11 +213,11 @@ Thread.dump('thread.json')
 # Commented out for safety
 # for item in Thread.scan():
 #     item.delete()
-print("Table size: {}".format(Thread.describe_table().get('ItemCount')))
+print(f"Table size: {Thread.describe_table().get('ItemCount')}")
 
 # Restore table from a file
 Thread.load('thread.json')
-print("Table size: {}".format(Thread.describe_table().get('ItemCount')))
+print(f"Table size: {Thread.describe_table().get('ItemCount')}")
 
 # Dump the entire table to a string
 serialized = Thread.dumps()

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -75,7 +75,7 @@ class MetaTable(object):
 
     def __repr__(self) -> str:
         if self.data:
-            return "MetaTable<{}>".format(self.data.get(TABLE_NAME))
+            return f"MetaTable<{self.data.get(TABLE_NAME)}>"
         return ""
 
     @property
@@ -144,7 +144,7 @@ class MetaTable(object):
                 for schema_key in index.get(KEY_SCHEMA):
                     if schema_key.get(KEY_TYPE) == HASH:
                         return schema_key.get(ATTR_NAME)
-        raise ValueError("No hash key attribute for index: {}".format(index_name))
+        raise ValueError(f"No hash key attribute for index: {index_name}")
 
     def get_index_range_keyname(self, index_name):
         """
@@ -196,7 +196,7 @@ class MetaTable(object):
                 if key in value:
                     return key
         attr_names = [attr.get(ATTR_NAME) for attr in self.data.get(ATTR_DEFINITIONS, [])]
-        raise ValueError("No attribute {} in {}".format(attribute_name, attr_names))
+        raise ValueError(f"No attribute {attribute_name} in {attr_names}")
 
     def get_identifier_map(self, hash_key: str, range_key: Optional[str] = None, key: str = KEY):
         """
@@ -289,7 +289,7 @@ class Connection(object):
             self._extra_headers = get_settings_value('extra_headers')
 
     def __repr__(self) -> str:
-        return "Connection<{}>".format(self.client.meta.endpoint_url)
+        return f"Connection<{self.client.meta.endpoint_url}>"
 
     def _log_debug(self, operation: str, kwargs: str):
         """
@@ -383,7 +383,7 @@ class Connection(object):
                 prepared_request = self._create_prepared_request(request_dict, operation_model)
 
                 # Implement the before-send event from botocore
-                event_name = 'before-send.dynamodb.{}'.format(operation_model.name)
+                event_name = f'before-send.dynamodb.{operation_model.name}'
                 event_responses = self.client._endpoint._event_emitter.emit(event_name, request=prepared_request)
                 event_response = first_non_none_response(event_responses)
 
@@ -551,7 +551,7 @@ class Connection(object):
                 data = self.dispatch(DESCRIBE_TABLE, operation_kwargs)
                 self._tables[table_name] = MetaTable(data.get(TABLE_KEY))
             except BotoCoreError as e:
-                raise TableError("Unable to describe table: {}".format(e), e)
+                raise TableError(f"Unable to describe table: {e}", e)
             except ClientError as e:
                 if 'ResourceNotFound' in e.response['Error']['Code']:
                     raise TableDoesNotExist(e.response['Error']['Message'])
@@ -593,7 +593,7 @@ class Connection(object):
         operation_kwargs[ATTR_DEFINITIONS] = attrs_list
 
         if billing_mode not in AVAILABLE_BILLING_MODES:
-            raise ValueError("incorrect value for billing_mode, available modes: {}".format(AVAILABLE_BILLING_MODES))
+            raise ValueError(f"incorrect value for billing_mode, available modes: {AVAILABLE_BILLING_MODES}")
         if billing_mode == PAY_PER_REQUEST_BILLING_MODE:
             del operation_kwargs[PROVISIONED_THROUGHPUT]
         elif billing_mode == PROVISIONED_BILLING_MODE:
@@ -642,7 +642,7 @@ class Connection(object):
         try:
             data = self.dispatch(CREATE_TABLE, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise TableError("Failed to create table: {}".format(e), e)
+            raise TableError(f"Failed to create table: {e}", e)
         return data
 
     def update_time_to_live(self, table_name: str, ttl_attribute_name: str) -> Dict:
@@ -659,7 +659,7 @@ class Connection(object):
         try:
             return self.dispatch(UPDATE_TIME_TO_LIVE, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise TableError("Failed to update TTL on table: {}".format(e), e)
+            raise TableError(f"Failed to update TTL on table: {e}", e)
 
     def delete_table(self, table_name: str) -> Dict:
         """
@@ -671,7 +671,7 @@ class Connection(object):
         try:
             data = self.dispatch(DELETE_TABLE, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise TableError("Failed to delete table: {}".format(e), e)
+            raise TableError(f"Failed to delete table: {e}", e)
         return data
 
     def update_table(
@@ -710,7 +710,7 @@ class Connection(object):
         try:
             return self.dispatch(UPDATE_TABLE, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise TableError("Failed to update table: {}".format(e), e)
+            raise TableError(f"Failed to update table: {e}", e)
 
     def list_tables(
         self,
@@ -732,7 +732,7 @@ class Connection(object):
         try:
             return self.dispatch(LIST_TABLES, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise TableError("Unable to list tables: {}".format(e), e)
+            raise TableError(f"Unable to list tables: {e}", e)
 
     def describe_table(self, table_name: str) -> Dict:
         """
@@ -758,7 +758,7 @@ class Connection(object):
         """
         tbl = self.get_meta_table(table_name)
         if tbl is None:
-            raise TableError("No such table {}".format(table_name))
+            raise TableError(f"No such table {table_name}")
         return tbl.get_item_attribute_map(
             attributes,
             item_key=item_key,
@@ -780,7 +780,7 @@ class Connection(object):
                     if return_type:
                         return key, attribute.get(key)
                     return attribute.get(key)
-            raise ValueError("Invalid attribute supplied: {}".format(attribute))
+            raise ValueError(f"Invalid attribute supplied: {attribute}")
         else:
             if return_type:
                 return None, attribute
@@ -798,7 +798,7 @@ class Connection(object):
         """
         tbl = self.get_meta_table(table_name)
         if tbl is None:
-            raise TableError("No such table {}".format(table_name))
+            raise TableError(f"No such table {table_name}")
         return tbl.get_attribute_type(attribute_name, value=value)
 
     def get_identifier_map(
@@ -813,7 +813,7 @@ class Connection(object):
         """
         tbl = self.get_meta_table(table_name)
         if tbl is None:
-            raise TableError("No such table {}".format(table_name))
+            raise TableError(f"No such table {table_name}")
         return tbl.get_identifier_map(hash_key, range_key=range_key, key=key)
 
     def get_consumed_capacity_map(self, return_consumed_capacity: str) -> Dict:
@@ -821,7 +821,7 @@ class Connection(object):
         Builds the consumed capacity map that is common to several operations
         """
         if return_consumed_capacity.upper() not in RETURN_CONSUMED_CAPACITY_VALUES:
-            raise ValueError("{} must be one of {}".format(RETURN_ITEM_COLL_METRICS, RETURN_CONSUMED_CAPACITY_VALUES))
+            raise ValueError(f"{RETURN_ITEM_COLL_METRICS} must be one of {RETURN_CONSUMED_CAPACITY_VALUES}")
         return {
             RETURN_CONSUMED_CAPACITY: str(return_consumed_capacity).upper()
         }
@@ -831,7 +831,7 @@ class Connection(object):
         Builds the return values map that is common to several operations
         """
         if return_values.upper() not in RETURN_VALUES_VALUES:
-            raise ValueError("{} must be one of {}".format(RETURN_VALUES, RETURN_VALUES_VALUES))
+            raise ValueError(f"{RETURN_VALUES} must be one of {RETURN_VALUES_VALUES}")
         return {
             RETURN_VALUES: str(return_values).upper()
         }
@@ -857,7 +857,7 @@ class Connection(object):
         Builds the item collection map
         """
         if return_item_collection_metrics.upper() not in RETURN_ITEM_COLL_METRICS_VALUES:
-            raise ValueError("{} must be one of {}".format(RETURN_ITEM_COLL_METRICS, RETURN_ITEM_COLL_METRICS_VALUES))
+            raise ValueError(f"{RETURN_ITEM_COLL_METRICS} must be one of {RETURN_ITEM_COLL_METRICS_VALUES}")
         return {
             RETURN_ITEM_COLL_METRICS: str(return_item_collection_metrics).upper()
         }
@@ -868,7 +868,7 @@ class Connection(object):
         """
         tbl = self.get_meta_table(table_name)
         if tbl is None:
-            raise TableError("No such table {}".format(table_name))
+            raise TableError(f"No such table {table_name}")
         return tbl.get_exclusive_start_key_map(exclusive_start_key)
 
     def get_operation_kwargs(
@@ -951,7 +951,7 @@ class Connection(object):
         try:
             return self.dispatch(DELETE_ITEM, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise DeleteError("Failed to delete item: {}".format(e), e)
+            raise DeleteError(f"Failed to delete item: {e}", e)
 
     def update_item(
         self,
@@ -983,7 +983,7 @@ class Connection(object):
         try:
             return self.dispatch(UPDATE_ITEM, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise UpdateError("Failed to update item: {}".format(e), e)
+            raise UpdateError(f"Failed to update item: {e}", e)
 
     def put_item(
         self,
@@ -1013,7 +1013,7 @@ class Connection(object):
         try:
             return self.dispatch(PUT_ITEM, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise PutError("Failed to put item: {}".format(e), e)
+            raise PutError(f"Failed to put item: {e}", e)
 
     def _get_transact_operation_kwargs(
         self,
@@ -1126,7 +1126,7 @@ class Connection(object):
         try:
             return self.dispatch(BATCH_WRITE_ITEM, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise PutError("Failed to batch write items: {}".format(e), e)
+            raise PutError(f"Failed to batch write items: {e}", e)
 
     def batch_get_item(
         self,
@@ -1167,7 +1167,7 @@ class Connection(object):
         try:
             return self.dispatch(BATCH_GET_ITEM, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise GetError("Failed to batch get items: {}".format(e), e)
+            raise GetError(f"Failed to batch get items: {e}", e)
 
     def get_item(
         self,
@@ -1190,7 +1190,7 @@ class Connection(object):
         try:
             return self.dispatch(GET_ITEM, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise GetError("Failed to get item: {}".format(e), e)
+            raise GetError(f"Failed to get item: {e}", e)
 
     def scan(
         self,
@@ -1242,7 +1242,7 @@ class Connection(object):
         try:
             return self.dispatch(SCAN, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise ScanError("Failed to scan table: {}".format(e), e)
+            raise ScanError(f"Failed to scan table: {e}", e)
 
     def query(
         self,
@@ -1271,10 +1271,10 @@ class Connection(object):
 
         tbl = self.get_meta_table(table_name)
         if tbl is None:
-            raise TableError("No such table: {}".format(table_name))
+            raise TableError(f"No such table: {table_name}")
         if index_name:
             if not tbl.has_index_name(index_name):
-                raise ValueError("Table {} has no index: {}".format(table_name, index_name))
+                raise ValueError(f"Table {table_name} has no index: {index_name}")
             hash_keyname = tbl.get_index_hash_keyname(index_name)
         else:
             hash_keyname = tbl.hash_keyname
@@ -1304,7 +1304,7 @@ class Connection(object):
             operation_kwargs.update(self.get_consumed_capacity_map(return_consumed_capacity))
         if select:
             if select.upper() not in SELECT_VALUES:
-                raise ValueError("{} must be one of {}".format(SELECT, SELECT_VALUES))
+                raise ValueError(f"{SELECT} must be one of {SELECT_VALUES}")
             operation_kwargs[SELECT] = str(select).upper()
         if scan_index_forward is not None:
             operation_kwargs[SCAN_INDEX_FORWARD] = scan_index_forward
@@ -1316,12 +1316,12 @@ class Connection(object):
         try:
             return self.dispatch(QUERY, operation_kwargs)
         except BOTOCORE_EXCEPTIONS as e:
-            raise QueryError("Failed to query items: {}".format(e), e)
+            raise QueryError(f"Failed to query items: {e}", e)
 
     def _check_condition(self, name, condition):
         if condition is not None:
             if not isinstance(condition, Condition):
-                raise ValueError("'{}' must be an instance of Condition".format(name))
+                raise ValueError(f"'{name}' must be an instance of Condition")
 
     @staticmethod
     def _reverse_dict(d):

--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -93,7 +93,7 @@ class TableDoesNotExist(PynamoDBException):
     Raised when an operation is attempted on a table that doesn't exist
     """
     def __init__(self, table_name: str) -> None:
-        msg = "Table does not exist: `{}`".format(table_name)
+        msg = f"Table does not exist: `{table_name}`"
         super(TableDoesNotExist, self).__init__(msg)
 
 
@@ -123,7 +123,7 @@ class AttributeDeserializationError(TypeError):
     Raised when attribute type is invalid
     """
     def __init__(self, attr_name: str, attr_type: str):
-        msg = "Cannot deserialize '{}' attribute from type: {}".format(attr_name, attr_type)
+        msg = f"Cannot deserialize '{attr_name}' attribute from type: {attr_type}"
         super(AttributeDeserializationError, self).__init__(msg)
 
 

--- a/pynamodb/expressions/condition.py
+++ b/pynamodb/expressions/condition.py
@@ -46,7 +46,7 @@ class Condition(object):
 
     def __bool__(self):
         # Prevent users from accidentally comparing the condition object instead of the attribute instance
-        raise TypeError("unsupported operand type(s) for bool: {}".format(self.__class__.__name__))
+        raise TypeError(f"unsupported operand type(s) for bool: {self.__class__.__name__}")
 
 
 class Comparison(Condition):
@@ -54,7 +54,7 @@ class Comparison(Condition):
 
     def __init__(self, operator, lhs, rhs):
         if operator not in ['=', '<>', '<', '<=', '>', '>=']:
-            raise ValueError("{0} is not a valid comparison operator: {0}".format(operator))
+            raise ValueError(f"{operator} is not a valid comparison operator.")
         super().__init__(operator, lhs, rhs)
 
 

--- a/pynamodb/expressions/operand.py
+++ b/pynamodb/expressions/operand.py
@@ -49,7 +49,7 @@ class _Operand:
 
     def _type_check(self, *types):
         if self.attr_type and self.attr_type not in types:
-            raise ValueError("The data type of '{}' must be one of {}".format(self, list(types)))
+            raise ValueError(f"The data type of '{self}' must be one of {list(types)}")
 
 
 class _ConditionOperand(_Operand):
@@ -254,26 +254,26 @@ class Path(_NumericOperand, _ListAppendOperand, _ConditionOperand):
 
     def __iter__(self):
         # Because we define __getitem__ Path is considered an iterable
-        raise TypeError("'{}' object is not iterable".format(self.__class__.__name__))
+        raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
 
     def __getitem__(self, item: Union[int, str]) -> 'Path':
         # The __getitem__ call returns a new Path instance without any attribute set.
         # This is intended since the nested element is not the same attribute as ``self``.
         if self.attribute and self.attribute.attr_type not in [LIST, MAP]:
-            raise TypeError("'{}' object has no attribute __getitem__".format(self.attribute.__class__.__name__))
+            raise TypeError(f"'{self.attribute.__class__.__name__}' object has no attribute __getitem__")
         if self.attr_type == LIST and not isinstance(item, int):
-            raise TypeError("list indices must be integers, not {}".format(type(item).__name__))
+            raise TypeError(f"list indices must be integers, not {type(item).__name__}")
         if self.attr_type == MAP and not isinstance(item, str):
-            raise TypeError("map attributes must be strings, not {}".format(type(item).__name__))
+            raise TypeError(f"map attributes must be strings, not {type(item).__name__}")
         if isinstance(item, int):
             # list dereference operator
             element_path = Path(self.path)  # copy the document path before indexing last element
-            element_path.path[-1] = '{}[{}]'.format(self.path[-1], item)
+            element_path.path[-1] = f'{self.path[-1]}[{item}]'
             return element_path
         if isinstance(item, str):
             # map dereference operator
             return Path(self.path + [item])
-        raise TypeError("item must be an integer or string, not {}".format(type(item).__name__))
+        raise TypeError(f"item must be an integer or string, not {type(item).__name__}")
 
     def __or__(self, other):
         return _IfNotExists(self, self._to_operand(other))
@@ -304,8 +304,7 @@ class Path(_NumericOperand, _ListAppendOperand, _ConditionOperand):
 
     def is_type(self, attr_type: str) -> IsType:
         if attr_type not in ATTRIBUTE_TYPES:
-            raise ValueError("{} is not a valid attribute type. Must be one of {}".format(
-                attr_type, ATTRIBUTE_TYPES))
+            raise ValueError(f"{attr_type} is not a valid attribute type. Must be one of {ATTRIBUTE_TYPES}")
         return IsType(self, Value(attr_type))
 
     def startswith(self, prefix: str) -> BeginsWith:
@@ -333,7 +332,7 @@ class Path(_NumericOperand, _ListAppendOperand, _ConditionOperand):
         return '.'.join(quoted_path)
 
     def __repr__(self) -> str:
-        return "Path({})".format(self.path)
+        return f"Path({self.path})"
 
     @staticmethod
     def _quote_path(path: str) -> str:

--- a/pynamodb/expressions/update.py
+++ b/pynamodb/expressions/update.py
@@ -94,7 +94,7 @@ class Update:
         elif isinstance(action, DeleteAction):
             self.delete_actions.append(action)
         else:
-            raise ValueError("unsupported action type: '{}'".format(action.__class__.__name__))
+            raise ValueError(f"unsupported action type: '{action.__class__.__name__}'")
 
     def serialize(self, placeholder_names: Dict[str, str], expression_attribute_values: Dict[str, str]) -> Optional[str]:
         clauses = [

--- a/pynamodb/expressions/util.py
+++ b/pynamodb/expressions/util.py
@@ -37,7 +37,7 @@ def substitute_names(document_path: Union[str, List[str]], placeholders: Dict[st
     for idx, segment in enumerate(path_segments):
         match = PATH_SEGMENT_REGEX.match(segment)
         if not match:
-            raise ValueError('{} is not a valid document path'.format('.'.join(document_path)))
+            raise ValueError(f"{'.'.join(document_path)} is not a valid document path")
         name, indexes = match.groups()
         if name in placeholders:
             placeholder = placeholders[name]

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -252,7 +252,7 @@ class MetaModel(AttributeContainerMeta):
 
             ttl_attr_names = [name for name, attr_obj in attrs.items() if isinstance(attr_obj, TTLAttribute)]
             if len(ttl_attr_names) > 1:
-                raise ValueError("The model has more than one TTL attribute: {}".format(", ".join(ttl_attr_names)))
+                raise ValueError(f"The model has more than one TTL attribute: {', '.join(ttl_attr_names)}")
 
             if META_CLASS_NAME not in attrs:
                 setattr(cls, META_CLASS_NAME, DefaultMeta)
@@ -383,9 +383,9 @@ class Model(AttributeContainer, metaclass=MetaModel):
         table_name = self.Meta.table_name if self.Meta.table_name else 'unknown'
         serialized = self._serialize(null_check=False)
         if self._range_keyname:
-            msg = "{}<{}, {}>".format(self.Meta.table_name, serialized.get(HASH), serialized.get(RANGE))
+            msg = f"{self.Meta.table_name}<{serialized.get(HASH)}, {serialized.get(RANGE)}>"
         else:
-            msg = "{}<{}>".format(self.Meta.table_name, serialized.get(HASH))
+            msg = f"{self.Meta.table_name}<{serialized.get(HASH)}>"
         return msg
 
     def delete(self, condition: Optional[Condition] = None) -> Any:
@@ -820,7 +820,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
                 cls._get_connection().update_time_to_live(ttl_attribute.attr_name)
             except Exception:
                 if ignore_update_ttl_errors:
-                    log.info("Unable to update the TTL for {}".format(cls.Meta.table_name))
+                    log.info(f"Unable to update the TTL for {cls.Meta.table_name}")
                 else:
                     raise
 
@@ -1140,7 +1140,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
 
         if serialized is None:
             if not attr.null:
-                raise ValueError("Attribute '{}' cannot be None".format(attr.attr_name))
+                raise ValueError(f"Attribute '{attr.attr_name}' cannot be None")
             return {NULL: True}
 
         return {attr.attr_type: serialized}

--- a/pynamodb/settings.py
+++ b/pynamodb/settings.py
@@ -34,9 +34,9 @@ if os.path.isfile(OVERRIDE_SETTINGS_PATH):
     override_settings = _load_module('__pynamodb_override_settings__', OVERRIDE_SETTINGS_PATH)
     if hasattr(override_settings, 'session_cls') or hasattr(override_settings, 'request_timeout_seconds'):
         warnings.warn("The `session_cls` and `request_timeout_second` options are no longer supported")
-    log.info('Override settings for pynamo available {}'.format(OVERRIDE_SETTINGS_PATH))
+    log.info(f'Override settings for pynamo available {OVERRIDE_SETTINGS_PATH}')
 else:
-    log.info('Override settings for pynamo not available {}'.format(OVERRIDE_SETTINGS_PATH))
+    log.info(f'Override settings for pynamo not available {OVERRIDE_SETTINGS_PATH}')
     log.info('Using Default settings value')
 
 

--- a/tests/deep_eq.py
+++ b/tests/deep_eq.py
@@ -92,8 +92,7 @@ def deep_eq(_v1, _v2, datetime_fudge=default_fudge, _assert=False):
 
     def _check_assert(R, a, b, reason=''):
         if _assert and not R:
-            assert 0, "an assertion has failed in deep_eq ({}) {} != {}".format(
-                reason, str(a), str(b))
+            assert 0, f"an assertion has failed in deep_eq ({reason}) {str(a)} != {str(b)}"
         return R
 
     def _deep_dict_eq(d1, d2):

--- a/tests/integration/base_integration_test.py
+++ b/tests/integration/base_integration_test.py
@@ -143,7 +143,7 @@ def test_connection_integration(ddb_url):
     items = []
     for i in range(10):
         items.append(
-            {"Forum": "FooForum", "Thread": "thread-{}".format(i)}
+            {"Forum": "FooForum", "Thread": f"thread-{i}"}
         )
     print("conn.batch_write_items...")
     conn.batch_write_item(

--- a/tests/integration/model_integration_test.py
+++ b/tests/integration/model_integration_test.py
@@ -68,26 +68,26 @@ def test_model_integration(ddb_url):
     obj3.refresh()
 
     with TestModel.batch_write() as batch:
-        items = [TestModel('hash-{}'.format(x), '{}'.format(x)) for x in range(10)]
+        items = [TestModel(f'hash-{x}', f'{x}') for x in range(10)]
         for item in items:
             batch.save(item)
 
-    item_keys = [('hash-{}'.format(x), 'thread-{}'.format(x)) for x in range(10)]
+    item_keys = [(f'hash-{x}', f'thread-{x}') for x in range(10)]
 
     for item in TestModel.batch_get(item_keys):
         print(item)
 
     for item in TestModel.query('setitem', TestModel.thread.startswith('set')):
-        print("Query Item {}".format(item))
+        print(f"Query Item {item}")
 
     with TestModel.batch_write() as batch:
-        items = [TestModel('hash-{}'.format(x), '{}'.format(x)) for x in range(10)]
+        items = [TestModel(f'hash-{x}', f'{x}') for x in range(10)]
         for item in items:
             print("Batch delete")
             batch.delete(item)
 
     for item in TestModel.scan():
-        print("Scanned item: {}".format(item))
+        print(f"Scanned item: {item}")
 
     tstamp = datetime.now()
     query_obj = TestModel('query_forum', 'query_thread')
@@ -95,10 +95,10 @@ def test_model_integration(ddb_url):
     query_obj.save()
     query_obj.update([TestModel.view.add(1)])
     for item in TestModel.epoch_index.query(tstamp):
-        print("Item queried from index: {}".format(item))
+        print(f"Item queried from index: {item}")
 
     for item in TestModel.view_index.query('foo', TestModel.view > 0):
-        print("Item queried from index: {}".format(item.view))
+        print(f"Item queried from index: {item.view}")
 
     print(query_obj.update([TestModel.view.add(1)], condition=TestModel.forum.exists()))
     TestModel.delete_table()

--- a/tests/integration/table_integration_test.py
+++ b/tests/integration/table_integration_test.py
@@ -135,7 +135,7 @@ def test_table_integration(ddb_url):
     items = []
     for i in range(10):
         items.append(
-            {"Forum": "FooForum", "Thread": "thread-{}".format(i)}
+            {"Forum": "FooForum", "Thread": f"thread-{i}"}
         )
     print("conn.batch_write_items...")
     conn.batch_write_item(

--- a/tests/mypy_helpers.py
+++ b/tests/mypy_helpers.py
@@ -15,7 +15,7 @@ def _run_mypy(program: str, *, use_pdb: bool) -> Iterable[str]:
     import mypy.api
 
     with TemporaryDirectory() as tempdirname:
-        with open('{}/__main__.py'.format(tempdirname), 'w') as f:
+        with open(f'{tempdirname}/__main__.py', 'w') as f:
             f.write(program)
         error_pattern = re.compile(fr'^{re.escape(f.name)}:'
                                    r'(?P<line>\d+): (?P<level>note|warning|error): (?P<message>.*)$')

--- a/tests/test_base_connection.py
+++ b/tests/test_base_connection.py
@@ -72,7 +72,7 @@ class ConnectionTestCase(TestCase):
         conn = Connection(host='http://foohost')
         self.assertIsNotNone(conn.client)
         self.assertIsNotNone(conn)
-        self.assertEqual(repr(conn), "Connection<{}>".format(conn.host))
+        self.assertEqual(repr(conn), f"Connection<{conn.host}>")
 
     def test_subsequent_client_is_not_cached_when_credentials_none(self):
         with patch('pynamodb.connection.Connection.session') as session_mock:
@@ -932,7 +932,7 @@ class ConnectionTestCase(TestCase):
         table_name = 'Thread'
         for i in range(10):
             items.append(
-                {"ForumName": "FooForum", "Subject": "thread-{}".format(i)}
+                {"ForumName": "FooForum", "Subject": f"thread-{i}"}
             )
         self.assertRaises(
             ValueError,
@@ -1066,7 +1066,7 @@ class ConnectionTestCase(TestCase):
         table_name = 'Thread'
         for i in range(10):
             items.append(
-                {"ForumName": "FooForum", "Subject": "thread-{}".format(i)}
+                {"ForumName": "FooForum", "Subject": f"thread-{i}"}
             )
         with patch(PATCH_METHOD) as req:
             req.return_value = DESCRIBE_TABLE_DATA

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -477,14 +477,14 @@ class ModelTestCase(TestCase):
         This function allows both the lists and dictionaries to have any order
         """
         if len(list1) != len(list2):
-            raise AssertionError("Values not equal: {} {}".format(list1, list2))
+            raise AssertionError(f"Values not equal: {list1} {list2}")
         for d1_item in list1:
             found = False
             for d2_item in list2:
                 if d2_item == d1_item:
                     found = True
             if not found:
-                raise AssertionError("Values not equal: {} {}".format(list1, list2))
+                raise AssertionError(f"Values not equal: {list1} {list2}")
 
     def test_create_model(self):
         """
@@ -658,12 +658,12 @@ class ModelTestCase(TestCase):
         self.assertEqual(item.email, 'needs_email')
         self.assertEqual(item.callable_field, 42)
         self.assertEqual(
-            repr(item), '{}<{}, {}>'.format(UserModel.Meta.table_name, item.custom_user_name, item.user_id)
+            repr(item), f'{UserModel.Meta.table_name}<{item.custom_user_name}, {item.user_id}>'
         )
 
         self.init_table_meta(SimpleUserModel, SIMPLE_MODEL_TABLE_DATA)
         item = SimpleUserModel('foo')
-        self.assertEqual(repr(item), '{}<{}>'.format(SimpleUserModel.Meta.table_name, item.user_name))
+        self.assertEqual(repr(item), f'{SimpleUserModel.Meta.table_name}<{item.user_name}>')
         self.assertRaises(ValueError, item.save)
 
         self.assertRaises(ValueError, UserModel.from_raw_data, None)
@@ -1211,7 +1211,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(5):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
 
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
@@ -1228,7 +1228,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(5):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
 
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
@@ -1245,7 +1245,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(30):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
 
             req.side_effect = [
@@ -1273,7 +1273,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(30):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
 
             req.side_effect = [
@@ -1301,7 +1301,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(30):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
 
             req.side_effect = [
@@ -1328,7 +1328,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(30):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
 
             req.side_effect = [
@@ -1356,7 +1356,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(30):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
 
             req.side_effect = [
@@ -1385,7 +1385,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -1400,7 +1400,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -1412,7 +1412,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -1424,7 +1424,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -1436,7 +1436,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -1448,7 +1448,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -1460,7 +1460,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -1503,7 +1503,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -1550,7 +1550,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(30):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
 
             req.side_effect = [
@@ -1613,7 +1613,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             scanned_items = []
@@ -1655,7 +1655,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{0}'.format(idx)}
+                item['user_id'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             for item in UserModel.scan(
@@ -1767,7 +1767,7 @@ class ModelTestCase(TestCase):
 
         with patch(PATCH_METHOD) as req:
             req.return_value = SIMPLE_BATCH_GET_ITEMS
-            item_keys = ['hash-{}'.format(x) for x in range(10)]
+            item_keys = [f'hash-{x}' for x in range(10)]
             for item in SimpleUserModel.batch_get(item_keys):
                 self.assertIsNotNone(item)
             params = {
@@ -1793,7 +1793,7 @@ class ModelTestCase(TestCase):
 
         with patch(PATCH_METHOD) as req:
             req.return_value = SIMPLE_BATCH_GET_ITEMS
-            item_keys = ['hash-{}'.format(x) for x in range(10)]
+            item_keys = [f'hash-{x}' for x in range(10)]
             for item in SimpleUserModel.batch_get(item_keys, attributes_to_get=['numbers']):
                 self.assertIsNotNone(item)
             params = {
@@ -1823,7 +1823,7 @@ class ModelTestCase(TestCase):
 
         with patch(PATCH_METHOD) as req:
             req.return_value = SIMPLE_BATCH_GET_ITEMS
-            item_keys = ['hash-{}'.format(x) for x in range(10)]
+            item_keys = [f'hash-{x}' for x in range(10)]
             for item in SimpleUserModel.batch_get(item_keys, consistent_read=True):
                 self.assertIsNotNone(item)
             params = {
@@ -1851,7 +1851,7 @@ class ModelTestCase(TestCase):
         self.init_table_meta(UserModel, MODEL_TABLE_DATA)
 
         with patch(PATCH_METHOD) as req:
-            item_keys = [('hash-{}'.format(x), '{}'.format(x)) for x in range(10)]
+            item_keys = [(f'hash-{x}', f'{x}') for x in range(10)]
             item_keys_copy = list(item_keys)
             req.return_value = BATCH_GET_ITEMS
             for item in UserModel.batch_get(item_keys):
@@ -1906,7 +1906,7 @@ class ModelTestCase(TestCase):
         batch_get_mock.side_effect = fake_batch_get
 
         with patch(PATCH_METHOD, new=batch_get_mock) as req:
-            item_keys = [('hash-{}'.format(x), '{}'.format(x)) for x in range(200)]
+            item_keys = [(f'hash-{x}', f'{x}') for x in range(200)]
             for item in UserModel.batch_get(item_keys):
                 self.assertIsNotNone(item)
 
@@ -1926,30 +1926,30 @@ class ModelTestCase(TestCase):
 
             with self.assertRaises(ValueError):
                 with UserModel.batch_write(auto_commit=False) as batch:
-                    items = [UserModel('hash-{}'.format(x), '{}'.format(x)) for x in range(26)]
+                    items = [UserModel(f'hash-{x}', f'{x}') for x in range(26)]
                     for item in items:
                         batch.delete(item)
                     self.assertRaises(ValueError, batch.save, UserModel('asdf', '1234'))
 
             with UserModel.batch_write(auto_commit=False) as batch:
-                items = [UserModel('hash-{}'.format(x), '{}'.format(x)) for x in range(25)]
+                items = [UserModel(f'hash-{x}', f'{x}') for x in range(25)]
                 for item in items:
                     batch.delete(item)
                 self.assertRaises(ValueError, batch.save, UserModel('asdf', '1234'))
 
             with UserModel.batch_write(auto_commit=False) as batch:
-                items = [UserModel('hash-{}'.format(x), '{}'.format(x)) for x in range(25)]
+                items = [UserModel(f'hash-{x}', f'{x}') for x in range(25)]
                 for item in items:
                     batch.save(item)
                 self.assertRaises(ValueError, batch.save, UserModel('asdf', '1234'))
 
             with UserModel.batch_write() as batch:
-                items = [UserModel('hash-{}'.format(x), '{}'.format(x)) for x in range(30)]
+                items = [UserModel(f'hash-{x}', f'{x}') for x in range(30)]
                 for item in items:
                     batch.delete(item)
 
             with UserModel.batch_write() as batch:
-                items = [UserModel('hash-{}'.format(x), '{}'.format(x)) for x in range(30)]
+                items = [UserModel(f'hash-{x}', f'{x}') for x in range(30)]
                 for item in items:
                     batch.save(item)
 
@@ -1961,7 +1961,7 @@ class ModelTestCase(TestCase):
         for idx in range(10):
             items.append(UserModel(
                 'daniel',
-                '{}'.format(idx),
+                f'{idx}',
                 picture=picture_blob,
             ))
 
@@ -1971,7 +1971,7 @@ class ModelTestCase(TestCase):
                 'PutRequest': {
                     'Item': {
                         'custom_username': {STRING: 'daniel'},
-                        'user_id': {STRING: '{}'.format(idx)},
+                        'user_id': {STRING: f'{idx}'},
                         'picture': {BINARY: base64.b64encode(picture_blob).decode(DEFAULT_ENCODING)}
                     }
                 }
@@ -2002,7 +2002,7 @@ class ModelTestCase(TestCase):
         items = []
         for idx in range(10):
             items.append(BatchModel(
-                '{}'.format(idx)
+                f'{idx}'
             ))
 
         unprocessed_items = []
@@ -2057,8 +2057,8 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_name'] = {STRING: 'id-{}'.format(idx)}
-                item['email'] = {STRING: 'id-{}'.format(idx)}
+                item['user_name'] = {STRING: f'id-{idx}'}
+                item['email'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -2092,8 +2092,8 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_name'] = {STRING: 'id-{}'.format(idx)}
-                item['email'] = {STRING: 'id-{}'.format(idx)}
+                item['user_name'] = {STRING: f'id-{idx}'}
+                item['email'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -2134,7 +2134,7 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_name'] = {STRING: 'id-{}'.format(idx)}
+                item['user_name'] = {STRING: f'id-{idx}'}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}
             queried = []
@@ -2430,8 +2430,8 @@ class ModelTestCase(TestCase):
             items = []
             for idx in range(10):
                 item = copy.copy(GET_MODEL_ITEM_DATA.get(ITEM))
-                item['user_id'] = {STRING: 'id-{}'.format(idx)}
-                item['email'] = {STRING: 'email-{}'.format(random.randint(0, 65536))}
+                item['user_id'] = {STRING: f'id-{idx}'}
+                item['email'] = {STRING: f'email-{random.randint(0, 65536)}'}
                 item['picture'] = {BINARY: BINARY_ATTR_DATA}
                 items.append(item)
             req.return_value = {'Count': len(items), 'ScannedCount': len(items), 'Items': items}

--- a/tests/test_table_connection.py
+++ b/tests/test_table_connection.py
@@ -384,7 +384,7 @@ class ConnectionTestCase(TestCase):
         conn = TableConnection(self.test_table_name)
         for i in range(10):
             items.append(
-                {"ForumName": "FooForum", "Subject": "thread-{}".format(i)}
+                {"ForumName": "FooForum", "Subject": f"thread-{i}"}
             )
         with patch(PATCH_METHOD) as req:
             req.return_value = DESCRIBE_TABLE_DATA
@@ -421,7 +421,7 @@ class ConnectionTestCase(TestCase):
         conn = TableConnection(self.test_table_name)
         for i in range(10):
             items.append(
-                {"ForumName": "FooForum", "Subject": "thread-{}".format(i)}
+                {"ForumName": "FooForum", "Subject": f"thread-{i}"}
             )
         with patch(PATCH_METHOD) as req:
             req.return_value = DESCRIBE_TABLE_DATA


### PR DESCRIPTION
I've used [flynt](https://github.com/ikamensh/flynt) to convert the source to use f-strings:
```
Execution time:                            1.278s
Files modified:                            19
Character count reduction:                 1400 (0.22%)

Per expression type:
No old style (`%`) expressions attempted.
`.format(...)` calls attempted:            169/170 (99.4%)
No concatenations attempted.
F-string expressions created:              158
```
Since unit tests only run for python 3.6+, I gathered this should be acceptable for the dependencies.

I've also done a manual change in a place where f-string wouldn't be created automatically:

`"{0} is not a valid comparison operator: {0}".format(operator)`
-> `"{operator} is not a valid comparison operator."`
