### PR TITLE
Propagate null_check flag when serializing nested MapAttributes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+v5.0.3
+----------
+
+:date: 2021-02-14
+
+* Propagate ``Model.serialize``'s ``null_check`` parameter to nested MapAttributes (#908)
+
+
 v5.0.2
 ----------
 

--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '5.0.2'
+__version__ = '5.0.3'

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2874,6 +2874,41 @@ class ModelTestCase(TestCase):
             item = BooleanModel.get('justin')
             self.assertTrue(item.is_human)
 
+    def test_serializing_map_with_null_check(self):
+        item = TreeModel(
+            tree_key='test',
+            left=TreeLeaf(
+                value=42,
+                left=TreeLeaf1(
+                    value=42,
+                    left=TreeLeaf2(value=42),
+                    right=TreeLeaf2(value=42),
+                ),
+                right=TreeLeaf1(
+                    value=42,
+                    left=TreeLeaf2(value=42),
+                    right=TreeLeaf2(value=42),
+                ),
+            ),
+            right=TreeLeaf(
+                value=42,
+                left=TreeLeaf1(
+                    value=42,
+                    left=TreeLeaf2(value=42),
+                    right=TreeLeaf2(value=42),
+                ),
+                right=TreeLeaf1(
+                    value=42,
+                    left=TreeLeaf2(value=42),
+                    right=TreeLeaf2(value=42),
+                ),
+            ),
+        )
+        item.serialize(null_check=False)
+
+        item.left.left.left.value = None
+        item.serialize(null_check=False)
+
     def test_deserializing_map_four_layers_deep_works(self):
         fake_db = self.database_mocker(TreeModel,
                                        TREE_MODEL_TABLE_DATA,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2906,6 +2906,7 @@ class ModelTestCase(TestCase):
         )
         item.serialize(null_check=False)
 
+        # now let's nullify an attribute a few levels deep to test that `null_check` propagates
         item.left.left.left.value = None
         item.serialize(null_check=False)
 


### PR DESCRIPTION
Before this change, the Model would propagate null_check to the immediate MapAttributes but then those MapAttributes wouldn't propagate it to deeper-nested ones.

P.S. In practice we're not using `null_check` anymore, since we're no longer calling `get_save_args` for non-save. We used to pass `null_check=False` to prevent updates tripping on unrelated null attributes but it's not needed since #905. It is part of the API though.