### PR TITLE
Workaround for botocore 1.28 (round 2)

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+v5.2.3
+----------
+* Update for botocore 1.28 private API change (#1087) which caused the following exception::
+
+    TypeError: Cannot mix str and non-str arguments
+
+
 v5.2.2
 ----------
 * Update for botocore 1.28 private API change (#1083) which caused the following exception::

--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '5.2.2'
+__version__ = '5.2.3'

--- a/pynamodb/connection/_botocore_private.py
+++ b/pynamodb/connection/_botocore_private.py
@@ -1,7 +1,7 @@
 """
 Type-annotates the private botocore APIs that we're currently relying on.
 """
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import botocore.client
 import botocore.credentials
@@ -24,5 +24,23 @@ class BotocoreBaseClientPrivate(botocore.client.BaseClient):
     _request_signer: BotocoreRequestSignerPrivate
     _service_model: botocore.model.ServiceModel
 
-    def _convert_to_request_dict(self, api_params: Dict[str, Any], operation_model: botocore.model.OperationModel, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+    def _resolve_endpoint_ruleset(
+        self,
+        operation_model: botocore.model.OperationModel,
+        params: Dict[str, Any],
+        request_context: Dict[str, Any],
+        ignore_signing_region: bool = ...,
+    ):
+        ...
+
+    def _convert_to_request_dict(
+        self,
+        api_params: Dict[str, Any],
+        operation_model: botocore.model.OperationModel,
+        *,
+        endpoint_url: str = ...,  # added in botocore 1.28
+        context: Optional[Dict[str, Any]] = ...,
+        headers: Optional[Dict[str, Any]] = ...,
+        set_user_agent_header: bool = ...,
+    ) -> Dict[str, Any]:
         ...

--- a/tests/test_base_connection.py
+++ b/tests/test_base_connection.py
@@ -2,11 +2,14 @@
 Tests for the base connection class
 """
 import base64
+import io
 import json
 from unittest import mock, TestCase
 from unittest.mock import patch
 
 import botocore.exceptions
+import botocore.httpsession
+import urllib3
 from botocore.awsrequest import AWSPreparedRequest, AWSRequest, AWSResponse
 from botocore.client import ClientError
 from botocore.exceptions import BotoCoreError
@@ -1397,6 +1400,22 @@ class ConnectionTestCase(TestCase):
                 ScanError,
                 conn.scan,
                 table_name)
+
+    def test_make_api_call__happy_path(self):
+        response = AWSResponse(
+            url='https://www.example.com',
+            status_code=200,
+            raw=urllib3.HTTPResponse(
+                body=io.BytesIO(json.dumps({}).encode('utf-8')),
+                preload_content=False,
+            ),
+            headers={'x-amzn-RequestId': 'abcdef'},
+        )
+
+        c = Connection()
+
+        with patch.object(botocore.httpsession.URLLib3Session, 'send', return_value=response):
+            c._make_api_call('CreateTable', {'TableName': 'MyTable'})
 
     @mock.patch('pynamodb.connection.Connection.client')
     def test_make_api_call_throws_verbose_error_after_backoff(self, client_mock):


### PR DESCRIPTION
In #1083 we've started passing an `endpoint_url` parameter to `_convert_to_request_dict` due to changes made in botocore 1.28. 

All of our integration tests have an explicit `host`, and all our unit tests either mock `_make_api_call` entirely or mock the botocore client, so we didn't realize that `endpoint_url` cannot be `None`. To determine `endpoint_url` in botocore ≥1.28, we must call another private method, `_resolve_endpoint_ruleset`.