### PR TITLE
Bump version to 6.0 pre-release

### DIFF
--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '5.2.0'
+__version__ = '6.0a0'


### PR DESCRIPTION
With https://github.com/pynamodb/PynamoDB/pull/995 and other breaking changes about to enter, we should bump the version so we won't accidentally release them under 5.x.