### PR TITLE
New CompressedAttribute Type: a zlib-compressed binary attribute

### DIFF
--- a/docs/attributes.rst
+++ b/docs/attributes.rst
@@ -194,3 +194,16 @@ These attributes can then be used inside of Model classes just like any other at
         model = UnicodeAttribute(null=True)
 
 `As with a model and its top-level attributes <https://github.com/pynamodb/PynamoDB/blob/master/docs/quickstart.rst#changing-items>`_, a PynamoDB MapAttribute will ignore sub-attributes it does not know about during deserialization. As a result, if the item in DynamoDB contains sub-attributes not declared as properties of the corresponding MapAttribute, save() will cause those sub-attributes to be deleted.
+
+Compressed Attribute
+--------------------
+
+Compressed attributes use the zlib compression included in the Python standard library to more efficiently store binary attributes.
+The compression ratio depends on the data provided, but are `typically between 2:1 and 5:1 <https://www.zlib.net/zlib_tech.html#:~:text=More%20typical%20zlib%20compression%20ratios,%3A1%20to%205%3A.>` for real-world data.
+
+.. code-block:: python
+
+    from pynamodb.attributes import CompressedAttribute
+
+    class CarInfoMap(MapAttribute):
+        blob = CompressedAttribute()

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -7,6 +7,7 @@ import json
 import time
 import warnings
 from base64 import b64encode, b64decode
+import zlib
 from copy import deepcopy
 from datetime import datetime
 from datetime import timedelta
@@ -456,6 +457,25 @@ class BinaryAttribute(Attribute[bytes]):
         Returns a decoded byte string from a base64 encoded value
         """
         return b64decode(value)
+
+
+class CompressedAttribute(Attribute[bytes]):
+    """
+    A zlib-compressed binary attribute
+    """
+    attr_type = BINARY
+
+    def serialize(self, value):
+        """
+        Returns the compressed binary of the value
+        """
+        return zlib.compress(value)
+
+    def deserialize(self, value):
+        """
+        Returns a decoded byte string from a base64 encoded value
+        """
+        return zlib.decompress(value)
 
 
 class BinarySetAttribute(Attribute[Set[bytes]]):

--- a/tests/integration/binary_update_test.py
+++ b/tests/integration/binary_update_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pynamodb.attributes import UnicodeAttribute, BinaryAttribute, BinarySetAttribute
+from pynamodb.attributes import UnicodeAttribute, BinaryAttribute, BinarySetAttribute, CompressedAttribute
 from pynamodb.models import Model
 
 
@@ -23,6 +23,23 @@ def test_binary_attribute_update(ddb_url):
     new_data = b'\xff'
     m.update(actions=[DataModel.data.set(new_data)])
     assert new_data == m.data
+
+@pytest.mark.ddblocal
+def test_compressed_attribute_writes_large_items(ddb_url):
+    class DataModel(Model):
+        class Meta:
+            table_name = 'compressed_attr_update'
+            host = ddb_url
+        pkey = UnicodeAttribute(hash_key=True)
+        data = CompressedAttribute()
+
+    DataModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
+    # create a 1MB+ string of bytes to compress and put in the DB
+    data = bytes('1234567890' * 1024 * 1024, 'utf-8')
+    pkey = 'pkey'
+    DataModel(pkey, data=data).save()
+    m = DataModel.get(pkey)
+    assert m.data == data
 
 @pytest.mark.ddblocal
 def test_binary_set_attribute_update(ddb_url):


### PR DESCRIPTION
This commit adds CompressedAttribute, a zlib-compressed binary type to
support larger binary attrs than the 440K size limit would otherwise
allow. 