### PR TITLE
Add generic self type hint to Transaction

### DIFF
--- a/pynamodb/transactions.py
+++ b/pynamodb/transactions.py
@@ -7,7 +7,7 @@ from pynamodb.expressions.update import Action
 from pynamodb.models import Model, _ModelFuture, _KeyType
 
 _M = TypeVar('_M', bound=Model)
-TTransaction = TypeVar('TTransaction', bound='Transaction')
+_TTransaction = TypeVar('_TTransaction', bound='Transaction')
 
 
 class Transaction:
@@ -23,7 +23,7 @@ class Transaction:
     def _commit(self):
         raise NotImplementedError()
 
-    def __enter__(self: TTransaction) -> TTransaction:
+    def __enter__(self: _TTransaction) -> _TTransaction:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/pynamodb/transactions.py
+++ b/pynamodb/transactions.py
@@ -7,6 +7,7 @@ from pynamodb.expressions.update import Action
 from pynamodb.models import Model, _ModelFuture, _KeyType
 
 _M = TypeVar('_M', bound=Model)
+TTransaction = TypeVar('TTransaction', bound='Transaction')
 
 
 class Transaction:
@@ -22,7 +23,7 @@ class Transaction:
     def _commit(self):
         raise NotImplementedError()
 
-    def __enter__(self) -> 'Transaction':
+    def __enter__(self: TTransaction) -> TTransaction:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -247,5 +247,5 @@ def test_transactions(assert_mypy_output):
     assert_mypy_output("""
     from pynamodb.transactions import TransactWrite
     with TransactWrite() as tx:
-        reveal_type(tx)
+        reveal_type(tx)  # N: Revealed type is 'pynamodb.transactions.TransactWrite*'
     """)

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -242,3 +242,10 @@ def test_append(assert_mypy_output):
     MyModel.attr.prepend(42)  # E: Argument 1 to "prepend" of "Attribute" has incompatible type "int"; expected "Iterable[Any]"  [arg-type]
     MyModel.attr.prepend([42])
     """)
+
+def test_transactions(assert_mypy_output):
+    assert_mypy_output("""
+    from pynamodb.transactions import TransactWrite
+    with TransactWrite() as tx:
+        reveal_type(tx)
+    """)


### PR DESCRIPTION
This should fix #916, as the __enter__ method now returns the correct subclass from which it was called.

I created a testcase to mypy tests, but I think it's not really testing anything yet. I would be glad to get help on proper test implementation.