### PR TITLE
Improve first iteration logic

### DIFF
--- a/pynamodb/pagination.py
+++ b/pynamodb/pagination.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Callable, Dict, Iterable, Iterator, TypeVar, Optional
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, TypeVar
 
 from pynamodb.constants import (CAMEL_COUNT, ITEMS, LAST_EVALUATED_KEY, SCANNED_COUNT,
                                 CONSUMED_CAPACITY, TOTAL, CAPACITY_UNITS)
@@ -172,14 +172,14 @@ class ResultIterator(Iterator[_T]):
         self._map_fn = map_fn
         self._limit = limit
         self._total_count = 0
-        self._items = None
+        self._items: List = []
         self._index = 0
         self._count = 0
 
     def _get_next_page(self) -> None:
         page = next(self.page_iter)
         self._count = page[CAMEL_COUNT]
-        self._items = page.get(ITEMS)  # not returned if 'Select' is set to 'COUNT'
+        self._items = page.get(ITEMS) or []  # not returned if 'Select' is set to 'COUNT'
         self._index = 0 if self._items else self._count
         self._total_count += self._count
 

--- a/pynamodb/pagination.py
+++ b/pynamodb/pagination.py
@@ -172,14 +172,13 @@ class ResultIterator(Iterator[_T]):
         self._map_fn = map_fn
         self._limit = limit
         self._total_count = 0
-        self._items: List = []
         self._index = 0
         self._count = 0
 
     def _get_next_page(self) -> None:
         page = next(self.page_iter)
         self._count = page[CAMEL_COUNT]
-        self._items = page.get(ITEMS) or []  # not returned if 'Select' is set to 'COUNT'
+        self._items = page.get(ITEMS)  # not returned if 'Select' is set to 'COUNT'
         self._index = 0 if self._items else self._count
         self._total_count += self._count
 

--- a/pynamodb/pagination.py
+++ b/pynamodb/pagination.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, TypeVar
+from typing import Any, Callable, Dict, Iterable, Iterator, Optional, TypeVar
 
 from pynamodb.constants import (CAMEL_COUNT, ITEMS, LAST_EVALUATED_KEY, SCANNED_COUNT,
                                 CONSUMED_CAPACITY, TOTAL, CAPACITY_UNITS)

--- a/pynamodb/pagination.py
+++ b/pynamodb/pagination.py
@@ -90,8 +90,8 @@ class PageIterator(Iterator[_T]):
         self._operation = operation
         self._args = args
         self._kwargs = kwargs
-        self._first_iteration = True
         self._last_evaluated_key = kwargs.get('exclusive_start_key')
+        self._is_last_page = False
         self._total_scanned_count = 0
         self._rate_limiter = None
         if rate_limit:
@@ -102,10 +102,8 @@ class PageIterator(Iterator[_T]):
         return self
 
     def __next__(self) -> _T:
-        if self._last_evaluated_key is None and not self._first_iteration:
+        if self._is_last_page:
             raise StopIteration()
-
-        self._first_iteration = False
 
         self._kwargs['exclusive_start_key'] = self._last_evaluated_key
 
@@ -114,6 +112,7 @@ class PageIterator(Iterator[_T]):
             self._kwargs['return_consumed_capacity'] = TOTAL
         page = self._operation(*self._args, settings=self._settings, **self._kwargs)
         self._last_evaluated_key = page.get(LAST_EVALUATED_KEY)
+        self._is_last_page = self._last_evaluated_key is None
         self._total_scanned_count += page[SCANNED_COUNT]
 
         if self._rate_limiter:
@@ -170,10 +169,12 @@ class ResultIterator(Iterator[_T]):
         settings: OperationSettings = OperationSettings.default,
     ) -> None:
         self.page_iter: PageIterator = PageIterator(operation, args, kwargs, rate_limit, settings)
-        self._first_iteration = True
         self._map_fn = map_fn
         self._limit = limit
         self._total_count = 0
+        self._items = None
+        self._index = 0
+        self._count = 0
 
     def _get_next_page(self) -> None:
         page = next(self.page_iter)
@@ -188,10 +189,6 @@ class ResultIterator(Iterator[_T]):
     def __next__(self) -> _T:
         if self._limit == 0:
             raise StopIteration
-
-        if self._first_iteration:
-            self._first_iteration = False
-            self._get_next_page()
 
         while self._index == self._count:
             self._get_next_page()
@@ -209,7 +206,7 @@ class ResultIterator(Iterator[_T]):
 
     @property
     def last_evaluated_key(self) -> Optional[Dict[str, Dict[str, Any]]]:
-        if self._first_iteration or self._index == self._count:
+        if self._index == self._count:
             # Not started iterating yet: return `exclusive_start_key` if set, otherwise expect None; or,
             # Entire page has been consumed: last_evaluated_key is whatever DynamoDB returned
             # It may correspond to the current item, or it may correspond to an item evaluated but not returned.


### PR DESCRIPTION
Improving the first iteration logic in `PageIterator` and `ResultIterator`.

Both iterators had a `_first_iteration` state attribute that could be replaced with better logic:
- In `PageIterator`, it can be replaced with `_is_last_page` which
  - is exception-safe (only mutate after we do I/O), and
  - (IMO) more directly relates to the state we're handling
- In `ResultsIterator`, we can do without `_first_iteration` (but we should initialize `_index` and `_count`)

Inspired by #1059.