### PR TITLE
AttributeContainer.__repr__: include all attrs

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -466,6 +466,10 @@ class AttributeContainer(metaclass=AttributeContainerMeta):
         AttributeContainer._container_deserialize(instance, attribute_values)
         return instance
 
+    def __repr__(self) -> str:
+        fields = ', '.join(f'{k}={v!r}' for k, v in self.attribute_values.items())
+        return f'{type(self).__name__}({fields})'
+
 
 class DiscriminatorAttribute(Attribute[type]):
     attr_type = STRING

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -399,13 +399,12 @@ class Model(AttributeContainer, metaclass=MetaModel):
         """
         return BatchWrite(cls, auto_commit=auto_commit, settings=settings)
 
-    def __repr__(self) -> str:
-        hash_key, range_key = self._get_serialized_keys()
-        if self._range_keyname:
-            msg = "{}<{}, {}>".format(self.Meta.table_name, hash_key, range_key)
-        else:
-            msg = "{}<{}>".format(self.Meta.table_name, hash_key)
-        return msg
+        # hash_key, range_key = self._get_serialized_keys()
+        # if self._range_keyname:
+        #     msg = "{}<{}, {}>".format(self.Meta.table_name, hash_key, range_key)
+        # else:
+        #     msg = "{}<{}>".format(self.Meta.table_name, hash_key)
+        # return msg
 
     def delete(self, condition: Optional[Condition] = None, settings: OperationSettings = OperationSettings.default) -> Any:
         """

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -399,13 +399,6 @@ class Model(AttributeContainer, metaclass=MetaModel):
         """
         return BatchWrite(cls, auto_commit=auto_commit, settings=settings)
 
-        # hash_key, range_key = self._get_serialized_keys()
-        # if self._range_keyname:
-        #     msg = "{}<{}, {}>".format(self.Meta.table_name, hash_key, range_key)
-        # else:
-        #     msg = "{}<{}>".format(self.Meta.table_name, hash_key)
-        # return msg
-
     def delete(self, condition: Optional[Condition] = None, settings: OperationSettings = OperationSettings.default) -> Any:
         """
         Deletes this object from dynamodb

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2907,6 +2907,10 @@ class ModelTestCase(TestCase):
         actual = instance.map_attr
         for k, v in map_native.items():
             self.assertEqual(v, actual[k])
+        self.assertEqual(
+            repr(actual),
+            "MapAttribute(foo='bar', num=1, bool_type=True, other_b_type=False, floaty=1.2, listy=[1, 2, 12345678909876543211234234324234], mapy={'baz': 'bongo'})"
+        )
 
     def test_raw_map_from_raw_data_works(self):
         map_native = {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -647,12 +647,12 @@ class ModelTestCase(TestCase):
         self.assertEqual(item.email, 'needs_email')
         self.assertEqual(item.callable_field, 42)
         self.assertEqual(
-            repr(item), '{}<{}, {}>'.format(UserModel.Meta.table_name, item.custom_user_name, item.user_id)
+            repr(item), "UserModel(callable_field=42, email='needs_email', custom_user_name='foo', user_id='bar')"
         )
 
         self.init_table_meta(SimpleUserModel, SIMPLE_MODEL_TABLE_DATA)
         item = SimpleUserModel('foo')
-        self.assertEqual(repr(item), '{}<{}>'.format(SimpleUserModel.Meta.table_name, item.user_name))
+        self.assertEqual(repr(item), "SimpleUserModel(user_name='foo')")
         self.assertRaises(ValueError, item.save)
 
         self.assertRaises(ValueError, UserModel.from_raw_data, None)
@@ -2801,6 +2801,10 @@ class ModelTestCase(TestCase):
                 item.person.fname,
                 COMPLEX_MODEL_ITEM_DATA.get(ITEM).get('weird_person').get(
                     MAP).get('firstName').get(STRING))
+            self.assertEqual(
+                repr(item),
+                "ComplexModel(key=123, person=Person(age=31, fname='Justin', is_male=True, lname='Phillips'))"
+            )
 
     def database_mocker(self, model, table_data, item_data,
                         primary_key_name, primary_key_dynamo_type, primary_key_id):


### PR DESCRIPTION
Making the representation more ergonomic (especially for MapAttributes, which currently have no `__repr__`), by switching to a [attrs](https://www.attrs.org/)-like repr.

Practically, for `Model`s, the repr is changing from
```
my_table_name<HashValue>
my_table_name<HashValue, RangeValue>
```
to
```
MyModel(my_hash_attr="HashValue", spam="ham")
MyModel(my_hash_attr="HashValue", my_range_attr="RangeValue", spam="ham")
```

and for `MapAttribute`s, the repr is changing from
```
<my_module.MyMap object at 0xdeadbeef>
```
to
```
MyMap(spam="ham")
```