### PR TITLE
Workaround for botocore 1.28 (round 2)

### DIFF
--- a/pynamodb/connection/_botocore_private.py
+++ b/pynamodb/connection/_botocore_private.py
@@ -1,7 +1,7 @@
 """
 Type-annotates the private botocore APIs that we're currently relying on.
 """
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import botocore.client
 import botocore.credentials
@@ -24,5 +24,23 @@ class BotocoreBaseClientPrivate(botocore.client.BaseClient):
     _request_signer: BotocoreRequestSignerPrivate
     _service_model: botocore.model.ServiceModel
 
-    def _convert_to_request_dict(self, api_params: Dict[str, Any], operation_model: botocore.model.OperationModel, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+    def _resolve_endpoint_ruleset(
+        self,
+        operation_model: botocore.model.OperationModel,
+        params: Dict[str, Any],
+        request_context: Dict[str, Any],
+        ignore_signing_region: bool = ...,
+    ):
+        ...
+
+    def _convert_to_request_dict(
+        self,
+        api_params: Dict[str, Any],
+        operation_model: botocore.model.OperationModel,
+        *,
+        endpoint_url: str = ...,  # added in botocore 1.28
+        context: Optional[Dict[str, Any]] = ...,
+        headers: Optional[Dict[str, Any]] = ...,
+        set_user_agent_header: bool = ...,
+    ) -> Dict[str, Any]:
         ...


### PR DESCRIPTION
In #1083 we've started passing an `endpoint_url` parameter to _convert_to_request_dict due to changes made in botocore 1.28.

When a model does not specify a `host`, the `endpoint_url` would be `None`. To determine the actual `endpoint_url` in botocore ≥1.28, we must call another private method, `_resolve_endpoint_ruleset`.

We're not updating the release notes due to #1079 being expected to land.

This is a port of #1087.