### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ setup(
     version=__import__('pynamodb').__version__,
     packages=find_packages(exclude=('examples', 'tests', 'tests.integration',)),
     url='http://jlafon.io/pynamodb.html',
+    project_urls={
+        'Source': 'https://github.com/pynamodb/PynamoDB',
+    },
     author='Jharrod LaFon',
     author_email='jlafon@eyesopen.com',
     description='A Pythonic Interface to DynamoDB',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)