### PR TITLE
Add CancellationReasons in the VerboseClientError (#891)

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -418,6 +418,10 @@ class Connection(object):
                 if '#' in code:
                     code = code.rsplit('#', 1)[1]
                 botocore_expected_format = {'Error': {'Message': data.get('message', '') or data.get('Message', ''), 'Code': code}}
+
+                if 'CancellationReasons' in data:
+                    botocore_expected_format['CancellationReasons'] = data['CancellationReasons']
+
                 verbose_properties = {
                     'request_id': headers.get('x-amzn-RequestId')
                 }

--- a/tests/integration/test_transaction_integration.py
+++ b/tests/integration/test_transaction_integration.py
@@ -164,6 +164,7 @@ def test_transact_write__error__transaction_cancelled__condition_check_failure(c
     assert 'ConditionalCheckFailed' in get_error_message(exc_info.value)
     assert User.Meta.table_name in exc_info.value.cause.MSG_TEMPLATE
     assert BankStatement.Meta.table_name in exc_info.value.cause.MSG_TEMPLATE
+    assert 'CancellationReasons' in exc_info.value.cause.response
 
 
 @pytest.mark.ddblocal
@@ -351,6 +352,7 @@ def test_transaction_write_with_version_attribute_condition_failure(connection):
     assert get_error_code(exc_info.value) == TRANSACTION_CANCELLED
     assert 'ConditionalCheckFailed' in get_error_message(exc_info.value)
     assert Foo.Meta.table_name in exc_info.value.cause.MSG_TEMPLATE
+    assert 'CancellationReasons' in exc_info.value.cause.response
 
     with pytest.raises(TransactWriteError) as exc_info:
         with TransactWrite(connection=connection) as transaction:
@@ -363,6 +365,7 @@ def test_transaction_write_with_version_attribute_condition_failure(connection):
     assert get_error_code(exc_info.value) == TRANSACTION_CANCELLED
     assert 'ConditionalCheckFailed' in get_error_message(exc_info.value)
     assert Foo.Meta.table_name in exc_info.value.cause.MSG_TEMPLATE
+    assert 'CancellationReasons' in exc_info.value.cause.response
     # Version attribute is not updated on failure.
     assert foo2.version is None
 
@@ -372,3 +375,4 @@ def test_transaction_write_with_version_attribute_condition_failure(connection):
     assert get_error_code(exc_info.value) == TRANSACTION_CANCELLED
     assert 'ConditionalCheckFailed' in get_error_message(exc_info.value)
     assert Foo.Meta.table_name in exc_info.value.cause.MSG_TEMPLATE
+    assert 'CancellationReasons' in exc_info.value.cause.response


### PR DESCRIPTION
Note
----
This change is to add the CancellationReasons into the VerboseClientError,
which is included in the botocore TransactionCanceledException.
https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.exceptions.TransactionCanceledException

Adding this would help developers to figure out the detail cancellation reasons directly rather than parsing the
message.