### PR TITLE
create_table should include polymorphic indexes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e.[signals] sphinx sphinx-rtd-theme
+        python -m pip install -r docs/requirements.txt
     - name: Build docs
       run: |
         sphinx-build -W docs /tmp/docs-build

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+.[signals]
 sphinx-rtd-theme==0.4.3

--- a/pynamodb/_schema.py
+++ b/pynamodb/_schema.py
@@ -1,8 +1,16 @@
+import sys
 from typing import Dict
 from typing import List
 
-from typing_extensions import NotRequired
-from typing_extensions import TypedDict
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+if sys.version_info >= (3, 11):
+    from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
 
 
 class SchemaAttrDefinition(TypedDict):

--- a/pynamodb/_schema.py
+++ b/pynamodb/_schema.py
@@ -1,0 +1,43 @@
+from typing import Dict
+from typing import List
+
+from typing_extensions import NotRequired
+from typing_extensions import TypedDict
+
+
+class SchemaAttrDefinition(TypedDict):
+    AttributeName: str
+    AttributeType: str
+
+
+class KeySchema(TypedDict):
+    AttributeName: str
+    KeyType: str
+
+
+class Projection(TypedDict):
+    ProjectionType: str
+    NonKeyAttributes: NotRequired[List[str]]
+
+
+class IndexSchema(TypedDict):
+    index_name: str
+    key_schema: List[Dict[str, str]]
+    projection: Dict[str, str]
+    attribute_definitions: List[SchemaAttrDefinition]
+
+
+class ProvisionedThroughput(TypedDict, total=False):
+    ReadCapacityUnits: int
+    WriteCapacityUnits: int
+
+
+class GlobalSecondaryIndexSchema(IndexSchema):
+    provisioned_throughput: ProvisionedThroughput
+
+
+class ModelSchema(TypedDict):
+    attribute_definitions: List[SchemaAttrDefinition]
+    key_schema: List[KeySchema]
+    global_secondary_indexes: List[GlobalSecondaryIndexSchema]
+    local_secondary_indexes: List[IndexSchema]

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -487,7 +487,7 @@ class DiscriminatorAttribute(Attribute[type]):
 
         self._discriminator_map[discriminator] = cls
 
-    def get_registered_subclasses(self, cls: type) -> List[type]:
+    def get_registered_subclasses(self, cls: Type[_T]) -> List[Type[_T]]:
         return [k for k in self._class_map.keys() if issubclass(k, cls)]
 
     def get_discriminator(self, cls: type) -> Optional[Any]:

--- a/pynamodb/constants.py
+++ b/pynamodb/constants.py
@@ -1,6 +1,7 @@
 """
 Pynamodb constants
 """
+from typing_extensions import Final
 
 # Operations
 TRANSACT_WRITE_ITEMS = 'TransactWriteItems'
@@ -41,8 +42,8 @@ ATTRS_TO_GET = 'AttributesToGet'
 TABLE_STATUS = 'TableStatus'
 TABLE_NAME = 'TableName'
 KEY_SCHEMA = 'KeySchema'
-ATTR_NAME = 'AttributeName'
-ATTR_TYPE = 'AttributeType'
+ATTR_NAME: Final = 'AttributeName'
+ATTR_TYPE: Final = 'AttributeType'
 ITEM_COUNT = 'ItemCount'
 CAMEL_COUNT = 'Count'
 PUT_REQUEST = 'PutRequest'
@@ -51,7 +52,7 @@ ATTRIBUTES = 'Attributes'
 TABLE_KEY = 'Table'
 RESPONSES = 'Responses'
 RANGE_KEY = 'RangeKey'
-KEY_TYPE = 'KeyType'
+KEY_TYPE: Final = 'KeyType'
 UPDATE = 'Update'
 SELECT = 'Select'
 ACTIVE = 'ACTIVE'
@@ -100,8 +101,8 @@ DEFAULT_BILLING_MODE = PROVISIONED_BILLING_MODE
 
 # Create Table arguments
 PROVISIONED_THROUGHPUT = 'ProvisionedThroughput'
