### PR TITLE
Split BinaryAttribute into BinaryDataAttribute and LegacyBinaryAttribute

### DIFF
--- a/examples/attributes.py
+++ b/examples/attributes.py
@@ -2,7 +2,7 @@
 A PynamoDB example using a custom attribute
 """
 import pickle
-from pynamodb.attributes import BinaryAttribute, UnicodeAttribute
+from pynamodb.attributes import BinaryDataAttribute, UnicodeAttribute
 from pynamodb.models import Model
 
 
@@ -17,7 +17,7 @@ class Color(object):
         return "<Color: {}>".format(self.name)
 
 
-class PickleAttribute(BinaryAttribute):
+class PickleAttribute(BinaryDataAttribute):
     """
     This class will serializer/deserialize any picklable Python object.
     The value will be stored as a binary attribute in DynamoDB.

--- a/pynamodb/util.py
+++ b/pynamodb/util.py
@@ -1,6 +1,7 @@
 """
 Utils
 """
+import base64
 import json
 from typing import Any
 from typing import Dict
@@ -25,7 +26,11 @@ def attribute_value_to_json(attribute_value: Dict[str, Any]) -> Any:
         return {k: attribute_value_to_json(v) for k, v in attr_value.items()}
     if attr_type == NULL:
         return None
-    if attr_type in {BINARY, BINARY_SET, BOOLEAN, STRING, STRING_SET}:
+    if attr_type == BINARY:
+        return base64.b64encode(attr_value).decode()
+    if attr_type == BINARY_SET:
+        return [base64.b64encode(v).decode() for v in attr_value]
+    if attr_type in {BOOLEAN, STRING, STRING_SET}:
         return attr_value
     if attr_type == NUMBER:
         return json.loads(attr_value)

--- a/tests/integration/binary_update_test.py
+++ b/tests/integration/binary_update_test.py
@@ -1,6 +1,8 @@
 import pytest
 
-from pynamodb.attributes import UnicodeAttribute, BinaryAttribute, BinarySetAttribute
+from pynamodb.attributes import LegacyBinaryAttribute
+from pynamodb.attributes import LegacyBinarySetAttribute
+from pynamodb.attributes import UnicodeAttribute, BinaryDataAttribute, BinaryDataSetAttribute
 from pynamodb.models import Model
 
 
@@ -11,18 +13,83 @@ def test_binary_attribute_update(ddb_url):
             table_name = 'binary_attr_update'
             host = ddb_url
         pkey = UnicodeAttribute(hash_key=True)
-        data = BinaryAttribute()
+        data = BinaryDataAttribute()
+        legacy_data = LegacyBinaryAttribute()
 
     DataModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
     data = b'\x00hey\xfb'
     pkey = 'pkey'
-    DataModel(pkey, data=data).save()
+    DataModel(pkey, data=data, legacy_data=data).save()
     m = DataModel.get(pkey)
     assert m.data == data
+    assert m.legacy_data == data
 
     new_data = b'\xff'
-    m.update(actions=[DataModel.data.set(new_data)])
-    assert new_data == m.data
+    m.update(actions=[
+        DataModel.data.set(new_data),
+        DataModel.legacy_data.set(new_data),
+    ])
+    assert m.data == new_data
+    assert m.legacy_data == new_data
+
+
+@pytest.mark.ddblocal
+def test_binary_attribute_size(ddb_url):
+    class OldAttrModel(Model):
+        class Meta:
+            table_name = 'binary_attr_old'
+            host = ddb_url
+        pkey = UnicodeAttribute(hash_key=True)
+        data = LegacyBinaryAttribute()
+
+    class NewAttrModel(Model):
+        class Meta:
+            table_name = 'binary_attr_new'
+            host = ddb_url
+        pkey = UnicodeAttribute(hash_key=True)
+        data = BinaryDataAttribute()
+
+    OldAttrModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
+    NewAttrModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
+
+    old_model = OldAttrModel('pkey', data=b'spam' * 1000)
+    old_rcu = old_model.save()['ConsumedCapacity']['CapacityUnits']
+
+    new_model = NewAttrModel('pkey', data=b'spam' * 1000)
+    new_rcu = new_model.save()['ConsumedCapacity']['CapacityUnits']
+
+    assert old_rcu == 6
+    assert new_rcu == 4
+
+
+@pytest.mark.ddblocal
+def test_binary_set_attribute_size(ddb_url):
+    class OldAttrModel(Model):
+        class Meta:
+            table_name = 'binary_set_attr_old'
+            host = ddb_url
+        pkey = UnicodeAttribute(hash_key=True)
+        data = LegacyBinarySetAttribute()
+
+    class NewAttrModel(Model):
+        class Meta:
+            table_name = 'binary_set_attr_new'
+            host = ddb_url
+        pkey = UnicodeAttribute(hash_key=True)
+        data = BinaryDataSetAttribute()
+
+    OldAttrModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
+    NewAttrModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
+
+    old_model = OldAttrModel('pkey', data={b'spam' * 1000})
+    old_rcu = old_model.save()['ConsumedCapacity']['CapacityUnits']
+
+    new_model = NewAttrModel('pkey', data={b'spam' * 1000})
+    new_rcu = new_model.save()['ConsumedCapacity']['CapacityUnits']
+
+    assert old_rcu == 6
+    assert new_rcu == 4
+
 
 @pytest.mark.ddblocal
 def test_binary_set_attribute_update(ddb_url):
