### PR TITLE
Do not serialize all attributes for updates and deletes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+v5.0.2
+----------
+
+:date: 2021-02-11
+
+* Do not serialize all attributes for updates and deletes (#905)
+
+
 v5.0.1
 ----------
 

--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '5.0.1'
+__version__ = '5.0.2'

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -434,7 +434,8 @@ class Model(AttributeContainer, metaclass=MetaModel):
         Save this object to dynamodb
         """
         args, kwargs = self._get_save_args(condition=condition)
-        data = self._get_connection().put_item(*args, settings=settings, **kwargs)
+        kwargs['settings'] = settings
+        data = self._get_connection().put_item(*args, **kwargs)
         self.update_local_version_attribute()
         return data
 
@@ -489,7 +490,9 @@ class Model(AttributeContainer, metaclass=MetaModel):
         return_values_on_condition_failure: Optional[str] = None,
     ) -> Dict[str, Any]:
         args, save_kwargs = self._get_save_args(null_check=True, condition=condition)
-        return self._get_connection().get_operation_kwargs(*args, key=ITEM, return_values_on_condition_failure=return_values_on_condition_failure, **save_kwargs)
+        save_kwargs['key'] = ITEM
+        save_kwargs['return_values_on_condition_failure'] = return_values_on_condition_failure
+        return self._get_connection().get_operation_kwargs(*args, **save_kwargs)
 
     @classmethod
     def get_operation_kwargs_from_class(

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -946,8 +946,8 @@ class Model(AttributeContainer, metaclass=MetaModel):
         return args, kwargs
 
     def _get_hash_range_key_serialized_values(self) -> Tuple[Any, Optional[Any]]:
-        if not self._hash_keyname:
-            raise RuntimeError
+        if self._hash_keyname is None:
+            raise Exception("The model has no hash key")
 
         attrs = self.get_attributes()
 

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -434,9 +434,6 @@ class Model(AttributeContainer, metaclass=MetaModel):
         Save this object to dynamodb
         """
         args, kwargs = self._get_save_args(condition=condition)
-        print('x' * 80)
-        print(args, kwargs)
-        print('x' * 80)
         data = self._get_connection().put_item(*args, settings=settings, **kwargs)
         self.update_local_version_attribute()
         return data

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -396,16 +396,14 @@ class Model(AttributeContainer, metaclass=MetaModel):
 
         :raises pynamodb.exceptions.DeleteError: If the record can not be deleted
         """
-        args, kwargs = self._get_save_args(attributes=False, null_check=False)
-        version_condition = self._handle_version_attribute(kwargs)
+        hk_value, rk_value = self._get_hash_range_key_serialized_values()
+        version_condition = self._get_version_attribute_condition()
         if version_condition is not None:
             condition &= version_condition
 
-        kwargs['condition'] = condition
-        kwargs['settings'] = settings
-        return self._get_connection().delete_item(*args, **kwargs)
+        return self._get_connection().delete_item(hk_value, range_key=rk_value, condition=condition, settings=settings)
 
-    def update(self, actions: Sequence[Action], condition: Optional[Condition] = None, settings: OperationSettings = OperationSettings.default) -> Any:
+    def update(self, actions: List[Action], condition: Optional[Condition] = None, settings: OperationSettings = OperationSettings.default) -> Any:
         """
         Updates an item using the UpdateItem operation.
 
@@ -418,21 +416,12 @@ class Model(AttributeContainer, metaclass=MetaModel):
         if not isinstance(actions, list) or len(actions) == 0:
             raise TypeError("the value of `actions` is expected to be a non-empty list")
 
-        args, save_kwargs = self._get_save_args(null_check=False)
-        version_condition = self._handle_version_attribute(save_kwargs, actions=actions)
+        hk_value, rk_value = self._get_hash_range_key_serialized_values()
+        version_condition = self._get_version_attribute_condition_for_update(actions)
         if version_condition is not None:
             condition &= version_condition
-        kwargs: Dict[str, Any] = {
-            'return_values': ALL_NEW,
-            'condition': condition,
-            'actions': actions,
-            'settings': settings,
-        }
 
-        if 'range_key' in save_kwargs:
-            kwargs['range_key'] = save_kwargs['range_key']
-
-        data = self._get_connection().update_item(*args, **kwargs)
+        data = self._get_connection().update_item(hk_value, range_key=rk_value, return_values=ALL_NEW, condition=condition, actions=actions, settings=settings)
         item_data = data[ATTRIBUTES]
         stored_cls = self._get_discriminator_class(item_data)
         if stored_cls and stored_cls != type(self):
@@ -445,7 +434,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
         Save this object to dynamodb
         """
         args, kwargs = self._get_save_args()
-        version_condition = self._handle_version_attribute(serialized_attributes=kwargs)
+        version_condition = self._get_version_attribute_condition_for_save(kwargs)
         if version_condition is not None:
             condition &= version_condition
         kwargs['condition'] = condition
@@ -462,10 +451,8 @@ class Model(AttributeContainer, metaclass=MetaModel):
         :param settings: per-operation settings
         :raises ModelInstance.DoesNotExist: if the object to be updated does not exist
         """
-        args, kwargs = self._get_save_args(attributes=False)
-        kwargs.setdefault('consistent_read', consistent_read)
-        kwargs['settings'] = settings
-        attrs = self._get_connection().get_item(*args, **kwargs)
+        hk_value, rk_value = self._get_hash_range_key_serialized_values()
+        attrs = self._get_connection().get_item(hk_value, range_key=rk_value, consistent_read=consistent_read, settings=settings)
         item_data = attrs.get(ITEM, None)
         if item_data is None:
             raise self.DoesNotExist("This item does not exist in the table.")
@@ -474,34 +461,51 @@ class Model(AttributeContainer, metaclass=MetaModel):
             raise ValueError("Cannot refresh this item from the returned class: {}".format(stored_cls.__name__))
         self.deserialize(item_data)
 
-    def get_operation_kwargs_from_instance(
+    def get_update_kwargs_from_instance(
         self,
-        key: str = KEY,
-        actions: Optional[Sequence[Action]] = None,
+        actions: List[Action],
         condition: Optional[Condition] = None,
         return_values_on_condition_failure: Optional[str] = None,
     ) -> Dict[str, Any]:
-        is_update = actions is not None
-        is_delete = actions is None and key is KEY
-        args, save_kwargs = self._get_save_args(null_check=not is_update)
+        hk_value, rk_value = self._get_hash_range_key_serialized_values()
 
-        version_condition = self._handle_version_attribute(
-            serialized_attributes={} if is_delete else save_kwargs,
-            actions=actions
-        )
+        version_condition = self._get_version_attribute_condition_for_update(actions)
+        if version_condition is not None:
+            condition &= version_condition
+
+        return self._get_connection().get_operation_kwargs(hk_value, key=KEY, actions=actions, condition=condition, return_values_on_condition_failure=return_values_on_condition_failure, range_key=rk_value)
+
+    def get_delete_kwargs_from_instance(
+        self,
+        condition: Optional[Condition] = None,
+        return_values_on_condition_failure: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        hk_value, rk_value = self._get_hash_range_key_serialized_values()
+
+        version_condition = self._get_version_attribute_condition()
+        if version_condition is not None:
+            condition &= version_condition
+
+        return self._get_connection().get_operation_kwargs(hk_value, key=KEY, condition=condition, return_values_on_condition_failure=return_values_on_condition_failure, range_key=rk_value)
+
+    def get_save_kwargs_from_instance(
+        self,
+        condition: Optional[Condition] = None,
+        return_values_on_condition_failure: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        args, save_kwargs = self._get_save_args(null_check=True)
+
+        version_condition = self._get_version_attribute_condition_for_save(save_kwargs)
         if version_condition is not None:
             condition &= version_condition
 
         kwargs: Dict[str, Any] = dict(
-            key=key,
-            actions=actions,
+            key=ITEM,
+            actions=None,
             condition=condition,
             return_values_on_condition_failure=return_values_on_condition_failure
         )
-        if not is_update:
-            kwargs.update(save_kwargs)
-        elif 'range_key' in save_kwargs:
-            kwargs['range_key'] = save_kwargs['range_key']
+        kwargs.update(save_kwargs)
         return self._get_connection().get_operation_kwargs(*args, **kwargs)
 
     @classmethod
@@ -928,16 +932,14 @@ class Model(AttributeContainer, metaclass=MetaModel):
                     cls._indexes['local_secondary_indexes'].append(idx)
         return cls._indexes
 
-    def _get_save_args(self, attributes=True, null_check=True):
+    def _get_save_args(self, null_check: bool = True) -> Tuple[Iterable[Any], Dict[str, Any]]:
         """
         Gets the proper *args, **kwargs for saving and retrieving this object
 
         This is used for serializing items to be saved, or for serializing just the keys.
 
-        :param attributes: If True, then attributes are included.
         :param null_check: If True, then attributes are checked for null.
         """
-        kwargs = {}
         attribute_values = self.serialize(null_check)
         hash_key_attribute = self._hash_key_attribute()
         hash_key = attribute_values.pop(hash_key_attribute.attr_name, {}).get(hash_key_attribute.attr_type)
@@ -946,18 +948,49 @@ class Model(AttributeContainer, metaclass=MetaModel):
         if range_key_attribute:
             range_key = attribute_values.pop(range_key_attribute.attr_name, {}).get(range_key_attribute.attr_type)
         args = (hash_key, )
+        kwargs = {}
         if range_key is not None:
             kwargs['range_key'] = range_key
-        if attributes:
-            kwargs['attributes'] = attribute_values
+        kwargs['attributes'] = attribute_values
         return args, kwargs
 
-    def _handle_version_attribute(self, serialized_attributes, actions=None):
+    def _get_hash_range_key_serialized_values(self) -> Tuple[Any, Optional[Any]]:
+        if not self._hash_keyname:
+            raise RuntimeError
+
+        attrs = self.get_attributes()
+
+        hk_value = getattr(self, self._hash_keyname)
+        hk_serialized_value = attrs[self._hash_keyname].serialize(hk_value)
+
+        rk_serialized_value = None
+        if self._range_keyname:
+            rk_value = getattr(self, self._range_keyname)
+            if rk_value is not None:
+                rk_serialized_value = attrs[self._range_keyname].serialize(rk_value)
+
+        return hk_serialized_value, rk_serialized_value
+
+    def _get_version_attribute_condition(self) -> Optional[Condition]:
+        """
+        Handles modifying the request to set or increment the version attribute.
+        """
+        if self._version_attribute_name is None:
+            return None
+
+        version_attribute = self.get_attributes()[self._version_attribute_name]
+        version_attribute_value = getattr(self, self._version_attribute_name)
+
+        if version_attribute_value is not None:
+            return version_attribute == version_attribute_value
+        else:
+            return version_attribute.does_not_exist()
+
+    def _get_version_attribute_condition_for_save(self, serialized_attributes) -> Optional[Condition]:
         """
         Handles modifying the request to set or increment the version attribute.
 
         :param serialized_attributes: A dictionary mapping attribute names to serialized values.
-        :param actions: A non-empty list when performing an update, otherwise None.
         """
         if self._version_attribute_name is None:
             return
@@ -967,20 +1000,35 @@ class Model(AttributeContainer, metaclass=MetaModel):
 
         if version_attribute_value is not None:
             version_condition = version_attribute == version_attribute_value
-            if actions:
-                actions.append(version_attribute.add(1))
-            elif 'attributes' in serialized_attributes:
-                serialized_attributes['attributes'][version_attribute.attr_name] = self._serialize_value(
-                    version_attribute, version_attribute_value + 1
-                )
+            serialized_attributes['attributes'][version_attribute.attr_name] = self._serialize_value(
+                version_attribute, version_attribute_value + 1
+            )
         else:
             version_condition = version_attribute.does_not_exist()
-            if actions:
-                actions.append(version_attribute.set(1))
-            elif 'attributes' in serialized_attributes:
-                serialized_attributes['attributes'][version_attribute.attr_name] = self._serialize_value(
-                    version_attribute, 1
-                )
+            serialized_attributes['attributes'][version_attribute.attr_name] = self._serialize_value(
+                version_attribute, 1
+            )
+
+        return version_condition
+
+    def _get_version_attribute_condition_for_update(self, actions: List[Action]) -> Optional[Condition]:
+        """
+        Handles modifying the request to set or increment the version attribute.
+
+        :param actions: A list of update actions
+        """
+        if self._version_attribute_name is None:
+            return
+
+        version_attribute = self.get_attributes()[self._version_attribute_name]
+        version_attribute_value = getattr(self, self._version_attribute_name)
+
+        if version_attribute_value is not None:
+            version_condition = version_attribute == version_attribute_value
+            actions.append(version_attribute.add(1))
+        else:
+            version_condition = version_attribute.does_not_exist()
+            actions.append(version_attribute.set(1))
 
         return version_condition
 

--- a/pynamodb/transactions.py
+++ b/pynamodb/transactions.py
@@ -100,12 +100,11 @@ class TransactWrite(Transaction):
         self._condition_check_items.append(operation_kwargs)
 
     def delete(self, model: _M, condition: Optional[Condition] = None) -> None:
-        operation_kwargs = model.get_operation_kwargs_from_instance(condition=condition)
+        operation_kwargs = model.get_delete_kwargs_from_instance(condition=condition)
         self._delete_items.append(operation_kwargs)
 
     def save(self, model: _M, condition: Optional[Condition] = None, return_values: Optional[str] = None) -> None:
-        operation_kwargs = model.get_operation_kwargs_from_instance(
-            key=ITEM,
+        operation_kwargs = model.get_save_kwargs_from_instance(
             condition=condition,
             return_values_on_condition_failure=return_values
         )
@@ -113,7 +112,7 @@ class TransactWrite(Transaction):
         self._models_for_version_attribute_update.append(model)
 
     def update(self, model: _M, actions: List[Action], condition: Optional[Condition] = None, return_values: Optional[str] = None) -> None:
-        operation_kwargs = model.get_operation_kwargs_from_instance(
+        operation_kwargs = model.get_update_kwargs_from_instance(
             actions=actions,
             condition=condition,
             return_values_on_condition_failure=return_values

--- a/tests/integration/model_integration_test.py
+++ b/tests/integration/model_integration_test.py
@@ -55,9 +55,9 @@ def test_model_integration(ddb_url):
         scores = NumberSetAttribute()
         version = VersionAttribute()
 
-    if not TestModel.exists():
-        print("Creating table")
-        TestModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
+    if TestModel.exists():
+        TestModel.delete_table()
+    TestModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
 
     obj = TestModel('1', '2')
     obj.save()
@@ -104,7 +104,6 @@ def test_model_integration(ddb_url):
 
     print(query_obj.update([TestModel.view.add(1)], condition=TestModel.forum.exists()))
     TestModel.delete_table()
-
 
 
 def test_can_inherit_version_attribute(ddb_url) -> None:


### PR DESCRIPTION
Not only it is more efficient not to serialize attributes you don't need, it also manifested in an issue where an `update` operation would fail null-checks on attributes that are not even affected by the update -- see added `test_update_doesnt_do_validation_on_null_attributes` test.

p.s. this uncovered another bug where we fail to propagate `null_checks=True` through MapAttributes, but we'll address it separately