### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -87,7 +87,7 @@ While striving for the library to be useful, we're also trying to "do one thing 
   as strings is doubtlessly something many applications have had a need for, but as long as it doesn't
   exercise any core DynamoDB functionality (e.g. in the case of a UUID attribute, there isn't
   a dedicated DynamoDB data type or API feature for storing UUIDs), we would recommend relegating
-  such functionality to auxillary libraries. One such library is `pynamodb-attributes <https://github.com/lyft/pynamodb-attributes>`_.
+  such functionality to auxiliary libraries. One such library is `pynamodb-attributes <https://github.com/lyft/pynamodb-attributes>`_.
 
 
 Pull Requests

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -89,7 +89,7 @@ Use of `update()` (in its simplest form) looks like this::
 a consequence, even if you modify only one attribute prior to calling
 `save()`, the entire object is re-written. Any modifications done to
 the same user by other processes will be lost, even if made to other
-attributues that you did not change. To avoid this, use `update()` to
+attributes that you did not change. To avoid this, use `update()` to
 perform more fine grained updates or see the
 :ref:`conditional_operations` for how to avoid race conditions
 entirely.

--- a/docs/rate_limited_operations.rst
+++ b/docs/rate_limited_operations.rst
@@ -32,7 +32,7 @@ Suppose that you have defined a `User` Model for the examples below.
         name = UnicodeAttribute(range_key=True)
 
 
-Here is an example using `rate-limit` in while scaning the `User` model
+Here is an example using `rate-limit` in while scanning the `User` model
 
 .. code-block:: python
 

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -26,7 +26,7 @@ Arguments         Description
 *sender*          The object that fired that method.
 *operation_name*  The string name of the DynamoDB action
 *table_name*      The name of the table the operation is called upon.
-*req_uuid*        A unique identifer so subscribers can correlate the before and after events.
+*req_uuid*        A unique identifier so subscribers can correlate the before and after events.
 ================  ===========
 
 To subscribe to a signal, the user needs to import the signal object and connect your callback, like so.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -183,7 +183,7 @@ Here is an example of an attribute that can be empty:
 By default, PynamoDB assumes that the attribute name used on a Model has the same
 name in DynamoDB. For example, if you define a `UnicodeAttribute` called 'username' then
 PynamoDB will use 'username' as the field name for that attribute when interacting with DynamoDB.
-If you wish to have custom attribute names, they can be overidden. One such use case is the ability to
+If you wish to have custom attribute names, they can be overridden. One such use case is the ability to
 use human readable attribute names in PynamoDB that are stored in DynamoDB using shorter, terse attribute
 to save space.
 
@@ -215,7 +215,7 @@ PynamoDB comes with several built in attribute types for convenience, which incl
 * :py:class:`JSONAttribute <pynamodb.attributes.JSONAttribute>`
 * :py:class:`MapAttribute <pynamodb.attributes.MapAttribute>`
 
-All of these built in attributes handle serializing and deserializng themselves.
+All of these built in attributes handle serializing and deserializing themselves.
 
 Creating the table
 ------------------


### PR DESCRIPTION
There are small typos in:
- docs/contributing.rst
- docs/quickstart.rst
- docs/rate_limited_operations.rst
- docs/signals.rst
- docs/tutorial.rst

Fixes:
- Should read `scanning` rather than `scaning`.
- Should read `overridden` rather than `overidden`.
- Should read `identifier` rather than `identifer`.
- Should read `deserializing` rather than `deserializng`.
- Should read `auxiliary` rather than `auxillary`.
- Should read `attributes` rather than `attributues`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md