### PR TITLE
added new sts role configuration parameter to assume aws role dynamic…

### DIFF
--- a/docs/awsaccess.rst
+++ b/docs/awsaccess.rst
@@ -24,5 +24,19 @@ If for some reason you can't use conventional AWS configuration methods, you can
             aws_secret_access_key = 'my_secret_access_key'
             aws_session_token = 'my_session_token' # Optional, only for temporary credentials like those received when assuming a role
 
+If you need to access DynamoDB passing for a specific AWS Role and so you need to perform an assume-role operation on your Role ARN you can configure it in the Model Meta class:
+
+.. code-block:: python
+
+    from pynamodb.models import Model
+
+    class MyModel(Model):
+        class Meta:
+            aws_sts_role_arn='arn:aws:iam::1234567:role/my-aws-role'
+            aws_sts_role_session_name='MySession' # Optional, by default it is PynamoDB
+            aws_sts_session_expiration=3600 # Optional, it is the session token duration in seconds. Default is 3600
+
+Note that your environment variables credentials, or in case, credentials setted in the Model Meta class, need to have grant to perform the assume-role operation.
+
 Finally, see the `AWS CLI documentation <http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-installing-credentials>`_
 for more details on how to pass credentials to botocore.

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -273,7 +273,7 @@ class Connection(object):
             # Initialize empty STS Credentials if STS auth is configured
             self.sts_session = STSCredentials()
             self.aws_sts_role_arn = aws_sts_role_arn
-            self.aws_sts_role_session_name = aws_sts_role_session_name
+            self.aws_sts_role_session_name = aws_sts_role_session_name or 'PynamoDB'
             self.aws_sts_session_expiration = aws_sts_session_expiration or 3600
 
         if region:
@@ -538,15 +538,14 @@ class Connection(object):
 
         if self.sts_session.expired():
             self.assume_role_session()
-            return True
 
-        return False
+        return True
 
     def assume_role_session(self):
         sts = self.session.create_client('sts')
         sts_response = sts.assume_role(
             RoleArn=self.aws_sts_role_arn,
-            RoleSessionName=self.aws_sts_role_session_name or 'PynamoDB',
+            RoleSessionName=self.aws_sts_role_session_name,
             DurationSeconds=self.aws_sts_session_expiration
         )
         self.sts_session = STSCredentials(**sts_response['Credentials'])

