### PR TITLE
5.x do not describe

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,19 @@
 Release Notes
 =============
 
+v5.3.0
+----------
+* No longer call ``DescribeTable`` API before first operation
+
+  Before this change, we would call ``DescribeTable`` before the first operation
+  on a given table in order to discover its schema. This slowed down bootstrap
+  (particularly important for lambdas), complicated testing and could potentially
+  cause inconsistent behavior since queries were serialized using the table's
+  (key) schema but deserialized using the model's schema.
+
+  With this change, both queries and models now use the model's schema.
+
+
 v5.2.3
 ----------
 * Update for botocore 1.28 private API change (#1087) which caused the following exception::

--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -30,6 +30,8 @@ class TableConnection:
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         aws_session_token: Optional[str] = None,
+        *,
+        meta_table: Optional[MetaTable] = None,
     ) -> None:
         self.table_name = table_name
         self.connection = Connection(region=region,
@@ -40,17 +42,19 @@ class TableConnection:
                                      base_backoff_ms=base_backoff_ms,
                                      max_pool_connections=max_pool_connections,
                                      extra_headers=extra_headers)
+        if meta_table is not None:
+            self.connection.add_meta_table(meta_table)
 
         if aws_access_key_id and aws_secret_access_key:
             self.connection.session.set_credentials(aws_access_key_id,
                                                     aws_secret_access_key,
                                                     aws_session_token)
 
-    def get_meta_table(self, refresh: bool = False) -> MetaTable:
+    def get_meta_table(self) -> MetaTable:
         """
         Returns a MetaTable
         """
-        return self.connection.get_meta_table(self.table_name, refresh=refresh)
+        return self.connection.get_meta_table(self.table_name)
 
     def get_operation_kwargs(
         self,

--- a/tests/data.py
+++ b/tests/data.py
@@ -39,7 +39,6 @@ SIMPLE_MODEL_TABLE_DATA = {
     }
 }
 
-
 MODEL_TABLE_DATA = {
     "Table": {
         "AttributeDefinitions": [
@@ -342,89 +341,6 @@ DESCRIBE_TABLE_DATA = {
         "TableName": "Thread",
         "TableSizeBytes": 0,
         "TableStatus": "ACTIVE"
-    }
-}
-
-DESCRIBE_TABLE_DATA_PAY_PER_REQUEST = {
-    "Table": {
-        "AttributeDefinitions": [
-            {
-                "AttributeName": "ForumName",
-                "AttributeType": "S"
-            },
-            {
-                "AttributeName": "LastPostDateTime",
-                "AttributeType": "S"
-            },
-            {
-                "AttributeName": "Subject",
-                "AttributeType": "S"
-            }
-        ],
-        "CreationDateTime": 1.363729002358E9,
-        "ItemCount": 0,
-        "KeySchema": [
-            {
-                "AttributeName": "ForumName",
-                "KeyType": "HASH"
-            },
-            {
-                "AttributeName": "Subject",
-                "KeyType": "RANGE"
-            }
-        ],
-        "GlobalSecondaryIndexes": [
-            {
-                "IndexName": "LastPostIndex",
-                "IndexSizeBytes": 0,
-                "ItemCount": 0,
-                "KeySchema": [
-                    {
-                        "AttributeName": "ForumName",
-                        "KeyType": "HASH"
-                    },
-                    {
-                        "AttributeName": "LastPostDateTime",
-                        "KeyType": "RANGE"
-                    }
-                ],
-                "Projection": {
-                    "ProjectionType": "KEYS_ONLY"
-                }
-            }
-        ],
-        "LocalSecondaryIndexes": [
-            {
-                "IndexName": "LastPostIndex",
-                "IndexSizeBytes": 0,
-                "ItemCount": 0,
-                "KeySchema": [
-                    {
-                        "AttributeName": "ForumName",
-                        "KeyType": "HASH"
-                    },
-                    {
-                        "AttributeName": "LastPostDateTime",
-                        "KeyType": "RANGE"
-                    }
-                ],
-                "Projection": {
-                    "ProjectionType": "KEYS_ONLY"
-                }
-            }
-        ],
-        "ProvisionedThroughput": {
-            "NumberOfDecreasesToday": 0,
-            "ReadCapacityUnits": 0,
-            "WriteCapacityUnits": 0
-        },
-        "TableName": "Thread",
-        "TableSizeBytes": 0,
-        "TableStatus": "ACTIVE",
-        "BillingModeSummary": {
-            "BillingMode": "PAY_PER_REQUEST",
-            "LastUpdateToPayPerRequestDateTime": 1548353644.074
-        }
     }
 }
 

--- a/tests/test_base_connection.py
+++ b/tests/test_base_connection.py
@@ -64,7 +64,7 @@ class ConnectionTestCase(TestCase):
     """
 
     def setUp(self):
-        self.test_table_name = 'ci-table'
+        self.test_table_name = 'Thread'
         self.region = DEFAULT_REGION
 
     def test_create_connection(self):
@@ -141,7 +141,7 @@ class ConnectionTestCase(TestCase):
             }
         ]
         params = {
-            'TableName': 'ci-table',
+            'TableName': 'Thread',
             'ProvisionedThroughput': {
                 'WriteCapacityUnits': 1,
                 'ReadCapacityUnits': 1
@@ -283,7 +283,7 @@ class ConnectionTestCase(TestCase):
         """
         Connection.delete_table
         """
-        params = {'TableName': 'ci-table'}
+        params = {'TableName': 'Thread'}
         with patch(PATCH_METHOD) as req:
             req.return_value = None
             conn = Connection(self.region)
@@ -308,7 +308,7 @@ class ConnectionTestCase(TestCase):
                     'WriteCapacityUnits': 2,
                     'ReadCapacityUnits': 2
                 },
-                'TableName': 'ci-table'
+                'TableName': 'Thread'
             }
             conn.update_table(
                 self.test_table_name,
@@ -341,7 +341,7 @@ class ConnectionTestCase(TestCase):
                 }
             ]
             params = {
-                'TableName': 'ci-table',
+                'TableName': 'Thread',
                 'ProvisionedThroughput': {
                     'ReadCapacityUnits': 2,
                     'WriteCapacityUnits': 2,
@@ -375,17 +375,11 @@ class ConnectionTestCase(TestCase):
             req.return_value = DESCRIBE_TABLE_DATA
             conn = Connection(self.region)
             conn.describe_table(self.test_table_name)
-            self.assertEqual(req.call_args[0][1], {'TableName': 'ci-table'})
+            self.assertEqual(req.call_args[0][1], {'TableName': 'Thread'})
 
         with self.assertRaises(TableDoesNotExist):
             with patch(PATCH_METHOD) as req:
                 req.side_effect = ClientError({'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Not Found'}}, "DescribeTable")
-                conn = Connection(self.region)
-                conn.describe_table(self.test_table_name)
-
-        with self.assertRaises(TableDoesNotExist):
-            with patch(PATCH_METHOD) as req:
-                req.side_effect = ValueError()
                 conn = Connection(self.region)
                 conn.describe_table(self.test_table_name)
 
@@ -422,9 +416,7 @@ class ConnectionTestCase(TestCase):
         Connection.delete_item
         """
         conn = Connection(self.region)
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(self.test_table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.side_effect = BotoCoreError
@@ -575,9 +567,7 @@ class ConnectionTestCase(TestCase):
         """
         conn = Connection(self.region)
         table_name = 'Thread'
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.return_value = GET_ITEM_DATA
@@ -627,20 +617,11 @@ class ConnectionTestCase(TestCase):
         Connection.update_item
         """
         conn = Connection()
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(self.test_table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         self.assertRaises(ValueError, conn.update_item, self.test_table_name, 'foo-key')
 
         self.assertRaises(ValueError, conn.update_item, self.test_table_name, 'foo', actions=[])
-
-        attr_updates = {
-            'Subject': {
-                'Value': 'foo-subject',
-                'Action': 'PUT'
-            },
-        }
 
         with patch(PATCH_METHOD) as req:
             req.return_value = {}
@@ -677,7 +658,7 @@ class ConnectionTestCase(TestCase):
                         'S': 'foo-subject'
                     }
                 },
-                'TableName': 'ci-table'
+                'TableName': 'Thread'
             }
             self.assertEqual(req.call_args[0][1], params)
 
@@ -724,7 +705,7 @@ class ConnectionTestCase(TestCase):
                     }
                 },
                 'ReturnConsumedCapacity': 'TOTAL',
