### PR TITLE
Workaround for _convert_to_request_dict change

### DIFF
--- a/pynamodb/connection/_botocore_private.py
+++ b/pynamodb/connection/_botocore_private.py
@@ -1,0 +1,28 @@
+"""
+Type-annotates the private botocore APIs that we're currently relying on.
+"""
+from typing import Any, Dict
+
+import botocore.client
+import botocore.credentials
+import botocore.endpoint
+import botocore.hooks
+import botocore.model
+import botocore.signers
+
+
+class BotocoreEndpointPrivate(botocore.endpoint.Endpoint):
+    _event_emitter: botocore.hooks.HierarchicalEmitter
+
+
+class BotocoreRequestSignerPrivate(botocore.signers.RequestSigner):
+    _credentials: botocore.credentials.Credentials
+
+
+class BotocoreBaseClientPrivate(botocore.client.BaseClient):
+    _endpoint: BotocoreEndpointPrivate
+    _request_signer: BotocoreRequestSignerPrivate
+    _service_model: botocore.model.ServiceModel
+
+    def _convert_to_request_dict(self, api_params: Dict[str, Any], operation_model: botocore.model.OperationModel, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        ...

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -10,7 +10,7 @@ import time
 import uuid
 from base64 import b64decode
 from threading import local
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, cast
 
 import botocore.client
 import botocore.exceptions
@@ -20,6 +20,7 @@ from botocore.hooks import first_non_none_response
 from botocore.exceptions import BotoCoreError
 from botocore.session import get_session
 
+from pynamodb.connection._botocore_private import BotocoreBaseClientPrivate
 from pynamodb.constants import (
     RETURN_CONSUMED_CAPACITY_VALUES, RETURN_ITEM_COLL_METRICS_VALUES,
     RETURN_ITEM_COLL_METRICS, RETURN_CONSUMED_CAPACITY, RETURN_VALUES_VALUES,
@@ -252,8 +253,8 @@ class Connection(object):
         self._tables: Dict[str, MetaTable] = {}
         self.host = host
         self._local = local()
-        self._client = None
-        self._convert_to_request_dict_kwargs = {}
+        self._client: Optional[BotocoreBaseClientPrivate] = None
+        self._convert_to_request_dict_kwargs: Dict[str, Any] = {}
         if region:
             self.region = region
         else:
@@ -522,7 +523,7 @@ class Connection(object):
         return self._local.session
 
     @property
-    def client(self):
+    def client(self) -> BotocoreBaseClientPrivate:
         """
         Returns a botocore dynamodb client
         """
@@ -536,7 +537,7 @@ class Connection(object):
                 connect_timeout=self._connect_timeout_seconds,
                 read_timeout=self._read_timeout_seconds,
                 max_pool_connections=self._max_pool_connections)
-            self._client = self.session.create_client(SERVICE_NAME, self.region, endpoint_url=self.host, config=config)
+            self._client = cast(BotocoreBaseClientPrivate, self.session.create_client(SERVICE_NAME, self.region, endpoint_url=self.host, config=config))
             self._convert_to_request_dict_kwargs = {}
             if 'endpoint_url' in inspect.signature(self._client._convert_to_request_dict).parameters:
                 self._convert_to_request_dict_kwargs['endpoint_url'] = self.host

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -538,7 +538,7 @@ class Connection(object):
                 max_pool_connections=self._max_pool_connections)
             self._client = self.session.create_client(SERVICE_NAME, self.region, endpoint_url=self.host, config=config)
             self._convert_to_request_dict_kwargs = {}
-            if 'endpoint_url' in inspect.getargs(self._client._convert_to_request_dict).args:
+            if 'endpoint_url' in inspect.signature(self._client._convert_to_request_dict).parameters:
                 self._convert_to_request_dict_kwargs['endpoint_url'] = self.host
         return self._client
 

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -1,6 +1,7 @@
 """
 Lowest level connection
 """
+import inspect
 import json
 import logging
 import random
@@ -252,6 +253,7 @@ class Connection(object):
         self.host = host
         self._local = local()
         self._client = None
+        self._convert_to_request_dict_kwargs = {}
         if region:
             self.region = region
         else:
@@ -358,6 +360,7 @@ class Connection(object):
         request_dict = self.client._convert_to_request_dict(
             operation_kwargs,
             operation_model,
+            **self._convert_to_request_dict_kwargs,
         )
 
         for i in range(0, self._max_retry_attempts_exception + 1):
@@ -534,6 +537,9 @@ class Connection(object):
                 read_timeout=self._read_timeout_seconds,
                 max_pool_connections=self._max_pool_connections)
             self._client = self.session.create_client(SERVICE_NAME, self.region, endpoint_url=self.host, config=config)
+            self._convert_to_request_dict_kwargs = {}
+            if 'endpoint_url' in inspect.getargs(self._client._convert_to_request_dict).args:
+                self._convert_to_request_dict_kwargs['endpoint_url'] = self.host
         return self._client
 
     def get_meta_table(self, table_name: str, refresh: bool = False):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,4 @@ typing-extensions==4.3.0
 pytest-cov
 
 # used for type-checking
-boto3-stubs[dynamodb]
+botocore-stubs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,6 @@ coveralls
 mypy==0.961
 typing-extensions==4.3.0
 pytest-cov
+
+# used for type-checking
+boto3-stubs[dynamodb]


### PR DESCRIPTION
botocore 1.28 [changed](https://github.com/boto/botocore/pull/2785) the signature of private method `botocore.client.BaseClient._convert_to_request_dict` adding an `endpoint_url` parameter. We are updating pynamodb to inspect the signature and add this parameter as needed.

P.S. we would probably need to backport this to 5.x.