### PR TITLE
Introduce DynamicMapAttribute

### DIFF
--- a/docs/attributes.rst
+++ b/docs/attributes.rst
@@ -193,6 +193,8 @@ These attributes can then be used inside of Model classes just like any other at
         make = UnicodeAttribute(null=False)
         model = UnicodeAttribute(null=True)
 
+`As with a model and its top-level attributes <https://github.com/pynamodb/PynamoDB/blob/master/docs/quickstart.rst#changing-items>`_, a PynamoDB MapAttribute will ignore sub-attributes it does not know about during deserialization. As a result, if the item in DynamoDB contains sub-attributes not declared as properties of the corresponding MapAttribute, save() will cause those sub-attributes to be deleted.
+
 ``DynamicMapAttribute`` is a subclass of ``MapAttribute`` which allows you to mix and match defined attributes and undefined attributes.
 
 .. code-block:: python
@@ -206,4 +208,3 @@ These attributes can then be used inside of Model classes just like any other at
     car = CarInfo(make='Make-A', model='Model-A', year=1975)
     other_car = CarInfo(make='Make-A', model='Model-A', year=1975, seats=3)
 
-`As with a model and its top-level attributes <https://github.com/pynamodb/PynamoDB/blob/master/docs/quickstart.rst#changing-items>`_, a PynamoDB MapAttribute will ignore sub-attributes it does not know about during deserialization. As a result, if the item in DynamoDB contains sub-attributes not declared as properties of the corresponding MapAttribute, save() will cause those sub-attributes to be deleted.

--- a/docs/attributes.rst
+++ b/docs/attributes.rst
@@ -193,4 +193,17 @@ These attributes can then be used inside of Model classes just like any other at
         make = UnicodeAttribute(null=False)
         model = UnicodeAttribute(null=True)
 
+``DynamicMapAttribute`` is a subclass of ``MapAttribute`` which allows you to mix and match defined attributes and undefined attributes.
+
+.. code-block:: python
+
+    from pynamodb.attributes import DynamicMapAttribute, UnicodeAttribute
+
+    class CarInfo(DynamicMapAttribute):
+        make = UnicodeAttribute(null=False)
+        model = UnicodeAttribute(null=True)
+
+    car = CarInfo(make='Make-A', model='Model-A', year=1975)
+    other_car = CarInfo(make='Make-A', model='Model-A', year=1975, seats=3)
+
 `As with a model and its top-level attributes <https://github.com/pynamodb/PynamoDB/blob/master/docs/quickstart.rst#changing-items>`_, a PynamoDB MapAttribute will ignore sub-attributes it does not know about during deserialization. As a result, if the item in DynamoDB contains sub-attributes not declared as properties of the corresponding MapAttribute, save() will cause those sub-attributes to be deleted.

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -1016,7 +1016,11 @@ class DynamicMapAttribute(MapAttribute):
             instance.attribute_values = {}  # clear any defaults
             instance._set_attributes(**values)
             values = instance
+        # this serializes the class defined attributes.
+        # we do this first because we have type checks that validate the data
         rval = AttributeContainer._container_serialize(values, null_check=null_check)
+        # this serializes the dynamically defined attributes
+        # we have no real type safety here so we have to dynamically construct the type to write to dynamo
         for attr_name in values:
             if attr_name not in self.get_attributes():
                 v = values[attr_name]
@@ -1031,7 +1035,10 @@ class DynamicMapAttribute(MapAttribute):
         return rval
 
     def deserialize(self, values):
+        # this deserializes the class defined attributes
+        # we do this first so that the we populate the defined object attributes fields properly with type safety
         instance = self._instantiate(values)
+        # this deserializes the dynamically defined attributes
         for attr_name, value in values.items():
             if instance._dynamo_to_python_attr(attr_name) not in instance.get_attributes():
                 attr_type, attr_value = next(iter(value.items()))

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -1004,7 +1004,10 @@ class DynamicMapAttribute(MapAttribute):
 
     def __setattr__(self, name, value):
         # Set attributes via the Attribute descriptor if it exists.
-        object.__setattr__(self, name, value) if name in self.get_attributes() else super().__setattr__(name, value)
+        if name in self.get_attributes():
+            object.__setattr__(self, name, value)
+        else:
+            super().__setattr__(name, value)
 
     def serialize(self, values):
         if not isinstance(values, type(self)):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -862,20 +862,20 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
         # If this instance is being used as an Attribute, treat item access like the map dereference operator.
         # This provides equivalence between DynamoDB's nested attribute access for map elements (MyMap.nestedField)
         # and Python's item access for dictionaries (MyMap['nestedField']).
-        if self.is_raw():
-            return Path(self.attr_path + [str(item)])  # type: ignore
-        elif item in self._attributes:  # type: ignore
+        if item in self.get_attributes():
             return getattr(self, item)
