### PR TITLE
Do not call DescribeTable for models

### DIFF
--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -568,15 +568,15 @@ class Connection(object):
 
     def add_meta_table(self, meta_table: MetaTable) -> None:
         """
-        Sets the meta table for a given table name
+        Adds information about the table's schema.
         """
         if meta_table.table_name in self._tables:
             raise ValueError(f"Meta-table for '{meta_table.table_name}' already added")
         self._tables[meta_table.table_name] = meta_table
 
-    def get_meta_table(self, table_name: str):
+    def get_meta_table(self, table_name: str) -> MetaTable:
         """
-        Returns a MetaTable
+        Returns information about the table's schema.
         """
         try:
             return self._tables[table_name]
@@ -612,8 +612,8 @@ class Connection(object):
             raise ValueError("attribute_definitions argument is required")
         for attr in attribute_definitions:
             attrs_list.append({
-                ATTR_NAME: attr.get('attribute_name'),
-                ATTR_TYPE: attr.get('attribute_type')
+                ATTR_NAME: attr.get(ATTR_NAME) or attr['attribute_name'],
+                ATTR_TYPE: attr.get(ATTR_TYPE) or attr['attribute_type']
             })
         operation_kwargs[ATTR_DEFINITIONS] = attrs_list
 
@@ -643,8 +643,8 @@ class Connection(object):
         key_schema_list = []
         for item in key_schema:
             key_schema_list.append({
-                ATTR_NAME: item.get('attribute_name'),
-                KEY_TYPE: str(item.get('key_type')).upper()
+                ATTR_NAME: item.get(ATTR_NAME) or item['attribute_name'],
+                KEY_TYPE: str(item.get(KEY_TYPE) or item['key_type']).upper()
             })
         operation_kwargs[KEY_SCHEMA] = sorted(key_schema_list, key=lambda x: x.get(KEY_TYPE))
 

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -80,6 +80,13 @@ class MetaTable(object):
         return ""
 
     @property
