### PR TITLE
Improve condition expression support for attribute comparisons. Fixes #508

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -143,17 +143,9 @@ class Attribute(Generic[_T]):
 
     # Condition Expression Support
     def __eq__(self, other: Any) -> 'Comparison':  # type: ignore[override]
-        if isinstance(other, MapAttribute) and other._is_attribute_container():
-            return Path(self).__eq__(other)
-        if other is None or isinstance(other, Attribute):  # handle object identity comparison
-            return self is other  # type: ignore
         return Path(self).__eq__(other)
 
     def __ne__(self, other: Any) -> 'Comparison':  # type: ignore[override]
-        if isinstance(other, MapAttribute) and other._is_attribute_container():
-            return Path(self).__ne__(other)
-        if other is None or isinstance(other, Attribute):  # handle object identity comparison
-            return self is not other  # type: ignore
         return Path(self).__ne__(other)
 
     def __lt__(self, other: Any) -> 'Comparison':
@@ -868,13 +860,33 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
 
     def __eq__(self, other: Any) -> 'Comparison':  # type: ignore[override]
         if self._is_attribute_container():
-            return self is other  # type: ignore
+            return NotImplemented
         return Attribute.__eq__(self, other)
 
     def __ne__(self, other: Any) -> 'Comparison':  # type: ignore[override]
         if self._is_attribute_container():
-            return self is not other  # type: ignore
+            return NotImplemented
         return Attribute.__ne__(self, other)
+
+    def __lt__(self, other: Any) -> 'Comparison':
+        if self._is_attribute_container():
+            return NotImplemented
+        return Attribute.__lt__(self, other)
+
+    def __le__(self, other: Any) -> 'Comparison':
+        if self._is_attribute_container():
+            return NotImplemented
+        return Attribute.__le__(self, other)
+
+    def __gt__(self, other: Any) -> 'Comparison':
+        if self._is_attribute_container():
+            return NotImplemented
+        return Attribute.__gt__(self, other)
+
+    def __ge__(self, other: Any) -> 'Comparison':
+        if self._is_attribute_container():
+            return NotImplemented
+        return Attribute.__ge__(self, other)
 
     def __iter__(self):
         if self._is_attribute_container():

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -340,6 +340,18 @@ class ConditionExpressionTestCase(TestCase):
         assert self.placeholder_names == {'foo': '#0'}
         assert self.expression_attribute_values == {':0': {'M': {'bar': {'S': 'baz'}}}}
 
+    def test_map_comparison_rhs(self):
+        # Simulate initialization from inside an AttributeContainer
+        my_map_attribute = MapAttribute[str, str](attr_name='foo')
+        my_map_attribute._make_attribute()
+        my_map_attribute._update_attribute_paths(my_map_attribute.attr_name)
+
+        condition = MapAttribute(bar='baz') == my_map_attribute
+        expression = condition.serialize(self.placeholder_names, self.expression_attribute_values)
+        assert expression == "#0 = :0"
+        assert self.placeholder_names == {'foo': '#0'}
+        assert self.expression_attribute_values == {':0': {'M': {'bar': {'S': 'baz'}}}}
+
     def test_list_comparison(self):
         condition = ListAttribute(attr_name='foo') == ['bar', 'baz']
         expression = condition.serialize(self.placeholder_names, self.expression_attribute_values)
@@ -408,6 +420,13 @@ class ConditionExpressionTestCase(TestCase):
 
         with self.assertRaises(AttributeError):
             _ = my_map_attribute['missing_attribute'] == 'baz'
+
+    def test_attribute_comparison(self):
+        condition = self.attribute == UnicodeAttribute(attr_name='bar')
+        expression = condition.serialize(self.placeholder_names, self.expression_attribute_values)
+        assert expression == "#0 = #1"
+        assert self.placeholder_names == {'foo': '#0', 'bar': '#1'}
+        assert self.expression_attribute_values == {}
 
 
 class UpdateExpressionTestCase(TestCase):


### PR DESCRIPTION
This commit makes two backwards incompatible changes.

- Attribute equality comparisons now return condition expressions instead of boolean values and attempting to treat them as a boolean raises a TypeError:
```
>>> from pynamodb.attributes import UnicodeAttribute
>>> UnicodeAttribute(attr_name='foo') == UnicodeAttribute(attr_name='bar')  # used to return `False`
foo = bar

>>> bool(UnicodeAttribute(attr_name='foo') == UnicodeAttribute(attr_name='bar'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jpinner/workspace/PynamoDB/pynamodb/expressions/condition.py", line 49, in __bool__
    raise TypeError("unsupported operand type(s) for bool: {}".format(self.__class__.__name__))
TypeError: unsupported operand type(s) for bool: Comparison
```

- MapAttribute instance comparisons are now symmetric:
```
>>> from pynamodb.models import Model
>>> from pynamodb.attributes import MapAttribute
>>> class MyModel(Model):
...     foo = MapAttribute()
... 
>>> MyModel.foo == MapAttribute()
foo = {'M': {}}
>>> MapAttribute() == MyModel.foo  # used to return `False`
foo = {'M': {}}
```