-READ_CAPACITY_UNITS = 'ReadCapacityUnits'
-WRITE_CAPACITY_UNITS = 'WriteCapacityUnits'
+READ_CAPACITY_UNITS: Final = 'ReadCapacityUnits'
+WRITE_CAPACITY_UNITS: Final = 'WriteCapacityUnits'
 BILLING_MODE = 'BillingMode'
 
 # Attribute Types

--- a/pynamodb/constants.py
+++ b/pynamodb/constants.py
@@ -1,7 +1,11 @@
 """
 Pynamodb constants
 """
-from typing_extensions import Final
+import sys
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final
 
 # Operations
 TRANSACT_WRITE_ITEMS = 'TransactWriteItems'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'botocore>=1.12.54',
-    'typing-extensions>=3.7; python_version<"3.8"'
+    'typing-extensions>=4; python_version<"3.11"',
 ]
 
 setup(

--- a/tests/integration/test_discriminator_index.py
+++ b/tests/integration/test_discriminator_index.py
@@ -1,0 +1,112 @@
+import pytest
+
+import pynamodb.exceptions
+from pynamodb.attributes import DiscriminatorAttribute
+from pynamodb.attributes import DynamicMapAttribute
+from pynamodb.attributes import ListAttribute
+from pynamodb.attributes import MapAttribute
+from pynamodb.attributes import NumberAttribute
+from pynamodb.attributes import UnicodeAttribute
+from pynamodb.indexes import AllProjection
+from pynamodb.models import Model
+from pynamodb.indexes import GlobalSecondaryIndex
+
+
+class TestDiscriminatorIndex:
+
+    def test_create_table(self, ddb_url):
+        class ParentModel(Model, discriminator='Parent'):
+            class Meta:
+                host = ddb_url
+                table_name = 'discriminator_index_test'
+                read_capacity_units = 1
+                write_capacity_units = 1
+
+            hash_key = UnicodeAttribute(hash_key=True)
+            cls = DiscriminatorAttribute()
+
+        class ChildIndex(GlobalSecondaryIndex):
+            class Meta:
+                index_name = 'child_index'
+                projection = AllProjection()
+                read_capacity_units = 1
+                write_capacity_units = 1
+
+            index_key = UnicodeAttribute(hash_key=True)
+
+        class ChildModel1(ParentModel, discriminator='Child1'):
+            child_index = ChildIndex()
+            index_key = UnicodeAttribute()
+
+        # Multiple child models can share the same index
+        class ChildModel2(ParentModel, discriminator='Child2'):
+            child_index = ChildIndex()
+            index_key = UnicodeAttribute()
+
+        # What's important to notice is that the child_index is not defined on the parent class.
+        # We're running `create_table` on the ParentModel, and expect it to know about child models
+        # (through the discriminator association) and include all child models' indexes
+        # during table creation.
+        ParentModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
+
+        model = ChildModel1()
+        model.hash_key = 'hash_key1'
+        model.index_key = 'bar'
+        model.save()
+
+        model = ChildModel2()
+        model.hash_key = 'hash_key2'
+        model.index_key = 'baz'
+        model.save()
+
+        model = next(ChildModel1.child_index.query('bar'))
+        assert isinstance(model, ChildModel1)
+
+        model = next(ChildModel2.child_index.query('baz'))
+        assert isinstance(model, ChildModel2)
+
+    def test_create_table__incompatible_indexes(self, ddb_url):
+        class ParentModel(Model, discriminator='Parent'):
+            class Meta:
+                host = ddb_url
+                table_name = 'discriminator_index_test__incompatible_indexes'
+                read_capacity_units = 1
+                write_capacity_units = 1
+
+            hash_key = UnicodeAttribute(hash_key=True)
+            cls = DiscriminatorAttribute()
+
+        class ChildIndex1(GlobalSecondaryIndex):
+            class Meta:
+                index_name = 'child_index1'
+                projection = AllProjection()
+                read_capacity_units = 1
+                write_capacity_units = 1
+
+            index_key = UnicodeAttribute(hash_key=True)
+
+        class ChildIndex2(GlobalSecondaryIndex):
+            class Meta:
+                index_name = 'child_index2'
+                projection = AllProjection()
+                read_capacity_units = 1
+                write_capacity_units = 1
+
+            # Intentionally a different type from ChildIndex1.index_key
+            index_key = NumberAttribute(hash_key=True)
+
+        # noinspection PyUnusedLocal
+        class ChildModel1(ParentModel, discriminator='Child1'):
+            child_index = ChildIndex1()
+            index_key = UnicodeAttribute()
+
+        # noinspection PyUnusedLocal
+        class ChildModel2(ParentModel, discriminator='Child2'):
+            child_index = ChildIndex2()
+            index_key = UnicodeAttribute()
+
+        # Unlike `test_create_table`, we expect this to fail because the child indexes
+        # attempt to use the same attribute name for different types, thus the resulting table's
+        # AttributeDefinitions would have the same attribute appear twice with conflicting types.
+        with pytest.raises(pynamodb.exceptions.TableError, match="Cannot have two attributes with the same name"):
+            ParentModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)

