### PR TITLE
Partial support for model inheritence backed by different tables. Fixes #361

### DIFF
--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -31,8 +31,6 @@ class TableConnection:
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
     ) -> None:
-        self._hash_keyname = None
-        self._range_keyname = None
         self.table_name = table_name
         self.connection = Connection(region=region,
                                      host=host,

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1009,6 +1009,8 @@ class Model(AttributeContainer, metaclass=MetaModel):
                     cls.__module__, cls.__name__,
                 ),
             )
+        # For now we just check that the connection exists and (in the case of model inheritance)
+        # points to the same table. In the future we should update the connection if any of the attributes differ.
         if cls._connection is None or cls._connection.table_name != cls.Meta.table_name:
             cls._connection = TableConnection(cls.Meta.table_name,
                                               region=cls.Meta.region,

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1009,7 +1009,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
                     cls.__module__, cls.__name__,
                 ),
             )
-        if cls._connection is None:
+        if cls._connection is None or cls._connection.table_name != cls.Meta.table_name:
             cls._connection = TableConnection(cls.Meta.table_name,
                                               region=cls.Meta.region,
                                               host=cls.Meta.host,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3256,3 +3256,18 @@ class ModelInitTestCase(TestCase):
         class ChildModel(ParentModel):
             pass
         self.assertEqual(ParentModel.Meta.table_name, ChildModel.Meta.table_name)
+
+    def test_connection_inheritance(self):
+        class Foo(Model):
+            class Meta:
+                table_name = 'foo'
+        class Bar(Foo):
+            class Meta:
+                table_name = 'bar'
+        class Baz(Foo):
+            pass
+        assert Foo._get_connection() is not Bar._get_connection()
+        assert Foo._get_connection() is Baz._get_connection()
+        self.assertEqual(Foo._get_connection().table_name, Foo.Meta.table_name)
+        self.assertEqual(Bar._get_connection().table_name, Bar.Meta.table_name)
+        self.assertEqual(Baz._get_connection().table_name, Baz.Meta.table_name)


### PR DESCRIPTION
This is very much an incomplete hack. This will support the use case in #361 for models with different tables;
however, inheritance of the same table but with other attributes differing (e.g. region) are still not supported.