### PR TITLE
Add some niceties from the dict API to MapAttribute

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -13,7 +13,10 @@ from datetime import timedelta
 from datetime import timezone
 from inspect import getfullargspec
 from inspect import getmembers
-from typing import Any, Callable, Dict, Generic, List, Mapping, Optional, TypeVar, Type, Union, Set, overload
+from typing import (
+    Any, Callable, Dict, Generic, ItemsView, KeysView, List, Mapping,
+    Optional, Set, TypeVar, Type, Union, ValuesView, overload
+)
 from typing import TYPE_CHECKING
 
 from pynamodb._compat import GenericMeta
@@ -983,22 +986,22 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
 
     def get(self, item: _KT, default: Any = None) -> Union[_VT, None]:
         if not self._is_attribute_container():
-            raise TypeError("MapAttribute must be acting as attribute container to MapAttribute.get")
+            raise TypeError("MapAttribute must be acting as attribute container to use MapAttribute.get")
         return self.attribute_values.get(item, default)
 
-    def items(self):
+    def items(self) -> ItemsView[_KT, _VT]:
         if not self._is_attribute_container():
-            raise TypeError("MapAttribute must be acting as attribute container to MapAttribute.items")
+            raise TypeError("MapAttribute must be acting as attribute container to use MapAttribute.items")
         return self.attribute_values.items()
 
-    def keys(self):
+    def keys(self) -> KeysView[_KT]:
         if not self._is_attribute_container():
-            raise TypeError("MapAttribute must be acting as attribute container to MapAttribute.keys")
+            raise TypeError("MapAttribute must be acting as attribute container to use MapAttribute.keys")
         return self.attribute_values.keys()
 
-    def values(self):
+    def values(self) -> ValuesView[_VT]:
         if not self._is_attribute_container():
-            raise TypeError("MapAttribute must be acting as attribute container to MapAttribute.values")
+            raise TypeError("MapAttribute must be acting as attribute container to use MapAttribute.values")
         return self.attribute_values.values()
 
 

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -983,22 +983,22 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
 
     def get(self, item: _KT, default: Any = None) -> Union[_VT, None]:
         if not self._is_attribute_container():
-            raise AssertionError("MapAttribute must be acting as attribute container to MapAttribute.get")
+            raise TypeError("MapAttribute must be acting as attribute container to MapAttribute.get")
         return self.attribute_values.get(item, default)
 
     def items(self):
         if not self._is_attribute_container():
-            raise AssertionError("MapAttribute must be acting as attribute container to MapAttribute.items")
+            raise TypeError("MapAttribute must be acting as attribute container to MapAttribute.items")
         return self.attribute_values.items()
 
     def keys(self):
         if not self._is_attribute_container():
-            raise AssertionError("MapAttribute must be acting as attribute container to MapAttribute.keys")
+            raise TypeError("MapAttribute must be acting as attribute container to MapAttribute.keys")
         return self.attribute_values.keys()
 
     def values(self):
         if not self._is_attribute_container():
-            raise AssertionError("MapAttribute must be acting as attribute container to MapAttribute.values")
+            raise TypeError("MapAttribute must be acting as attribute container to MapAttribute.values")
         return self.attribute_values.values()
 
 

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -979,6 +979,28 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
             result[key] = value.as_dict() if isinstance(value, MapAttribute) else value
         return result
 
+    # some of the dict API
+
+    def get(self, item: _KT, default: Any = None) -> Union[_VT, None]:
+        if not self._is_attribute_container():
+            raise AssertionError("MapAttribute must be acting as attribute container to MapAttribute.get")
+        return self.attribute_values.get(item, default)
+
+    def items(self):
+        if not self._is_attribute_container():
+            raise AssertionError("MapAttribute must be acting as attribute container to MapAttribute.items")
+        return self.attribute_values.items()
+
+    def keys(self):
+        if not self._is_attribute_container():
+            raise AssertionError("MapAttribute must be acting as attribute container to MapAttribute.keys")
+        return self.attribute_values.keys()
+
+    def values(self):
+        if not self._is_attribute_container():
+            raise AssertionError("MapAttribute must be acting as attribute container to MapAttribute.values")
+        return self.attribute_values.values()
+
 
 def _get_class_for_serialize(value):
     if value is None:

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -838,6 +838,24 @@ class TestMapAttribute:
             assert v == getattr(t.nested, k)
         assert list(t.nested.double_nested.values()) == list(t.nested.double_nested.as_dict().values())
 
+        # disallowed
+        with pytest.raises(AssertionError):
+            ThingModel.nested.get("something")
+        with pytest.raises(AssertionError):
+            NestedThing.double_nested.get("something")
+        with pytest.raises(AssertionError):
+            ThingModel.nested.items()
+        with pytest.raises(AssertionError):
+            NestedThing.double_nested.items()
+        with pytest.raises(AssertionError):
+            ThingModel.nested.keys()
+        with pytest.raises(AssertionError):
+            NestedThing.double_nested.keys()
+        with pytest.raises(AssertionError):
+            ThingModel.nested.values()
+        with pytest.raises(AssertionError):
+            NestedThing.double_nested.values()
+
     def test_attribute_paths_subclassing(self):
         class SubMapAttribute(MapAttribute):
             foo = UnicodeAttribute(attr_name='dyn_foo')

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -839,21 +839,21 @@ class TestMapAttribute:
         assert list(t.nested.double_nested.values()) == list(t.nested.double_nested.as_dict().values())
 
         # disallowed
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             ThingModel.nested.get("something")
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             NestedThing.double_nested.get("something")
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             ThingModel.nested.items()
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             NestedThing.double_nested.items()
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             ThingModel.nested.keys()
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             NestedThing.double_nested.keys()
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             ThingModel.nested.values()
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             NestedThing.double_nested.values()
 
     def test_attribute_paths_subclassing(self):


### PR DESCRIPTION
## Intro
This PR aims to add some of the functionality of `dict` objects to `MapAttribute` for convenience when manipulating model instances. Admittedly, I have not been a PynamoDB user for long, but I thought this would be a good addition.

I came across #156, which seems to be obsolete now, dead, and does not implement what I'm after here.

## What is added to `MapAttribute`
When the `MapAttribute` is acting as an `AttributeContainer`, you may call:
- `get`
- `items`
- `keys`
- `values`

These behave exactly like their equivalents on `dict` objects

## Follow ons?
I chose to steer clear of the parts of `dict` API that mutate the underlying dict, as I'm sure implementing those well would require a bit more familiarity with the existing implementation. I would welcome opinions or input on how these might be added, however I would be fine leaving them out:
- `pop`
- `update`
- `setdefault`
- `__delitem__`

Feedback welcome, also excuse any code style / type hinting no-nos.