### PR TITLE
Add support for JSON serialization.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 Unreleased
 ----------
 * The ``IndexMeta`` class has been removed. Now ``type(Index) == type``.
+* JSON serialization support (``Model.to_json`` and ``Model.from_json``) has been added.
 
 
 v5.1.0

--- a/pynamodb/util.py
+++ b/pynamodb/util.py
@@ -1,0 +1,50 @@
+"""
+Utils
+"""
+import json
+from typing import Any
+from typing import Dict
+
+from pynamodb.constants import BINARY
+from pynamodb.constants import BINARY_SET
+from pynamodb.constants import BOOLEAN
+from pynamodb.constants import LIST
+from pynamodb.constants import MAP
+from pynamodb.constants import NULL
+from pynamodb.constants import NUMBER
+from pynamodb.constants import NUMBER_SET
+from pynamodb.constants import STRING
+from pynamodb.constants import STRING_SET
+
+
+def attribute_value_to_json(attribute_value: Dict[str, Any]) -> Any:
+    attr_type, attr_value = next(iter(attribute_value.items()))
+    if attr_type == LIST:
+        return [attribute_value_to_json(v) for v in attr_value]
+    if attr_type == MAP:
+        return {k: attribute_value_to_json(v) for k, v in attr_value.items()}
+    if attr_type == NULL:
+        return None
+    if attr_type in {BINARY, BINARY_SET, BOOLEAN, STRING, STRING_SET}:
+        return attr_value
+    if attr_type == NUMBER:
+        return json.loads(attr_value)
+    if attr_type == NUMBER_SET:
+        return [json.loads(v) for v in attr_value]
+    raise ValueError("Unknown attribute type: {}".format(attr_type))
+
+
+def json_to_attribute_value(value: Any) -> Dict[str, Any]:
+    if value is None:
+        return {NULL: True}
+    if value is True or value is False:
+        return {BOOLEAN: value}
+    if isinstance(value, (int, float)):
+        return {NUMBER: json.dumps(value)}
+    if isinstance(value, str):
+        return {STRING: value}
+    if isinstance(value, list):
+        return {LIST: [json_to_attribute_value(v) for v in value]}
+    if isinstance(value, dict):
+        return {MAP: {k: json_to_attribute_value(v) for k, v in value.items()}}
+    raise ValueError("Unknown value type: {}".format(type(value).__name__))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2528,6 +2528,40 @@ class ModelTestCase(TestCase):
         with self.assertRaises(AttributeError):
             MissingTableNameModel.exists()
 
+    def test_to_json(self):
+        """
+        Model.to_json
+        """
+        user = UserModel()
+        user.custom_user_name = 'foo'
+        user.user_id = 'bar'
+        user.picture = base64.b64decode(BINARY_ATTR_DATA)
+        user.zip_code = 88030
+        json_user = json.loads(user.to_json())
+        self.assertEqual(json_user['user_name'], user.custom_user_name)  # uses custom attribute name
+        self.assertEqual(json_user['user_id'], user.user_id)
+        self.assertEqual(json_user['picture'], BINARY_ATTR_DATA)
+        self.assertEqual(json_user['zip_code'], user.zip_code)
+        self.assertEqual(json_user['email'], 'needs_email')  # set to default value
+
+    def test_from_json(self):
+        """
+        Model.from_json
+        """
+        json_user = {
+            'user_name': 'foo',
+            'user_id': 'bar',
+            'picture': BINARY_ATTR_DATA,
+            'zip_code': 88030,
+        }
+        user = UserModel()
+        user.from_json(json.dumps(json_user))
+        self.assertEqual(user.custom_user_name, json_user['user_name'])  # uses custom attribute name
+        self.assertEqual(user.user_id, json_user['user_id'])
+        self.assertEqual(user.picture, base64.b64decode(json_user['picture']))
+        self.assertEqual(user.zip_code, json_user['zip_code'])
+        self.assertEqual(user.email, 'needs_email')  # set to default value
+
     def _get_office_employee(self):
         justin = Person(
             fname='Justin',


### PR DESCRIPTION
Model instances now support two types of serialization:
- `serialize/deserialize` can be used to convert models to DynamoDB AttributeValue dictionaries
- `to_json/from_json` can be used to convert models to JSON strings