### PR TITLE
Fix typing on TransactGet

### DIFF
--- a/pynamodb/transactions.py
+++ b/pynamodb/transactions.py
@@ -31,11 +31,11 @@ class Transaction:
             self._commit()
 
 
-class TransactGet(Generic[_M], Transaction):
+class TransactGet(Transaction):
 
     _results: Optional[List] = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._get_items: List[Dict] = []
         self._futures: List[_ModelFuture] = []
         super(TransactGet, self).__init__(*args, **kwargs)


### PR DESCRIPTION
`TransactGet` can be used to fetch different Models in the same transaction, but because the `_M` was bound to the instance it was not possible to type such code correctly. I think `TransactGet` should be typed the same way as `TransactWrite`.

Additionally, I added typing to `__init__` to prevent _Call to untyped function in typed context_