### PR TITLE
Prepare for 5.2.1 release

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+v5.2.1
+----------
+* Fix issue from 5.2.0 with attempting to set GSI provisioned throughput on PAY_PER_REQUEST billing mode (#1018)
+
+
 v5.2.0
 ----------
 * The ``IndexMeta`` class has been removed. Now ``type(Index) == type`` (#998)

--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '5.2.0'
+__version__ = '5.2.1'


### PR DESCRIPTION
Backports https://github.com/pynamodb/PynamoDB/pull/1018 into a 5.2.1 release

See https://github.com/pynamodb/PynamoDB/commits/backport-1018-5.x