+    def table_name(self) -> str:
+        """
+        Returns the table name
+        """
+        return self.data[TABLE_NAME]
+
+    @property
     def range_keyname(self) -> Optional[str]:
         """
         Returns the name of this table's range key
@@ -559,25 +566,22 @@ class Connection(object):
             self._convert_to_request_dict__endpoint_url = 'endpoint_url' in inspect.signature(self._client._convert_to_request_dict).parameters
         return self._client
 
-    def get_meta_table(self, table_name: str, refresh: bool = False):
+    def add_meta_table(self, meta_table: MetaTable) -> None:
+        """
+        Sets the meta table for a given table name
+        """
+        if meta_table.table_name in self._tables:
+            raise ValueError(f"Meta-table for '{meta_table.table_name}' already added")
+        self._tables[meta_table.table_name] = meta_table
+
+    def get_meta_table(self, table_name: str):
         """
         Returns a MetaTable
         """
-        if table_name not in self._tables or refresh:
-            operation_kwargs = {
-                TABLE_NAME: table_name
-            }
-            try:
-                data = self.dispatch(DESCRIBE_TABLE, operation_kwargs)
-                self._tables[table_name] = MetaTable(data.get(TABLE_KEY))
-            except BotoCoreError as e:
-                raise TableError("Unable to describe table: {}".format(e), e)
-            except ClientError as e:
-                if 'ResourceNotFound' in e.response['Error']['Code']:
-                    raise TableDoesNotExist(e.response['Error']['Message'])
-                else:
-                    raise
-        return self._tables[table_name]
+        try:
+            return self._tables[table_name]
+        except KeyError:
+            raise TableError(f"Meta-table for '{table_name}' not initialized") from None
 
     def create_table(
         self,
@@ -767,13 +771,26 @@ class Connection(object):
         """
         Performs the DescribeTable operation
         """
+        operation_kwargs = {
+            TABLE_NAME: table_name
+        }
         try:
-            tbl = self.get_meta_table(table_name, refresh=True)
-            if tbl:
-                return tbl.data
-        except ValueError:
-            pass
-        raise TableDoesNotExist(table_name)
+            data = self.dispatch(DESCRIBE_TABLE, operation_kwargs)
+            table_data = data.get(TABLE_KEY)
+            # For compatibility with existing code which uses Connection directly,
+            # we can let DescribeTable set the meta table.
+            if table_data:
+                meta_table = MetaTable(table_data)
+                if meta_table.table_name not in self._tables:
+                    self.add_meta_table(meta_table)
+            return table_data
+        except BotoCoreError as e:
+            raise TableError("Unable to describe table: {}".format(e), e)
+        except ClientError as e:
+            if 'ResourceNotFound' in e.response['Error']['Code']:
+                raise TableDoesNotExist(e.response['Error']['Message'])
+            else:
+                raise
 
     def get_item_attribute_map(
         self,

--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -19,6 +19,7 @@ class TableConnection:
     def __init__(
         self,
         table_name: str,
+        meta_table: Optional[MetaTable] = None,
         region: Optional[str] = None,
         host: Optional[str] = None,
         connect_timeout_seconds: Optional[float] = None,
@@ -40,17 +41,19 @@ class TableConnection:
                                      base_backoff_ms=base_backoff_ms,
                                      max_pool_connections=max_pool_connections,
                                      extra_headers=extra_headers)
+        if meta_table is not None:
+            self.connection.add_meta_table(meta_table)
 
         if aws_access_key_id and aws_secret_access_key:
             self.connection.session.set_credentials(aws_access_key_id,
                                                     aws_secret_access_key,
                                                     aws_session_token)
 
-    def get_meta_table(self, refresh: bool = False) -> MetaTable:
+    def get_meta_table(self) -> MetaTable:
         """
         Returns a MetaTable
         """
-        return self.connection.get_meta_table(self.table_name, refresh=refresh)
+        return self.connection.get_meta_table(self.table_name)
 
     def get_operation_kwargs(
         self,

--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -19,7 +19,6 @@ class TableConnection:
     def __init__(
         self,
         table_name: str,
-        meta_table: Optional[MetaTable] = None,
         region: Optional[str] = None,
         host: Optional[str] = None,
         connect_timeout_seconds: Optional[float] = None,
@@ -31,6 +30,8 @@ class TableConnection:
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
+        *,
+        meta_table: Optional[MetaTable] = None,
     ) -> None:
         self.table_name = table_name
         self.connection = Connection(region=region,

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -871,18 +871,18 @@ class Model(AttributeContainer, metaclass=MetaModel):
         for attr_name, attr_cls in cls.get_attributes().items():
             if attr_cls.is_hash_key or attr_cls.is_range_key:
                 schema['attribute_definitions'].append({
-                    'attribute_name': attr_cls.attr_name,
-                    'attribute_type': attr_cls.attr_type
+                    ATTR_NAME: attr_cls.attr_name,
+                    ATTR_TYPE: attr_cls.attr_type
                 })
             if attr_cls.is_hash_key:
                 schema['key_schema'].append({
-                    'key_type': HASH,
-                    'attribute_name': attr_cls.attr_name
+                    KEY_TYPE: HASH,
+                    ATTR_NAME: attr_cls.attr_name
                 })
             elif attr_cls.is_range_key:
                 schema['key_schema'].append({
-                    'key_type': RANGE,
-                    'attribute_name': attr_cls.attr_name
+                    KEY_TYPE: RANGE,
+                    ATTR_NAME: attr_cls.attr_name
                 })
         for index in cls._indexes.values():
             index_schema = index._get_schema()
@@ -895,13 +895,13 @@ class Model(AttributeContainer, metaclass=MetaModel):
         attr_names = {key_schema[ATTR_NAME]
                       for index_schema in (*schema['global_secondary_indexes'], *schema['local_secondary_indexes'])
                       for key_schema in index_schema['key_schema']}
-        attr_keys = {attr.get('attribute_name') for attr in schema['attribute_definitions']}
+        attr_keys = {attr[ATTR_NAME] for attr in schema['attribute_definitions']}
         for attr_name in attr_names:
             if attr_name not in attr_keys:
                 attr_cls = cls.get_attributes()[cls._dynamo_to_python_attr(attr_name)]
                 schema['attribute_definitions'].append({
-                    'attribute_name': attr_cls.attr_name,
-                    'attribute_type': attr_cls.attr_type
+                    ATTR_NAME: attr_cls.attr_name,
+                    ATTR_TYPE: attr_cls.attr_type
                 })
         return schema
 
@@ -1067,20 +1067,8 @@ class Model(AttributeContainer, metaclass=MetaModel):
             schema = cls._get_schema()
             meta_table = MetaTable({
                 constants.TABLE_NAME: cls.Meta.table_name,
-                constants.KEY_SCHEMA: [
-                    {
-                        constants.KEY_TYPE: key_schema['key_type'],
-                        constants.ATTR_NAME: key_schema['attribute_name'],
-                    }
-                    for key_schema in schema['key_schema']
-                ],
-                constants.ATTR_DEFINITIONS: [
-                    {
-                        constants.ATTR_TYPE: attribute_definition['attribute_type'],
-                        constants.ATTR_NAME: attribute_definition['attribute_name'],
-                    }
-                    for attribute_definition in schema['attribute_definitions']
-                ],
+                constants.KEY_SCHEMA: schema['key_schema'],
+                constants.ATTR_DEFINITIONS: schema['attribute_definitions'],
                 constants.GLOBAL_SECONDARY_INDEXES: [
                     {
                         constants.INDEX_NAME: index_schema['index_name'],

--- a/tests/data.py
+++ b/tests/data.py
@@ -39,7 +39,6 @@ SIMPLE_MODEL_TABLE_DATA = {
     }
 }
 
-
 MODEL_TABLE_DATA = {
     "Table": {
         "AttributeDefinitions": [
@@ -342,89 +341,6 @@ DESCRIBE_TABLE_DATA = {
         "TableName": "Thread",
         "TableSizeBytes": 0,
         "TableStatus": "ACTIVE"
-    }
-}
-
-DESCRIBE_TABLE_DATA_PAY_PER_REQUEST = {
-    "Table": {
-        "AttributeDefinitions": [
-            {
-                "AttributeName": "ForumName",
-                "AttributeType": "S"
-            },
-            {
-                "AttributeName": "LastPostDateTime",
-                "AttributeType": "S"
-            },
-            {
-                "AttributeName": "Subject",
-                "AttributeType": "S"
-            }
-        ],
-        "CreationDateTime": 1.363729002358E9,
-        "ItemCount": 0,
-        "KeySchema": [
-            {
-                "AttributeName": "ForumName",
-                "KeyType": "HASH"
-            },
-            {
-                "AttributeName": "Subject",
-                "KeyType": "RANGE"
-            }
-        ],
-        "GlobalSecondaryIndexes": [
-            {
-                "IndexName": "LastPostIndex",
-                "IndexSizeBytes": 0,
-                "ItemCount": 0,
-                "KeySchema": [
-                    {
-                        "AttributeName": "ForumName",
-                        "KeyType": "HASH"
-                    },
-                    {
-                        "AttributeName": "LastPostDateTime",
-                        "KeyType": "RANGE"
-                    }
-                ],
-                "Projection": {
-                    "ProjectionType": "KEYS_ONLY"
-                }
-            }
-        ],
-        "LocalSecondaryIndexes": [
-            {
-                "IndexName": "LastPostIndex",
-                "IndexSizeBytes": 0,
-                "ItemCount": 0,
-                "KeySchema": [
-                    {
-                        "AttributeName": "ForumName",
-                        "KeyType": "HASH"
-                    },
-                    {
-                        "AttributeName": "LastPostDateTime",
-                        "KeyType": "RANGE"
-                    }
-                ],
-                "Projection": {
-                    "ProjectionType": "KEYS_ONLY"
-                }
-            }
-        ],
-        "ProvisionedThroughput": {
-            "NumberOfDecreasesToday": 0,
-            "ReadCapacityUnits": 0,
-            "WriteCapacityUnits": 0
-        },
-        "TableName": "Thread",
-        "TableSizeBytes": 0,
-        "TableStatus": "ACTIVE",
-        "BillingModeSummary": {
-            "BillingMode": "PAY_PER_REQUEST",
-            "LastUpdateToPayPerRequestDateTime": 1548353644.074
-        }
     }
 }
 

--- a/tests/test_base_connection.py
+++ b/tests/test_base_connection.py
@@ -64,7 +64,7 @@ class ConnectionTestCase(TestCase):
     """
 
     def setUp(self):