--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -16,21 +16,24 @@ class TableConnection:
     A higher level abstraction over botocore
     """
 
-    def __init__(
-        self,
-        table_name: str,
-        region: Optional[str] = None,
-        host: Optional[str] = None,
-        connect_timeout_seconds: Optional[float] = None,
-        read_timeout_seconds: Optional[float] = None,
-        max_retry_attempts: Optional[int] = None,
-        base_backoff_ms: Optional[int] = None,
-        max_pool_connections: Optional[int] = None,
-        extra_headers: Optional[Mapping[str, str]] = None,
-        aws_access_key_id: Optional[str] = None,
-        aws_secret_access_key: Optional[str] = None,
-        aws_session_token: Optional[str] = None,
-    ) -> None:
+    def __init__(self,
+                 table_name,
+                 region=None,
+                 host=None,
+                 connect_timeout_seconds=None,
+                 read_timeout_seconds=None,
+                 max_retry_attempts=None,
+                 base_backoff_ms=None,
+                 max_pool_connections=None,
+                 extra_headers=None,
+                 aws_access_key_id=None,
+                 aws_secret_access_key=None,
+                 aws_session_token=None,
+                 aws_sts_role_arn=None,
+                 aws_sts_role_session_name=None,
+                 aws_sts_session_expiration=None):
+        self._hash_keyname = None
+        self._range_keyname = None
         self.table_name = table_name
         self.connection = Connection(region=region,
                                      host=host,
@@ -39,7 +42,10 @@ class TableConnection:
                                      max_retry_attempts=max_retry_attempts,
                                      base_backoff_ms=base_backoff_ms,
                                      max_pool_connections=max_pool_connections,
-                                     extra_headers=extra_headers)
+                                     extra_headers=extra_headers,
+                                     aws_sts_role_arn=aws_sts_role_arn,
+                                     aws_sts_role_session_name=aws_sts_role_session_name,
+                                     aws_sts_session_expiration=aws_sts_session_expiration)
 
         if aws_access_key_id and aws_secret_access_key:
             self.connection.session.set_credentials(aws_access_key_id,

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -191,6 +191,9 @@ class MetaProtocol(Protocol):
     billing_mode: Optional[str]
     tags: Optional[Dict[str, str]]
     stream_view_type: Optional[str]
+    aws_sts_role_arn: Optional[str]
+    aws_sts_role_session_name: Optional[str]
+    aws_sts_session_expiration: Optional[int]
 
 
 class MetaModel(AttributeContainerMeta):
@@ -253,6 +256,12 @@ class MetaModel(AttributeContainerMeta):
                         setattr(attr_obj, 'aws_secret_access_key', None)
                     if not hasattr(attr_obj, 'aws_session_token'):
                         setattr(attr_obj, 'aws_session_token', None)
+                    if not hasattr(attr_obj, 'aws_sts_role_arn'):
+                        setattr(attr_obj, 'aws_sts_role_arn', None)
+                    if not hasattr(attr_obj, 'aws_sts_role_session_name'):
+                        setattr(attr_obj, 'aws_sts_role_session_name', None)
+                    if not hasattr(attr_obj, 'aws_sts_session_expiration'):
+                        setattr(attr_obj, 'aws_sts_session_expiration', None)
                 elif isinstance(attr_obj, Index):
                     attr_obj.Meta.model = cls
                     if not hasattr(attr_obj.Meta, "index_name"):
@@ -1079,18 +1088,23 @@ class Model(AttributeContainer, metaclass=MetaModel):
         # For now we just check that the connection exists and (in the case of model inheritance)
         # points to the same table. In the future we should update the connection if any of the attributes differ.
         if cls._connection is None or cls._connection.table_name != cls.Meta.table_name:
-            cls._connection = TableConnection(cls.Meta.table_name,
-                                              region=cls.Meta.region,
-                                              host=cls.Meta.host,
-                                              connect_timeout_seconds=cls.Meta.connect_timeout_seconds,
-                                              read_timeout_seconds=cls.Meta.read_timeout_seconds,
-                                              max_retry_attempts=cls.Meta.max_retry_attempts,
-                                              base_backoff_ms=cls.Meta.base_backoff_ms,
-                                              max_pool_connections=cls.Meta.max_pool_connections,
-                                              extra_headers=cls.Meta.extra_headers,
-                                              aws_access_key_id=cls.Meta.aws_access_key_id,
-                                              aws_secret_access_key=cls.Meta.aws_secret_access_key,
-                                              aws_session_token=cls.Meta.aws_session_token)
+            cls._connection = TableConnection(
+                cls.Meta.table_name,
+                region=cls.Meta.region,
+                host=cls.Meta.host,
+                connect_timeout_seconds=cls.Meta.connect_timeout_seconds,
+                read_timeout_seconds=cls.Meta.read_timeout_seconds,
+                max_retry_attempts=cls.Meta.max_retry_attempts,
+                base_backoff_ms=cls.Meta.base_backoff_ms,
+                max_pool_connections=cls.Meta.max_pool_connections,
+                extra_headers=cls.Meta.extra_headers,
+                aws_access_key_id=cls.Meta.aws_access_key_id,
+                aws_secret_access_key=cls.Meta.aws_secret_access_key,
+                aws_session_token=cls.Meta.aws_session_token,
+                aws_sts_role_arn=cls.Meta.aws_sts_role_arn,
+                aws_sts_role_session_name=cls.Meta.aws_sts_role_session_name,
+                aws_sts_session_expiration=cls.Meta.aws_sts_session_expiration
+            )
         return cls._connection
 
     @classmethod

--- a/tests/test_base_connection.py
+++ b/tests/test_base_connection.py
@@ -86,8 +86,14 @@ class ConnectionTestCase(TestCase):
 
             session_mock.create_client.assert_has_calls(
                 [
-                    mock.call('dynamodb', 'us-east-1', endpoint_url=None, config=mock.ANY),
-                    mock.call('dynamodb', 'us-east-1', endpoint_url=None, config=mock.ANY),
+                    mock.call('dynamodb', 'us-east-1', endpoint_url=None, config=mock.ANY, 
+                    aws_access_key_id=mock.ANY,
+                    aws_secret_access_key=mock.ANY,
+                    aws_session_token=mock.ANY),
+                    mock.call('dynamodb', 'us-east-1', endpoint_url=None, config=mock.ANY, 
+                    aws_access_key_id=mock.ANY,
+                    aws_secret_access_key=mock.ANY,
+                    aws_session_token=mock.ANY),
                 ],
                 any_order=True
             )
@@ -102,7 +108,14 @@ class ConnectionTestCase(TestCase):
             self.assertIsNotNone(conn.client)
 
             self.assertEqual(
-                session_mock.create_client.mock_calls.count(mock.call('dynamodb', 'us-east-1', endpoint_url=None, config=mock.ANY)),
+                session_mock.create_client.mock_calls.count(mock.call(
+                    'dynamodb', 
+                    'us-east-1', 
+                    endpoint_url=None, 
+                    config=mock.ANY,
+                    aws_access_key_id=mock.ANY,
+                    aws_secret_access_key=mock.ANY,
+                    aws_session_token=mock.ANY)),
                 1
             )
 


### PR DESCRIPTION
This PR is intended to add a new feature in order to allow dynamic assume role by just configuring the role-arn in the META class.

```python
class Tip(Model):
    class Meta:
        aws_sts_role_arn='arn:aws:iam::1234567:role/my-aws-role'  
        table_name = "my_table"
        region = 'eu-central-1'

    id = UnicodeAttribute(hash_key=True)
```

This is a draft, to get your POV about this feature: if it is acceptable, if my code can be improved, or so on.

I will add tests and update the doc in next days.