### PR TITLE
Null errors should include full attribute path

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+Unreleased
+----------
+
+* Null errors should include full attribute path (#915)
+
+
 v5.0.3
 ----------
 

--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -127,6 +127,17 @@ class AttributeDeserializationError(TypeError):
         super(AttributeDeserializationError, self).__init__(msg)
 
 
+class AttributeNullError(ValueError):
+    def __init__(self, attr_name: str) -> None:
+        self.attr_path = attr_name
+
+    def __str__(self):
+        return f"Attribute '{self.attr_path}' cannot be None"
+
+    def prepend_path(self, attr_name: str) -> None:
+        self.attr_path = attr_name + '.' + self.attr_path
+
+
 class VerboseClientError(botocore.exceptions.ClientError):
     def __init__(self, error_response: Any, operation_name: str, verbose_properties: Optional[Any] = None):
         """ Modify the message template to include the desired verbose properties """

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -29,7 +29,8 @@ else:
     from typing_extensions import Protocol
 
 from pynamodb.expressions.update import Action
-from pynamodb.exceptions import DoesNotExist, TableDoesNotExist, TableError, InvalidStateError, PutError
+from pynamodb.exceptions import DoesNotExist, TableDoesNotExist, TableError, InvalidStateError, PutError, \
+    AttributeNullError
 from pynamodb.attributes import (
     AttributeContainer, AttributeContainerMeta, TTLAttribute, VersionAttribute
 )
@@ -1104,7 +1105,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
 
         if serialized is None:
             if not attr.null:
-                raise ValueError("Attribute '{}' cannot be None".format(attr.attr_name))
+                raise AttributeNullError(attr.attr_name)
             return {NULL: True}
 
         return {attr.attr_type: serialized}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2643,8 +2643,9 @@ class ModelTestCase(TestCase):
         car_info = CarInfoMap(model='Envoy')
         item = CarModel(car_id=123, car_info=car_info)
         with patch(PATCH_METHOD):
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ValueError) as cm:
                 item.save()
+            assert str(cm.exception) == "Attribute 'car_info.make' cannot be None"
 
     def test_model_works_like_model(self):
         office_employee = self._get_office_employee()
@@ -2678,12 +2679,9 @@ class ModelTestCase(TestCase):
                                  '123')
 
         with patch(PATCH_METHOD, new=fake_db) as req:
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ValueError) as cm:
                 CarModel(car_id=2).save()
-            try:
-                CarModel(car_id=2).save()
-            except ValueError as e:
-                assert str(e) == "Attribute 'car_info' cannot be None"
+            assert str(cm.exception) == "Attribute 'car_info' cannot be None"
 
     def test_model_with_maps_retrieve_from_db(self):
         fake_db = self.database_mocker(OfficeEmployee, OFFICE_EMPLOYEE_MODEL_TABLE_DATA,


### PR DESCRIPTION
This would make it easier to understand errors when a nested field is left unset.