-                'TableName': 'ci-table'
+                'TableName': 'Thread'
             }
             self.assertEqual(req.call_args[0][1], params)
 
@@ -744,9 +725,7 @@ class ConnectionTestCase(TestCase):
         Connection.put_item
         """
         conn = Connection(self.region)
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(self.test_table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.side_effect = BotoCoreError
@@ -943,9 +922,7 @@ class ConnectionTestCase(TestCase):
             conn.batch_write_item,
             table_name)
 
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.return_value = {}
@@ -1072,9 +1049,7 @@ class ConnectionTestCase(TestCase):
             items.append(
                 {"ForumName": "FooForum", "Subject": "thread-{}".format(i)}
             )
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.side_effect = BotoCoreError
@@ -1156,9 +1131,7 @@ class ConnectionTestCase(TestCase):
         """
         conn = Connection()
         table_name = 'Thread'
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with pytest.raises(ValueError, match="Table Thread has no index: NonExistentIndexName"):
             conn.query(table_name, "FooForum", limit=1, index_name='NonExistentIndexName')
@@ -1291,9 +1264,7 @@ class ConnectionTestCase(TestCase):
         conn = Connection()
         table_name = 'Thread'
 
-        with patch(PATCH_METHOD) as req:
-            req.return_value = DESCRIBE_TABLE_DATA
-            conn.describe_table(table_name)
+        conn.add_meta_table(MetaTable(DESCRIBE_TABLE_DATA[TABLE_KEY]))
 
         with patch(PATCH_METHOD) as req:
             req.return_value = {}


### PR DESCRIPTION
- Only set GSI provisioned throughput for provisioned billing modes. Fixes #1017 (#1018)
- Prepare for 5.2.1 release (#1019)
- Workaround for _convert_to_request_dict change (#1083)
- Update changelog for 5.2.2
- mention the _convert_to_request_dict exception
- Workaround for botocore 1.28 (round 2) (#1087)
- Do not call DescribeTable for models (#1091)