+        elif self.is_raw():
+            return Path(self.attr_path + [str(item)])  # type: ignore
         else:
             raise AttributeError("'{}' has no attribute '{}'".format(self.__class__.__name__, item))
 
     def __setitem__(self, item, value):
         if not self._is_attribute_container():
             raise TypeError("'{}' object does not support item assignment".format(self.__class__.__name__))
-        if self.is_raw():
-            self.attribute_values[item] = value
-        elif item in self._attributes:  # type: ignore
+        if item in self.get_attributes():
             setattr(self, item, value)
+        elif self.is_raw():
+            self.attribute_values[item] = value
         else:
             raise AttributeError("'{}' has no attribute '{}'".format(self.__class__.__name__, item))
 
@@ -986,6 +986,59 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
         for key, value in self.attribute_values.items():
             result[key] = value.as_dict() if isinstance(value, MapAttribute) else value
         return result
+
+
+class DynamicMapAttribute(MapAttribute):
+    """
+    A map attribute that supports declaring attributes (like an AttributeContainer) but will also store
+    any other values that are set on it (like a raw MapAttribute).
+
+    >>> class MyDynamicMapAttribute(DynamicMapAttribute):
+    >>>     a_date_time = UTCDateTimeAttribute()  # raw map attributes cannot serialize/deserialize datetime values
+    >>>
+    >>> dynamic_map = MyDynamicMapAttribute()
+    >>> dynamic_map.a_date_time = datetime.utcnow()
+    >>> dynamic_map.a_number = 5
+    >>> dynamic_map.serialize()  # {'a_date_time': {'S': 'xxx'}, 'a_number': {'N': '5'}}
+    """
+
+    def __setattr__(self, name, value):
+        # Set attributes via the Attribute descriptor if it exists.
+        object.__setattr__(self, name, value) if name in self.get_attributes() else super().__setattr__(name, value)
+
+    def serialize(self, values):
+        if not isinstance(values, type(self)):
+            # Copy the values onto an instance of the class for serialization.
+            instance = type(self)()
+            instance.attribute_values = {}  # clear any defaults
+            instance._set_attributes(**values)
+            values = instance
+        rval = AttributeContainer.serialize(values)
+        for attr_name in values:
+            if attr_name not in self.get_attributes():
+                v = values[attr_name]
+                attr_class = _get_class_for_serialize(v)
+                attr_type = attr_class.attr_type
+                attr_value = attr_class.serialize(v)
+                if attr_value is None:
+                    # When attribute values serialize to "None" (e.g. empty sets) we store {"NULL": True} in DynamoDB.
+                    attr_type = NULL
+                    attr_value = True
+                rval[attr_name] = {attr_type: attr_value}
+        return rval
+
+    def deserialize(self, values):
+        instance = self._instantiate(values)
+        for attr_name, value in values.items():
+            if instance._dynamo_to_python_attr(attr_name) not in instance.get_attributes():
+                attr_type, attr_value = next(iter(value.items()))
+                instance[attr_name] = DESERIALIZE_CLASS_MAP[attr_type].deserialize(attr_value)
+        return instance
+
+    @classmethod
+    def is_raw(cls):
+        # All subclasses of DynamicMapAttribute should be treated like "raw" map attributes.
+        return True
 
 
 def _get_class_for_serialize(value):

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -1009,14 +1009,14 @@ class DynamicMapAttribute(MapAttribute):
         else:
             super().__setattr__(name, value)
 
-    def serialize(self, values):
+    def serialize(self, values, *, null_check: bool = True):
         if not isinstance(values, type(self)):
             # Copy the values onto an instance of the class for serialization.
             instance = type(self)()
             instance.attribute_values = {}  # clear any defaults
             instance._set_attributes(**values)
             values = instance
-        rval = AttributeContainer.serialize(values)
+        rval = AttributeContainer._container_serialize(values, null_check=null_check)
         for attr_name in values:
             if attr_name not in self.get_attributes():
                 v = values[attr_name]

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -891,7 +891,7 @@ class TestDynamicMapAttribute:
 
     def test_serialize(self):
         test_model = TestDynamicMapAttribute.TestModel()
-        test_model.test_map.created_at = datetime(2017, 1, 1)
+        test_model.test_map.created_at = datetime(2017, 1, 1, tzinfo=timezone.utc)
         test_model.test_map.foo = 'bar'
         test_model.test_map.empty = None
         assert test_model.serialize() == {'test_map': {'M': {
@@ -908,7 +908,7 @@ class TestDynamicMapAttribute:
         }}}
         test_model = TestDynamicMapAttribute.TestModel()
         test_model.deserialize(serialized)
-        assert test_model.test_map.created_at == datetime(2017, 1, 1)
+        assert test_model.test_map.created_at == datetime(2017, 1, 1, tzinfo=timezone.utc)
         assert test_model.test_map.foo == 'bar'
         assert test_model.test_map.empty is None
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -884,13 +884,13 @@ class TestMapAttribute:
 
 class TestDynamicMapAttribute:
 
