### PR TITLE
Fix type errors when deriving from a MapAttribute and another type

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+v5.0.1
+----------
+
+:date: 2021-02-10
+
+* Fix type errors when deriving from a MapAttribute and another type (#904)
+
+
 v5.0.0
 ----------
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ warn_unused_configs = True
 warn_redundant_casts = True
 warn_incomplete_stub = True
 follow_imports = normal
+show_error_codes = True
 
 # TODO: burn these down
 [mypy-tests.*]

--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '5.0.0'
+__version__ = '5.0.1'

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1120,7 +1120,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
             range_key = cls._range_key_attribute().serialize(range_key)
         return hash_key, range_key
 
-    def serialize(self, null_check=True) -> Dict[str, Dict[str, Any]]:
+    def serialize(self, null_check: bool = True) -> Dict[str, Dict[str, Any]]:
         """
         Serialize attribute values for DynamoDB
         """

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1120,6 +1120,18 @@ class Model(AttributeContainer, metaclass=MetaModel):
             range_key = cls._range_key_attribute().serialize(range_key)
         return hash_key, range_key
 
+    def serialize(self, null_check=True) -> Dict[str, Dict[str, Any]]:
+        """
+        Serialize attribute values for DynamoDB
+        """
+        return self._container_serialize(null_check=null_check)
+
+    def deserialize(self, attribute_values: Dict[str, Dict[str, Any]]) -> None:
+        """
+        Sets attributes sent back from DynamoDB on this object
+        """
+        return self._container_deserialize(attribute_values=attribute_values)
+
 
 class _ModelFuture(Generic[_T]):
     """

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -160,6 +160,7 @@ def test_paths(assert_mypy_output):
     reveal_type(MyModel.my_list[0] == MyModel())  # N: Revealed type is 'pynamodb.expressions.condition.Comparison'
     # the following string indexing is not type checked - not by mypy nor in runtime
     reveal_type(MyModel.my_list[0]['my_sub_attr'] == 'foobar')  # N: Revealed type is 'pynamodb.expressions.condition.Comparison'
+    reveal_type(MyModel.my_map == 'foobar')  # N: Revealed type is 'pynamodb.expressions.condition.Comparison'
     """)
 
 

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -203,3 +203,12 @@ def test_index_query_scan(assert_mypy_output):
     model = next(typed_result)
     not_model = next(typed_result)  # E: Incompatible types in assignment (expression has type "MyModel", variable has type "int")  [assignment]
     """)
+
+
+def test_map_attribute_derivation(assert_mypy_output):
+    assert_mypy_output("""
+    from pynamodb.attributes import MapAttribute
+
+    class MyMap(MapAttribute, object):
+        pass
+    """)


### PR DESCRIPTION
Doing this:
```python
from pynamodb.attributes import MapAttribute

class MyMap(MapAttribute, object):  # <-- location of type error
    pass
```
would result in the following errors from mypy:
```
error: Definition of "__eq__" in base class "Attribute" is incompatible with definition in base class "AttributeContainer"
error: Definition of "serialize" in base class "Attribute" is incompatible with definition in base class "AttributeContainer"
```

The error is not shown in the simpler form:
```python
class MyMap(MapAttribute):
    pass
```

https://github.com/python/mypy/issues/10066