### PR TITLE
Add explicit export to connection to fix mypy error

### DIFF
--- a/pynamodb/connection/__init__.py
+++ b/pynamodb/connection/__init__.py
@@ -4,3 +4,6 @@ PynamoDB lowest level connection
 
 from pynamodb.connection.base import Connection
 from pynamodb.connection.table import TableConnection
+
+
+__all__ = ["Connection", "TableConnection"]

--- a/pynamodb/connection/__init__.py
+++ b/pynamodb/connection/__init__.py
@@ -6,4 +6,7 @@ from pynamodb.connection.base import Connection
 from pynamodb.connection.table import TableConnection
 
 
-__all__ = ["Connection", "TableConnection"]
+__all__ = [
+    "Connection",
+    "TableConnection",
+]


### PR DESCRIPTION
When running `mypy` in strict mode I got this error:

```
error: Module "pynamodb.connection" does not explicitly export attribute "Connection"; implicit reexport disabled  [attr-defined]
```