-    class TestModel(Model):
+    class CreatedAtTestModel(Model):
         class CreatedAtMap(DynamicMapAttribute):
             created_at = UTCDateTimeAttribute()
         test_map = CreatedAtMap(default=dict)
 
     def test_serialize(self):
-        test_model = TestDynamicMapAttribute.TestModel()
+        test_model = TestDynamicMapAttribute.CreatedAtTestModel()
         test_model.test_map.created_at = datetime(2017, 1, 1, tzinfo=timezone.utc)
         test_model.test_map.foo = 'bar'
         test_model.test_map.empty = None
@@ -906,7 +906,7 @@ class TestDynamicMapAttribute:
             'foo': {'S': 'bar'},
             'empty': {'NULL': True},
         }}}
-        test_model = TestDynamicMapAttribute.TestModel()
+        test_model = TestDynamicMapAttribute.CreatedAtTestModel()
         test_model.deserialize(serialized)
         assert test_model.test_map.created_at == datetime(2017, 1, 1, tzinfo=timezone.utc)
         assert test_model.test_map.foo == 'bar'

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -12,7 +12,7 @@ from unittest.mock import patch, call
 import pytest
 
 from pynamodb.attributes import (
-    BinarySetAttribute, BinaryAttribute, NumberSetAttribute, NumberAttribute,
+    BinarySetAttribute, BinaryAttribute, DynamicMapAttribute, NumberSetAttribute, NumberAttribute,
     UnicodeAttribute, UnicodeSetAttribute, UTCDateTimeAttribute, BooleanAttribute, MapAttribute,
     ListAttribute, JSONAttribute, TTLAttribute, VersionAttribute)
 from pynamodb.constants import (
@@ -880,6 +880,37 @@ class TestMapAttribute:
         outer_map_attribute = OuterMapAttribute(inner_map={'foo': 'bar'})
         serialized = outer_map_attribute.serialize(outer_map_attribute)
         assert serialized == {'inner_map': {'M': {'foo': {'S': 'bar'}}}}
+
+
+class TestDynamicMapAttribute:
+
+    class TestModel(Model):
+        class CreatedAtMap(DynamicMapAttribute):
+            created_at = UTCDateTimeAttribute()
+        test_map = CreatedAtMap(default=dict)
+
+    def test_serialize(self):
+        test_model = TestDynamicMapAttribute.TestModel()
+        test_model.test_map.created_at = datetime(2017, 1, 1)
+        test_model.test_map.foo = 'bar'
+        test_model.test_map.empty = None
+        assert test_model.serialize() == {'test_map': {'M': {
+            'created_at': {'S': '2017-01-01T00:00:00.000000+0000'},
+            'foo': {'S': 'bar'},
+            'empty': {'NULL': True},
+        }}}
+
+    def test_deserialize(self):
+        serialized = {'test_map': {'M': {
+            'created_at': {'S': '2017-01-01T00:00:00.000000+0000'},
+            'foo': {'S': 'bar'},
+            'empty': {'NULL': True},
+        }}}
+        test_model = TestDynamicMapAttribute.TestModel()
+        test_model.deserialize(serialized)
+        assert test_model.test_map.created_at == datetime(2017, 1, 1)
+        assert test_model.test_map.foo == 'bar'
+        assert test_model.test_map.empty is None
 
 
 class TestListAttribute:


### PR DESCRIPTION
DynamicMapAttribute is a map attribute that supports declaring attributes (like an AttributeContainer),
but will also store any other values that are set on it (like a raw MapAttribute).

This class lets you create a "partially typed" map attribute so that it can store items that are not just primitive python types.

```
>>> from datetime import datetime
>>> from pynamodb.attributes import DynamicMapAttribute
>>> from pynamodb.attributes import UTCDateTimeAttribute
>>> from pynamodb.models import Model
>>> 
>>> class CreatedAtMap(DynamicMapAttribute):
...     created_at = UTCDateTimeAttribute()
... 
>>> class MyModel(Model):
...     my_map = CreatedAtMap(default={})
... 
>>> my_model = MyModel()
>>> my_model.my_map.created_at = datetime.utcnow()
>>> my_model.my_map.foo = 'bar'
>>> my_model.serialize()
{'my_map': {'M': {'created_at': {'S': '2020-10-14T16:39:15.077254+0000'}, 'foo': {'S': 'bar'}}}}
>>> 
>>> my_model_2 = MyModel()
>>> my_model_2.deserialize({'my_map': {'M': {'created_at': {'S': '2020-10-14T16:39:15.077254+0000'}, 'foo': {'S': 'bar'}}}})
>>> my_model_2.my_map.created_at
datetime.datetime(2020, 10, 14, 16, 39, 15, 77254, tzinfo=datetime.timezone.utc)
>>> my_model_2.my_map.foo
'bar'
```