@@ -31,7 +98,7 @@ def test_binary_set_attribute_update(ddb_url):
             table_name = 'binary_set_attr_update'
             host = ddb_url
         pkey = UnicodeAttribute(hash_key=True)
-        data = BinarySetAttribute()
+        data = BinaryDataSetAttribute()
 
     DataModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
     data = {b'\x00hey\xfb', b'\x00beautiful\xfb'}

--- a/tests/integration/model_integration_test.py
+++ b/tests/integration/model_integration_test.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pynamodb.models import Model
 from pynamodb.indexes import GlobalSecondaryIndex, AllProjection, LocalSecondaryIndex
 from pynamodb.attributes import (
-    UnicodeAttribute, BinaryAttribute, UTCDateTimeAttribute, NumberSetAttribute, NumberAttribute,
+    UnicodeAttribute, BinaryDataAttribute, UTCDateTimeAttribute, NumberSetAttribute, NumberAttribute,
     VersionAttribute)
 
 import pytest
@@ -51,7 +51,7 @@ def test_model_integration(ddb_url):
         view_index = LSIndex()
         epoch_index = GSIndex()
         epoch = UTCDateTimeAttribute(default=datetime.now)
-        content = BinaryAttribute(null=True)
+        content = BinaryDataAttribute(null=True)
         scores = NumberSetAttribute()
         version = VersionAttribute()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -25,8 +25,8 @@ from pynamodb.indexes import (
     IncludeProjection, KeysOnlyProjection, Index
 )
 from pynamodb.attributes import (
-    DiscriminatorAttribute, UnicodeAttribute, NumberAttribute, BinaryAttribute, UTCDateTimeAttribute,
-    UnicodeSetAttribute, NumberSetAttribute, BinarySetAttribute, MapAttribute,
+    DiscriminatorAttribute, UnicodeAttribute, NumberAttribute, BinaryDataAttribute, UTCDateTimeAttribute,
+    UnicodeSetAttribute, NumberSetAttribute, BinaryDataSetAttribute, MapAttribute,
     BooleanAttribute, ListAttribute, TTLAttribute, VersionAttribute)
 from .data import (
     MODEL_TABLE_DATA, GET_MODEL_ITEM_DATA, SIMPLE_MODEL_TABLE_DATA,
@@ -149,7 +149,7 @@ class IndexedModel(Model):
     include_index = NonKeyAttrIndex()
     numbers = NumberSetAttribute()
     aliases = UnicodeSetAttribute()
-    icons = BinarySetAttribute()
+    icons = BinaryDataSetAttribute()
 
 
 class LocalIndexedModel(Model):
@@ -165,7 +165,7 @@ class LocalIndexedModel(Model):
     email_index = LocalEmailIndex()
     numbers = NumberSetAttribute()
     aliases = UnicodeSetAttribute()
-    icons = BinarySetAttribute()
+    icons = BinaryDataSetAttribute()
 
 
 class SimpleUserModel(Model):
@@ -180,7 +180,7 @@ class SimpleUserModel(Model):
     email = UnicodeAttribute()
     numbers = NumberSetAttribute()
     custom_aliases = UnicodeSetAttribute(attr_name='aliases')
-    icons = BinarySetAttribute()
+    icons = BinaryDataSetAttribute()
     views = NumberAttribute(null=True)
     is_active = BooleanAttribute(null=True)
     signature = UnicodeAttribute(null=True)
@@ -222,7 +222,7 @@ class UserModel(Model):
 
     custom_user_name = UnicodeAttribute(hash_key=True, attr_name='user_name')
     user_id = UnicodeAttribute(range_key=True)
-    picture = BinaryAttribute(null=True)
+    picture = BinaryDataAttribute(null=True)
     zip_code = NumberAttribute(null=True)
     email = UnicodeAttribute(default='needs_email')
     callable_field = NumberAttribute(default=lambda: 42)


### PR DESCRIPTION
For many versions we had a known issue where Binary(Set)Attribute were double-base64-encoded in the underlying DynamoDB table item. Clearly this is inefficient and we wanted PynamoDB to be efficient by default, but similarly didn't want to risk breaking applications during an upgrade.

With that in mind, we decided to split `BinaryAttribute` into `LegacyBinary(Set)Attribute` (the old behavior, for compatibility with existing data) and `BinaryData(Set)Attribute` (new correct behavior), the rationale being that a symbol rename will cause upgraded services to fail to load (or fail tests) and thus prompt an informed decision. The alternative was to keep `BinaryAttribute` with the broken behavior (and introduce a "V2" class for new behavior), which would make PynamoDB less elegant for green-field uses.

P.S. the word "data" after "binary" doesn't really serve a purpose, but simply an attempt to pick a name that's different yet ordinary