### PR TITLE
Fix type definitions

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -404,7 +404,7 @@ class Model(AttributeContainer, metaclass=MetaModel):
 
         return self._get_connection().delete_item(hk_value, range_key=rk_value, condition=condition, settings=settings)
 
-    def update(self, actions: List[Action], condition: Optional[Condition] = None, settings: OperationSettings = OperationSettings.default) -> Any:
+    def update(self, actions: Sequence[Action], condition: Optional[Condition] = None, settings: OperationSettings = OperationSettings.default) -> Any:
         """
         Updates an item using the UpdateItem operation.
 

--- a/pynamodb/transactions.py
+++ b/pynamodb/transactions.py
@@ -1,4 +1,4 @@
-from typing import Tuple, TypeVar, Type, Any, List, Optional, Dict, Union, Text, Generic
+from typing import Sequence, Tuple, TypeVar, Type, Any, List, Optional, Dict, Union, Text, Generic
 
 from pynamodb.connection import Connection
 from pynamodb.constants import ITEM, RESPONSES
@@ -7,6 +7,7 @@ from pynamodb.expressions.update import Action
 from pynamodb.models import Model, _ModelFuture, _KeyType
 
 _M = TypeVar('_M', bound=Model)
+_T = TypeVar('_T', bound='Transaction')
 
 
 class Transaction:
@@ -22,7 +23,7 @@ class Transaction:
     def _commit(self):
         raise NotImplementedError()
 
-    def __enter__(self) -> 'Transaction':
+    def __enter__(self: _T) -> _T:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -111,7 +112,7 @@ class TransactWrite(Transaction):
         self._put_items.append(operation_kwargs)
         self._models_for_version_attribute_update.append(model)
 
-    def update(self, model: _M, actions: List[Action], condition: Optional[Condition] = None, return_values: Optional[str] = None) -> None:
+    def update(self, model: _M, actions: Sequence[Action], condition: Optional[Condition] = None, return_values: Optional[str] = None) -> None:
         operation_kwargs = model.get_update_kwargs_from_instance(
             actions=actions,
             condition=condition,


### PR DESCRIPTION
Pull request fixes type definition for Transaction context manager and update method type definition

1. Before type definition for Transaction.__enter__ always returned Transaction type which was not working properly for TransactoinWrite class
2. update method action argument stated that it accepts List[Action]. List[] itself is invariant which was not working properly with subclasses of Action. 

PR itself does not add any new feature
