### PR TITLE
Merge release notes from 5.x branch

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,33 @@ This is a major release and contains breaking changes. Please read the notes bel
 * Index count, query, and scan methods are now instance methods.
 
 
+v5.3.0
+----------
+* No longer call ``DescribeTable`` API before first operation
+
+  Before this change, we would call ``DescribeTable`` before the first operation
+  on a given table in order to discover its schema. This slowed down bootstrap
+  (particularly important for lambdas), complicated testing and could potentially
+  cause inconsistent behavior since queries were serialized using the table's
+  (key) schema but deserialized using the model's schema.
+
+  With this change, both queries and models now use the model's schema.
+
+
+v5.2.3
+----------
+* Update for botocore 1.28 private API change (#1087) which caused the following exception::
+
+    TypeError: Cannot mix str and non-str arguments
+
+
+v5.2.2
+----------
+* Update for botocore 1.28 private API change (#1083) which caused the following exception::
+
+    TypeError: _convert_to_request_dict() missing 1 required positional argument: 'endpoint_url'
+
+
 v5.2.1
 ----------
 * Fix issue from 5.2.0 with attempting to set GSI provisioned throughput on PAY_PER_REQUEST billing mode (#1018)


### PR DESCRIPTION
Users were naively going to the master branch's release notes, so I suppose we could update them whenever we backport changes (which shouldn't be very often).