### PR TITLE
Allow VersionAttribute to operate on items with a version of zero

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -936,7 +936,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
         version_attribute = self.get_attributes()[self._version_attribute_name]
         version_attribute_value = getattr(self, self._version_attribute_name)
 
-        if version_attribute_value:
+        if version_attribute_value is not None:
             version_condition = version_attribute == version_attribute_value
             if actions:
                 actions.append(version_attribute.add(1))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,pypy,pypy3
+envlist = py36,py37,py38,pypy,pypy3
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
This PR will allow PynamoDB to read & update historical data (persisted using another python client library) whose initial version value is less than 1. 

Currently, `version = 0` is [treated the same](https://github.com/pynamodb/PynamoDB/blob/b42c326529f9043bafccf334eaa0c16ac610d795/pynamodb/models.py#L939) as `version = None`: PynamoDB will add [does_not_exist condition check](https://github.com/pynamodb/PynamoDB/blob/b42c326529f9043bafccf334eaa0c16ac610d795/pynamodb/models.py#L948) when persisting to DynamoDB and this leads to `ConditionalCheckFailedException` as the item already exists.