-        self.test_table_name = 'ci-table'
+        self.test_table_name = 'Thread'
         self.region = 'us-east-1'
 
     def test_create_connection(self):
@@ -153,7 +153,7 @@ class ConnectionTestCase(TestCase):
             }
         ]
         params = {
-            'TableName': 'ci-table',
+            'TableName': 'Thread',
             'ProvisionedThroughput': {
                 'WriteCapacityUnits': 1,
                 'ReadCapacityUnits': 1
@@ -295,7 +295,7 @@ class ConnectionTestCase(TestCase):
         """
         Connection.delete_table
         """
-        params = {'TableName': 'ci-table'}
+        params = {'TableName': 'Thread'}
         with patch(PATCH_METHOD) as req:
             req.return_value = None
             conn = Connection(self.region)
@@ -320,7 +320,7 @@ class ConnectionTestCase(TestCase):
                     'WriteCapacityUnits': 2,
                     'ReadCapacityUnits': 2
                 },
-                'TableName': 'ci-table'
+                'TableName': 'Thread'
             }
             conn.update_table(
                 self.test_table_name,
@@ -353,7 +353,7 @@ class ConnectionTestCase(TestCase):
                 }
             ]
             params = {
-                'TableName': 'ci-table',
+                'TableName': 'Thread',
                 'ProvisionedThroughput': {
                     'ReadCapacityUnits': 2,
                     'WriteCapacityUnits': 2,
@@ -387,17 +387,11 @@ class ConnectionTestCase(TestCase):
             req.return_value = DESCRIBE_TABLE_DATA
             conn = Connection(self.region)
             conn.describe_table(self.test_table_name)
-            self.assertEqual(req.call_args[0][1], {'TableName': 'ci-table'})
+            self.assertEqual(req.call_args[0][1], {'TableName': 'Thread'})
 
         with self.assertRaises(TableDoesNotExist):
             with patch(PATCH_METHOD) as req:
                 req.side_effect = ClientError({'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Not Found'}}, "DescribeTable")
-                conn = Connection(self.region)
-                conn.describe_table(self.test_table_name)
-
-        with self.assertRaises(TableDoesNotExist):
-            with patch(PATCH_METHOD) as req:
-                req.side_effect = ValueError()
                 conn = Connection(self.region)
                 conn.describe_table(self.test_table_name)
 
@@ -434,9 +428,7 @@ class ConnectionTestCase(TestCase):
         Connection.delete_item
         """
         conn = Connection(self.region)
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(self.test_table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.side_effect = BotoCoreError
@@ -587,9 +579,7 @@ class ConnectionTestCase(TestCase):
         """
         conn = Connection(self.region)
         table_name = 'Thread'
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.return_value = GET_ITEM_DATA
@@ -639,20 +629,11 @@ class ConnectionTestCase(TestCase):
         Connection.update_item
         """
         conn = Connection()
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(self.test_table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         self.assertRaises(ValueError, conn.update_item, self.test_table_name, 'foo-key')
 
         self.assertRaises(ValueError, conn.update_item, self.test_table_name, 'foo', actions=[])
-
-        attr_updates = {
-            'Subject': {
-                'Value': 'foo-subject',
-                'Action': 'PUT'
-            },
-        }
 
         with patch(PATCH_METHOD) as req:
             req.return_value = {}
@@ -689,7 +670,7 @@ class ConnectionTestCase(TestCase):
                         'S': 'foo-subject'
                     }
                 },
-                'TableName': 'ci-table'
+                'TableName': 'Thread'
             }
             self.assertEqual(req.call_args[0][1], params)
 
@@ -736,7 +717,7 @@ class ConnectionTestCase(TestCase):
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
-                'TableName': 'ci-table'
+                'TableName': 'Thread'
             }
             self.assertEqual(req.call_args[0][1], params)
 
@@ -756,9 +737,7 @@ class ConnectionTestCase(TestCase):
         Connection.put_item
         """
         conn = Connection(self.region)
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(self.test_table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.side_effect = BotoCoreError
@@ -955,9 +934,7 @@ class ConnectionTestCase(TestCase):
             conn.batch_write_item,
             table_name)
 
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.return_value = {}
@@ -1084,9 +1061,7 @@ class ConnectionTestCase(TestCase):
             items.append(
                 {"ForumName": "FooForum", "Subject": "thread-{}".format(i)}
             )
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.side_effect = BotoCoreError
@@ -1168,9 +1143,7 @@ class ConnectionTestCase(TestCase):
         """
         conn = Connection()
         table_name = 'Thread'
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with pytest.raises(ValueError, match="Table Thread has no index: NonExistentIndexName"):
             conn.query(table_name, "FooForum", limit=1, index_name='NonExistentIndexName')
@@ -1303,9 +1276,7 @@ class ConnectionTestCase(TestCase):
         conn = Connection()
         table_name = 'Thread'
 
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.return_value = {}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -669,12 +669,12 @@ class ModelTestCase(TestCase):
         schema = CustomAttrNameModel._get_schema()
         correct_schema = {
             'KeySchema': [
-                {'key_type': 'HASH', 'attribute_name': 'user_name'},
-                {'key_type': 'RANGE', 'attribute_name': 'user_id'}
+                {'KeyType': 'HASH', 'AttributeName': 'user_name'},
+                {'KeyType': 'RANGE', 'AttributeName': 'user_id'}
             ],
             'AttributeDefinitions': [
-                {'attribute_type': 'S', 'attribute_name': 'user_name'},
-                {'attribute_type': 'S', 'attribute_name': 'user_id'}
+                {'AttributeType': 'S', 'AttributeName': 'user_name'},
+                {'AttributeType': 'S', 'AttributeName': 'user_id'}
             ]
         }
         self.assert_dict_lists_equal(correct_schema['KeySchema'], schema['key_schema'])
@@ -2401,9 +2401,9 @@ class ModelTestCase(TestCase):
                 }
             ],
             'attribute_definitions': [
-                {'attribute_type': 'S', 'attribute_name': 'user_name'},
-                {'attribute_type': 'S', 'attribute_name': 'email'},
-                {'attribute_type': 'NS', 'attribute_name': 'numbers'}
+                {'AttributeType': 'S', 'AttributeName': 'user_name'},
+                {'AttributeType': 'S', 'AttributeName': 'email'},
+                {'AttributeType': 'NS', 'AttributeName': 'numbers'}
             ]
         }
         self.assert_dict_lists_equal(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -30,7 +30,6 @@ from pynamodb.attributes import (
     BooleanAttribute, ListAttribute, TTLAttribute, VersionAttribute)
 from .data import (
     MODEL_TABLE_DATA, GET_MODEL_ITEM_DATA, SIMPLE_MODEL_TABLE_DATA,
-    DESCRIBE_TABLE_DATA_PAY_PER_REQUEST,
     BATCH_GET_ITEMS, SIMPLE_BATCH_GET_ITEMS, COMPLEX_TABLE_DATA,
     COMPLEX_ITEM_DATA, INDEX_TABLE_DATA, LOCAL_INDEX_TABLE_DATA, DOG_TABLE_DATA,
     CUSTOM_ATTR_NAME_INDEX_TABLE_DATA, CUSTOM_ATTR_NAME_ITEM_DATA,
@@ -556,24 +555,11 @@ class ModelTestCase(TestCase):
         self.assertEqual(UserModel.Meta.read_capacity_units, 25)
         self.assertEqual(UserModel.Meta.write_capacity_units, 25)
 
-        # Test for wrong billing_mode
-        setattr(UserModel.Meta, 'billing_mode', 'WRONG')
-        with patch(PATCH_METHOD) as req:
-            req.return_value = MODEL_TABLE_DATA
-            self.assertRaises(ValueError)
-        delattr(UserModel.Meta, 'billing_mode')
-
         # A table with billing_mode set as on_demand
         self.assertEqual(BillingModeOnDemandModel.Meta.billing_mode, 'PAY_PER_REQUEST')
         with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA_PAY_PER_REQUEST
+            req.return_value = MODEL_TABLE_DATA
             BillingModeOnDemandModel.create_table(read_capacity_units=2, write_capacity_units=2)
-            self.assertEqual(BillingModeOnDemandModel._connection.get_meta_table().data
-                             .get('BillingModeSummary', {}).get('BillingMode', None), 'PAY_PER_REQUEST')
-            self.assertEqual(BillingModeOnDemandModel._connection.get_meta_table().data
-                             .get('ProvisionedThroughput', {}).get('ReadCapacityUnits', None), 0)
-            self.assertEqual(BillingModeOnDemandModel._connection.get_meta_table().data
-                             .get('ProvisionedThroughput', {}).get('WriteCapacityUnits', None), 0)
 
         UserModel._connection = None
 
@@ -2077,21 +2063,16 @@ class ModelTestCase(TestCase):
                 {
                     UNPROCESSED_ITEMS: {
                         UserModel.Meta.table_name: unprocessed_items[:2],
-                    }
+                    },
                 },
-                {
-                    UNPROCESSED_ITEMS: {
-                        UserModel.Meta.table_name: unprocessed_items[2:],
-                    }
-                },
-                {}
+                {},
             ]
 
             with UserModel.batch_write() as batch:
                 for item in items:
                     batch.save(item)
 
-            self.assertEqual(len(req.mock_calls), 3)
+            self.assertEqual(len(req.mock_calls), 2)
 
     def test_batch_write_raises_put_error(self):
         items = []
@@ -2111,19 +2092,11 @@ class ModelTestCase(TestCase):
             })
 
         with patch(PATCH_METHOD) as req:
-            req.side_effect = [
-                {
-                    UNPROCESSED_ITEMS: {
-                        BatchModel.Meta.table_name: unprocessed_items[:2],
-                    }
-                },
-                {
-                    UNPROCESSED_ITEMS: {
-                        BatchModel.Meta.table_name: unprocessed_items[2:],
-                    }
-                },
-                {}
-            ]
+            req.return_value = {
+                UNPROCESSED_ITEMS: {
+                    BatchModel.Meta.table_name: unprocessed_items[2:],
+                }
+            }
             with self.assertRaises(PutError):
                 with BatchModel.batch_write() as batch:
                     for item in items:


### PR DESCRIPTION
When using DynamoDB through a `Model` or `Index` (rather than `(Table)Connection` directly), we will derive the "meta-table" from the model itself rather than make an initial `DescribeTable` call. This has numerous advantages:
- Faster bootstrap (important for lambdas, as pointed out in #422)
- More consistent handling of attribute types: Before this change, if the PynamoDB model definition and the DynamoDB table definition disagreed on a key attribute's type, PynamoDB would use its own idea of the type in some code paths and the underlying type in others. Now it would consistently use its own idea of the type, allowing the erroneous model definition to be spotted sooner.
- Easier testing, since there's no longer a one-off request that only happens once and affects global state.

This approach attempts to change the library as little as possible, by synthesizing a MetaTable from the model.