--- a/tests/integration/test_transaction_integration.py
+++ b/tests/integration/test_transaction_integration.py
@@ -137,6 +137,7 @@ def test_transact_write__error__idempotent_parameter_mismatch(connection):
 
 @pytest.mark.ddblocal
 def test_transact_write__error__different_regions(connection):
+    # Tip: This test *WILL* fail if run against `dynamodb-local -sharedDb` !
     with pytest.raises(TransactWriteError) as exc_info:
         with TransactWrite(connection=connection) as transact_write:
             # creating a model in a table outside the region everyone else operates in

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -481,6 +481,7 @@ class ModelTestCase(TestCase):
                 if d2_item == d1_item:
                     found = True
             if not found:
+                assert list1 == list2
                 raise AssertionError("Values not equal: {} {}".format(list1, list2))
 
     def test_create_model(self):
@@ -654,23 +655,37 @@ class ModelTestCase(TestCase):
         self.assertEqual(item.overidden_attr, 'test')
         self.assertTrue(not hasattr(item, 'foo_attr'))
 
-    def test_overidden_defaults(self):
+    def test_overridden_defaults(self):
         """
         Custom attribute names
         """
         schema = CustomAttrNameModel._get_schema()
-        correct_schema = {
-            'KeySchema': [
-                {'KeyType': 'HASH', 'AttributeName': 'user_name'},
-                {'KeyType': 'RANGE', 'AttributeName': 'user_id'}
+        self.assertListEqual(
+            schema['key_schema'],
+            [
+                {
+                    'KeyType': 'RANGE',
+                    'AttributeName': 'user_id'
+                },
+                {
+                    'KeyType': 'HASH',
+                    'AttributeName': 'user_name'
+                },
             ],
-            'AttributeDefinitions': [
-                {'AttributeType': 'S', 'AttributeName': 'user_name'},
-                {'AttributeType': 'S', 'AttributeName': 'user_id'}
+        )
+        self.assertListEqual(
+            schema['attribute_definitions'],
+            [
+                {
+                    'AttributeType': 'S',
+                    'AttributeName': 'user_id'
+                },
+                {
+                    'AttributeType': 'S',
+                    'AttributeName': 'user_name'
+                },
             ]
-        }
-        self.assert_dict_lists_equal(correct_schema['KeySchema'], schema['key_schema'])
-        self.assert_dict_lists_equal(correct_schema['AttributeDefinitions'], schema['attribute_definitions'])
+        )
 
     def test_overridden_attr_name(self):
         user = UserModel(custom_user_name="bob")
@@ -2300,43 +2315,22 @@ class ModelTestCase(TestCase):
         """
         schema = IndexedModel._get_schema()
 
-        expected = {
-            'local_secondary_indexes': [
-                {
-                    'KeySchema': [
-                        {'KeyType': 'HASH', 'AttributeName': 'email'},
-                        {'KeyType': 'RANGE', 'AttributeName': 'numbers'}
-                    ],
-                    'IndexName': 'include_index',
-                    'projection': {
-                        'ProjectionType': 'INCLUDE',
-                        'NonKeyAttributes': ['numbers']
-                    }
-                }
-            ],
-            'global_secondary_indexes': [
-                {
-                    'KeySchema': [
-                        {'KeyType': 'HASH', 'AttributeName': 'email'},
-                        {'KeyType': 'RANGE', 'AttributeName': 'numbers'}
-                    ],
-                    'IndexName': 'email_index',
-                    'projection': {'ProjectionType': 'ALL'},
-                    'provisioned_throughput': {
-                        'WriteCapacityUnits': 1,
-                        'ReadCapacityUnits': 2
-                    }
-                }
-            ],
-            'attribute_definitions': [
-                {'AttributeType': 'S', 'AttributeName': 'user_name'},
-                {'AttributeType': 'S', 'AttributeName': 'email'},
-                {'AttributeType': 'NS', 'AttributeName': 'numbers'}
-            ]
-        }
-        self.assert_dict_lists_equal(
+        self.assertListEqual(
             schema['attribute_definitions'],
-            expected['attribute_definitions']
+            [
+                {
+                    'AttributeType': 'S',
+                    'AttributeName': 'user_name'
+                },
+                {
+                    'AttributeType': 'NS',
+                    'AttributeName': 'numbers'
+                },
+                {
+                    'AttributeType': 'S',
+                    'AttributeName': 'email'
+                },
+            ]
         )
         self.assertEqual(schema['local_secondary_indexes'][0]['projection']['ProjectionType'], 'INCLUDE')
         self.assertEqual(schema['local_secondary_indexes'][0]['projection']['NonKeyAttributes'], ['numbers'])
@@ -2356,28 +2350,19 @@ class ModelTestCase(TestCase):
 
         with patch(PATCH_METHOD, new=fake_db) as req:
             LocalIndexedModel.create_table(read_capacity_units=2, write_capacity_units=2)
-            params = {
-                'AttributeDefinitions': [
-                    {
-                        'attribute_name': 'email', 'attribute_type': 'S'
-                    },
-                    {
-                        'attribute_name': 'numbers',
-                        'attribute_type': 'NS'
-                    }
-                ],
-                'KeySchema': [
+            schema = LocalIndexedModel.email_index._get_schema()
+            args = req.call_args[0][1]
+            self.assert_dict_lists_equal(
+                schema['key_schema'],
+                [
                     {
                         'AttributeName': 'email', 'KeyType': 'HASH'
                     },
                     {
                         'AttributeName': 'numbers', 'KeyType': 'RANGE'
                     }
-                ]
-            }
-            schema = LocalIndexedModel.email_index._get_schema()
-            args = req.call_args[0][1]
-            self.assert_dict_lists_equal(schema['key_schema'], params['KeySchema'])
+                ],
+            )
             self.assertTrue('ProvisionedThroughput' not in args['LocalSecondaryIndexes'][0])
 
     def test_projections(self):


### PR DESCRIPTION
With polymorphism, an index's key attribute might be defined only in a derived model (e.g. if it pertains only to a certain kind of model — for other models, it'd be a sparse index), and so it makes sense to add that index only to the derived model, e.g.
```python
class BaseModel(Model):
    ...
    cls = DescriminatorAttribute()

class DerivedIndex(GlobalSecondaryIndex):
    class Meta:
        index_name = 'derived'
        ...
    ham = UnicodeAttribute(hash_key=True)

class DerivedModel(BaseModel, discriminator='spam'):
    ham  = UnicodeAttribute()
    index = DerivedIndex()
```

A common pattern in a development environment is to use `Model.create_table`. For a polymorphic model, given you have to pick _one_ model to invoke `create_table` on, it only serves right that you invoke it on the base model.

Before this change, the base model's "schema"  didn't include all the derived models' indexes. With this change, it will.