### PR TITLE
Store Model class reference on an instance of index class. Fixes #992

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,7 +3,11 @@ Release Notes
 
 Unreleased
 ----------
+
+This is a major release and contains breaking changes. Please read the notes below carefully.
+
 * Python 3.6 is no longer supported.
+* Index count, query, and scan methods are now instance methods.
 
 
 v5.2.0

--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -27,6 +27,7 @@ class Index(Generic[_M]):
     Base class for secondary indexes
     """
     Meta: Any = None
+    _model: _M
 
     @classmethod
     def __init_subclass__(cls, **kwargs):
@@ -43,14 +44,13 @@ class Index(Generic[_M]):
             raise ValueError("No projection defined, define a projection for this class")
 
     def __set_name__(self, owner: Type[_M], name: str):
-        if not hasattr(self.Meta, "model"):
-            self.Meta.model = owner
+        if not hasattr(type(self), "_model"):
+            type(self)._model = owner
         if not hasattr(self.Meta, "index_name"):
             self.Meta.index_name = name
 
-    @classmethod
     def count(
-        cls,
+        self,
         hash_key: _KeyType,
         range_key_condition: Optional[Condition] = None,
         filter_condition: Optional[Condition] = None,
@@ -61,19 +61,18 @@ class Index(Generic[_M]):
         """
         Count on an index
         """
-        return cls.Meta.model.count(
+        return self._model.count(
             hash_key,
             range_key_condition=range_key_condition,
             filter_condition=filter_condition,
-            index_name=cls.Meta.index_name,
+            index_name=self.Meta.index_name,
             consistent_read=consistent_read,
             limit=limit,
             rate_limit=rate_limit,
         )
 
-    @classmethod
     def query(
-        cls,
+        self,
         hash_key: _KeyType,
         range_key_condition: Optional[Condition] = None,
         filter_condition: Optional[Condition] = None,
@@ -88,12 +87,12 @@ class Index(Generic[_M]):
         """
         Queries an index
         """
-        return cls.Meta.model.query(
+        return self._model.query(
             hash_key,
             range_key_condition=range_key_condition,
             filter_condition=filter_condition,
             consistent_read=consistent_read,
-            index_name=cls.Meta.index_name,
+            index_name=self.Meta.index_name,
             scan_index_forward=scan_index_forward,
             limit=limit,
             last_evaluated_key=last_evaluated_key,
@@ -102,9 +101,8 @@ class Index(Generic[_M]):
             rate_limit=rate_limit,
         )
 
-    @classmethod
     def scan(
-        cls,
+        self,
         filter_condition: Optional[Condition] = None,
         segment: Optional[int] = None,
         total_segments: Optional[int] = None,
@@ -118,7 +116,7 @@ class Index(Generic[_M]):
         """
         Scans an index
         """
-        return cls.Meta.model.scan(
+        return self._model.scan(
             filter_condition=filter_condition,
             segment=segment,
             total_segments=total_segments,
@@ -126,7 +124,7 @@ class Index(Generic[_M]):
             last_evaluated_key=last_evaluated_key,
             page_size=page_size,
             consistent_read=consistent_read,
-            index_name=cls.Meta.index_name,
+            index_name=self.Meta.index_name,
             rate_limit=rate_limit,
             attributes_to_get=attributes_to_get,
         )
@@ -191,7 +189,7 @@ class LocalSecondaryIndex(Index[_M]):
     pass
 
 
-class Projection(object):
+class Projection:
     """
     A class for presenting projections
     """

--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -76,7 +76,7 @@ class Index(Generic[_M]):
         hash_key: _KeyType,
         range_key_condition: Optional[Condition] = None,
         filter_condition: Optional[Condition] = None,
-        consistent_read: Optional[bool] = False,
+        consistent_read: bool = False,
         scan_index_forward: Optional[bool] = None,
         limit: Optional[int] = None,
         last_evaluated_key: Optional[Dict[str, Dict[str, Any]]] = None,

--- a/pynamodb/indexes.py
+++ b/pynamodb/indexes.py
@@ -44,8 +44,6 @@ class Index(Generic[_M]):
             raise ValueError("No projection defined, define a projection for this class")
 
     def __set_name__(self, owner: Type[_M], name: str):
-        if not hasattr(type(self), "_model"):
-            type(self)._model = owner
         if not hasattr(self.Meta, "index_name"):
             self.Meta.index_name = name
 

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -7,6 +7,7 @@ import time
 import logging
 import warnings
 import sys
+from copy import deepcopy
 from inspect import getmembers
 from typing import Any
 from typing import Dict
@@ -274,6 +275,10 @@ class MetaModel(AttributeContainerMeta):
         """
         cls._indexes = {}
         for name, index in getmembers(cls, lambda o: isinstance(o, Index)):
+            # Store a local reference to the containing Model class on a copy of the index to support polymorphism.
+            index = deepcopy(index)
+            index._model = cls
+            setattr(cls, name, index)
             cls._indexes[index.Meta.index_name] = index
 
 


### PR DESCRIPTION
This is a breaking change to the index API. The count, query, and scan methods are now instance methods.