### PR TITLE
Fix double base64 of binary attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ build/
 
 # Ignore Cache
 .cache/
+
+# Ignore built docs
+docs/_build/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Topics
    contributing
    release_notes
    versioning
+   upgrading_binary
    upgrading_unicodeset
 
 API docs

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -18,7 +18,6 @@ This is a major release and contains breaking changes. Please read the notes bel
 * Index count, query, and scan methods are now instance methods.
 
 
-
 v5.3.0
 ----------
 * No longer call ``DescribeTable`` API before first operation

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -6,8 +6,17 @@ Unreleased
 
 This is a major release and contains breaking changes. Please read the notes below carefully.
 
+* :py:class:`~pynamodb.attributes.BinaryAttribute` and :py:class:`~pynamodb.attributes.BinarySetAttribute` have undergone breaking changes:
+
+  * The attributes' internal encoding has changed. To avoid this change going unnoticed, :code:`legacy_encoding` have been made required: see :doc:`upgrading_binary` for details.
+    If your codebase uses :py:class:`~pynamodb.attributes.BinaryAttribute` or :py:class:`~pynamodb.attributes.BinarySetAttribute`,
+    go over the attribute declarations and mark them accordingly.
+  * When using binary attributes, the return value of :py:func:`~pynamodb.model.Model.serialize` will no longer be JSON-serializable
+    since it will contain :code:`bytes` objects.
+
 * Python 3.6 is no longer supported.
 * Index count, query, and scan methods are now instance methods.
+
 
 
 v5.3.0

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,8 +11,8 @@ This is a major release and contains breaking changes. Please read the notes bel
   * The attributes' internal encoding has changed. To prevent this change going unnoticed, :code:`legacy_encoding` have been made required: see :doc:`upgrading_binary` for details.
     If your codebase uses :py:class:`~pynamodb.attributes.BinaryAttribute` or :py:class:`~pynamodb.attributes.BinarySetAttribute`,
     go over the attribute declarations and mark them accordingly.
-  * When using binary attributes, the return value of :py:func:`~pynamodb.model.Model.serialize` will no longer be JSON-serializable
-    since it will contain :code:`bytes` objects.
+  * When using binary attributes, the return value of :py:func:`~pynamodb.models.Model.serialize` will no longer be JSON-serializable
+    since it will contain :code:`bytes` objects. Note that both `:py:func:`~pynamodb.models.Model.to_dict` and `:py:func:`~pynamodb.model.Model.to_json` are also affected.
 
 * Python 3.6 is no longer supported.
 * Index count, query, and scan methods are now instance methods.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -8,7 +8,7 @@ This is a major release and contains breaking changes. Please read the notes bel
 
 * :py:class:`~pynamodb.attributes.BinaryAttribute` and :py:class:`~pynamodb.attributes.BinarySetAttribute` have undergone breaking changes:
 
-  * The attributes' internal encoding has changed. To avoid this change going unnoticed, :code:`legacy_encoding` have been made required: see :doc:`upgrading_binary` for details.
+  * The attributes' internal encoding has changed. To prevent this change going unnoticed, :code:`legacy_encoding` have been made required: see :doc:`upgrading_binary` for details.
     If your codebase uses :py:class:`~pynamodb.attributes.BinaryAttribute` or :py:class:`~pynamodb.attributes.BinarySetAttribute`,
     go over the attribute declarations and mark them accordingly.
   * When using binary attributes, the return value of :py:func:`~pynamodb.model.Model.serialize` will no longer be JSON-serializable

--- a/docs/upgrading_binary.rst
+++ b/docs/upgrading_binary.rst
@@ -18,14 +18,14 @@ which were addressed in PynamoDB 6:
 - Top-level binary attributes (i.e. within a :py:class:`~pynamodb.models.Model`) were being Base64-encoded
   twice. For elements in BinarySetAttribute, each element was being encoded twice.
 
-  This behavior was an oversight that carried no particular advantage, and the disadvantage of larger item sizes.
+  This behavior was an oversight and resulted in larger item sizes and non-standard semantics.
 
   .. admonition:: For example...
 
-     The 4 bytes :code:`b'\\xCA\\xFE\\xF0\\x0D'` should've been sent over the wire as :code:`b'yv7wDQ=='` (single round
+     The 4 bytes :code:`CA FE F0 0D` should've been sent over the wire as :code:`yv7wDQ==` (single round
      of Base64 encoding). Server-side, they would've been decoded and stored as 4 bytes. Instead, they were put through an extra
-     round of Base64 encoding, thus sending :code:`b'eXY3d0RRPT0='` over the wire. Server-side, they decoded into :code:`b'yv7wDQ=='`
-     and stored as 8 bytes.
+     round of Base64 encoding, thus sending :code:`eXY3d0RRPT0=` over the wire. Server-side, they decoded into :code:`yv7wDQ==`
+     (in bytes, :code:`79 76 37 77 44 51 3D 3D`) and stored as 8 bytes.
 
 - Nested binary attributes (i.e. within a :py:class:`~pynamodb.attributes.MapAttribute` and :py:class:`~pynamodb.attributes.ListAttribute`)
   were being wrapped in an additional layer of Base64 encoding on every serialization roundtrip.

--- a/docs/upgrading_binary.rst
+++ b/docs/upgrading_binary.rst
@@ -1,0 +1,191 @@
+Upgrading Binary(Set)Attribute
+==============================
+
+.. warning::
+
+    The behavior of :py:class:`~pynamodb.attributes.BinaryAttribute` and
+    :py:class:`~pynamodb.attributes.BinarySetAttribute` has changed in backwards-incompatible ways
+    as of the 6.0 release of PynamoDB.
+
+    To prevent data corruption, use :code:`legacy_encoding=True` for **existing** binary attributes.
+
+Context
+#######
+
+PynamoDB version 5 (and lower) had two bugs in the way they handled binary attributes,
+which were addressed in PynamoDB 6:
+
+- Top-level binary attributes (i.e. within a :py:class:`~pynamodb.models.Model`) were being Base64-encoded
+  twice. For elements in BinarySetAttribute, each element was being encoded twice.
+
+  This behavior was an oversight that carried no particular advantage, and the disadvantage of larger item sizes.
+
+  .. admonition:: For example...
+
+     The 4 bytes :code:`b'\\xCA\\xFE\\xF0\\x0D'` should've been sent over the wire as :code:`b'yv7wDQ=='` (single round
+     of Base64 encoding). Server-side, they would've been decoded and stored as 4 bytes. Instead, they were put through an extra
+     round of Base64 encoding, thus sending :code:`b'eXY3d0RRPT0='` over the wire. Server-side, they decoded into :code:`b'yv7wDQ=='`
+     and stored as 8 bytes.
+
+- Nested binary attributes (i.e. within a :py:class:`~pynamodb.attributes.MapAttribute` and :py:class:`~pynamodb.attributes.ListAttribute`)
+  were being wrapped in an additional layer of Base64 encoding on every serialization roundtrip.
+
+  Not only it prevented them from being deserialized correctly, but also the model would also grow
+  in size exponentially until it hit the DynamoDB item limit of 400KB. For this reason we conclude
+  that :code:`BinaryAttribute` and :code:`BinarySetAttribute` were not used in practice within maps and lists
+  before PynamoDB 6.0 and thus will not require any legacy encoding.
+
+
+Guidance
+########
+
+Top-level binary attributes
+***************************
+
+- For binary and binary-set attributes in models which were written by PynamoDB 5 (or lower),
+  use :code:`legacy_encoding=True`.
+
+  .. note::
+
+     In PynamoDB 6 we require this new parameter to be explicitly set to prevent inadvertent data corruption
+     during upgrades. By setting it to :code:`True` during an upgrade, the developer marks the attribute as pre-existing
+     and thus requiring legacy handling.
+
+  For example:
+
+  .. code-block:: diff
+
+      class SomeExistingModel(Model):
+     -  my_binary = BinaryAttribute()
+     +  my_binary = BinaryAttribute(legacy_encoding=True)
+
+  .. code-block:: diff
+
+      class SomeExistingModel(Model):
+     -  my_binary = BinarySetAttribute()
+     +  my_binary = BinarySetAttribute(legacy_encoding=True)
+
+  After the version upgrade is complete, you can consider adding a new binary attribute
+  and :ref:`migrating the data <migrating>`.
+
+- For binary and binary-set attributes in new models, use :code:`legacy_encoding=False`.
+
+  .. code-block:: python
+
+     class NewModel(Model):
+       my_binary = BinaryAttribute(legacy_encoding=False)
+       my_binary_set = BinarySetAttribute(legacy_encoding=False)
+
+
+Nested binary attributes
+************************
+
+- For binary and binary-set attributes in maps, use :code:`legacy_encoding=False`.
+
+  .. code-block:: python
+
+     class MyMap(MapAttribute):
+       binary = BinaryAttribute(legacy_encoding=False)
+       binary_set = BinarySetAttribute(legacy_encoding=False)
+
+- For binary and binary-set attributes in raw maps, normal (non-legacy) encoding will be used.
+
+  .. code-block:: python
+
+     class MyModel(Model):
+       my_raw_map = MapAttribute()
+
+     my_model = MyModel()
+     my_model.my_raw_map = MapAttribute(binary=b'foo')
+
+- For binary (set) attributes in lists, normal (non-legacy) encoding will be used.
+
+  This applies to both :code:`ListAttribute(of=BinaryAttribute)` and
+  :code:`of=BinarySetAttribute` as well as when :code:`of=...`
+  is not specified (for :code:`bytes` and :code:`Set[bytes]` elements).
+
+  For example:
+
+  .. code-block:: python
+
+     class MyModel(Model):
+       binary_list = ListAttribute(of=BinaryAttribute)
+       binary_set_list = ListAttribute(of=BinarySetAttribute)
+       mixed_list = ListAttribute()
+
+
+     model = MyModel()
+     model.binary_list = [b'\xCA', b'\xFE']
+     model.binary_set_list = [{b'\xCA', b'\xFE'}, {b'\xF0', b'\x0D'}]
+     model.mixed_list = [
+        b'\xCA\xFE',
+        {b'\xF0', b'\x0D'},
+     ]
+
+
+.. _migrating:
+
+Migrating
+#########
+
+Migrating existing systems off the legacy encoding is not necessary at this time. For large tables,
+there might be significant cost and engineering complexity involved. If you choose to do so,
+follow the typical steps for data migration:
+
+1. Double-write to both the old and new attribute. Read from the new, falling back to the old.
+
+  .. code-block:: python
+
+     class SomeExistingModel(Model):
+        _my_binary_v1 = BinaryAttribute(legacy_encoding=True, attr_name='my_binary')
+        _my_binary_v2 = BinaryAttribute(legacy_encoding=False, attr_name='my_binary_v2')
+
+        @property
+        def my_binary() -> bytes:
+          return self._my_binary_v1 if self._my_binary_v2 is None else self._my_binary_v2
+
+        @my_binary.setter
+        def my_binary(value: bytes) -> None:
+          self._my_binary_v1 = value
+          self._my_binary_v2 = value
+
+        def save(self, *args, **kwargs):
+          self.my_binary_v2 = self._my_binary_v1
+          return super().save(*args, **kwargs)
+
+2. Change the old attribute to be optional:
+
+   .. code-block:: diff
+
+      class SomeExistingModel(Model):
+     -   _my_binary_v1 = BinaryAttribute(legacy_encoding=True, attr_name='my_binary')
+     +   _my_binary_v1 = BinaryAttribute(legacy_encoding=True, attr_name='my_binary', null=True)
+
+   and rather than double-write to it, unset it by assigning :code:`None`:
+
+   .. code-block:: diff
+
+       @my_binary.setter
+       def my_binary(value: bytes) -> None:
+      -  self._my_binary_v1 = value
+      +  self._my_binary_v1 = None
+         self._my_binary_v2 = value
+
+       def save(self, *args, **kwargs):
+      -  self.my_binary_v2 = self._my_binary_v1
+      +  if self._my_binary_v1 is not None:
+      +    self.my_binary_v2 = self._my_binary_v1
+      +    self._my_binary_v1 = None
+         return super().save(*args, **kwargs)
+
+
+   At this point, you can either let natural migration run its course (as your online system
+   re-saves models), or you can perform a one-time migration by scanning the table and
+   re-saving each item.
+
+3. Once migration is done, remove the old attribute and all migration logic.
+
+  .. code-block:: python
+
+     class SomeExistingModel(Model):
+        my_binary = BinaryAttribute(legacy_encoding=False, attr_name='my_binary_v2')

--- a/docs/upgrading_binary.rst
+++ b/docs/upgrading_binary.rst
@@ -42,8 +42,7 @@ Guidance
 Top-level binary attributes
 ***************************
 
-- For binary and binary-set attributes in models which were written by PynamoDB 5 (or lower),
-  use :code:`legacy_encoding=True`.
+- In models existing at the time of an upgrade from PynamoDB 5 (or lower), use :code:`legacy_encoding=True`.
 
   .. note::
 
@@ -68,7 +67,7 @@ Top-level binary attributes
   After the version upgrade is complete, you can consider adding a new binary attribute
   and :ref:`migrating the data <migrating>`.
 
-- For binary and binary-set attributes in new models, use :code:`legacy_encoding=False`.
+- In new models, use :code:`legacy_encoding=False`.
 
   .. code-block:: python
 
@@ -80,7 +79,7 @@ Top-level binary attributes
 Nested binary attributes
 ************************
 
-- For binary and binary-set attributes in maps, use :code:`legacy_encoding=False`.
+- In maps, use :code:`legacy_encoding=False`.
 
   .. code-block:: python
 
@@ -88,7 +87,7 @@ Nested binary attributes
        binary = BinaryAttribute(legacy_encoding=False)
        binary_set = BinarySetAttribute(legacy_encoding=False)
 
-- For binary and binary-set attributes in raw maps, normal (non-legacy) encoding will be used.
+- In raw maps, normal (non-legacy) encoding will be used.
 
   .. code-block:: python
 
@@ -98,7 +97,7 @@ Nested binary attributes
      my_model = MyModel()
      my_model.my_raw_map = MapAttribute(binary=b'foo')
 
-- For binary (set) attributes in lists, normal (non-legacy) encoding will be used.
+- In lists, normal (non-legacy) encoding will be used.
 
   This applies to both :code:`ListAttribute(of=BinaryAttribute)` and
   :code:`of=BinarySetAttribute` as well as when :code:`of=...`

--- a/docs/upgrading_binary.rst
+++ b/docs/upgrading_binary.rst
@@ -33,7 +33,7 @@ which were addressed in PynamoDB 6:
   Not only it prevented them from being deserialized correctly, but also the model would also grow
   in size exponentially until it hit the DynamoDB item limit of 400KB. For this reason we conclude
   that :code:`BinaryAttribute` and :code:`BinarySetAttribute` were not used in practice within maps and lists
-  before PynamoDB 6.0 and thus will not require any legacy encoding.
+  before PynamoDB 6.0 and thus there is no practical reason you would want :code:`legacy_encoding=True` for them.
 
 
 Guidance
@@ -127,9 +127,16 @@ Nested binary attributes
 Migrating
 #########
 
-Migrating existing systems off the legacy encoding is not necessary at this time. For large tables,
-there might be significant cost and engineering complexity involved. If you choose to do so,
-follow the typical steps for data migration:
+Since PynamoDB 6 is compatible with existing data through :code:`legacy_encoding=True`, you do not need
+to migrate data during an upgrade. Whether you want to migrate data depends on your use case.
+Advantages include smaller item sizes and more standardized serialization. However, for large tables,
+there might be significant cost and engineering complexity involved.
+
+ .. warning::
+
+    Be sure to have an up-to-date backup of your data.
+
+These are the typical steps to migrate an attribute:
 
 1. Double-write to both the old and new attribute. Read from the new, falling back to the old.
 

--- a/examples/attributes.py
+++ b/examples/attributes.py
@@ -2,7 +2,11 @@
 A PynamoDB example using a custom attribute
 """
 import pickle
-from pynamodb.attributes import BinaryAttribute, UnicodeAttribute
+from typing import Any
+
+from pynamodb.attributes import Attribute
+from pynamodb.attributes import UnicodeAttribute
+from pynamodb.constants import BINARY
 from pynamodb.models import Model
 
 
@@ -10,27 +14,25 @@ class Color(object):
     """
     This class is used to demonstrate the PickleAttribute below
     """
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
 
-    def __str__(self):
+    def __repr__(self) -> str:
         return "<Color: {}>".format(self.name)
 
 
-class PickleAttribute(BinaryAttribute):
+class PickleAttribute(Attribute[object]):
     """
     This class will serializer/deserialize any picklable Python object.
     The value will be stored as a binary attribute in DynamoDB.
     """
-    def serialize(self, value):
-        """
-        The super class takes the binary string returned from pickle.dumps
-        and encodes it for storage in DynamoDB
-        """
-        return super(PickleAttribute, self).serialize(pickle.dumps(value))
+    attr_type = BINARY
 
-    def deserialize(self, value):
-        return pickle.loads(super(PickleAttribute, self).deserialize(value))
+    def serialize(self, value: Any) -> bytes:
+        return pickle.dumps(value)
+
+    def deserialize(self, value: Any) -> Any:
+        return pickle.loads(value)
 
 
 class CustomAttributeModel(Model):
@@ -44,7 +46,7 @@ class CustomAttributeModel(Model):
         write_capacity_units = 1
 
     id = UnicodeAttribute(hash_key=True)
-    obj = PickleAttribute(legacy_encoding=False)
+    obj = PickleAttribute()
 
 
 # Create the example table
@@ -53,7 +55,7 @@ if not CustomAttributeModel.exists():
 
 
 instance = CustomAttributeModel()
-instance.obj = Color('red')  # type: ignore
+instance.obj = Color('red')
 instance.id = 'red'
 instance.save()
 

--- a/examples/attributes.py
+++ b/examples/attributes.py
@@ -44,7 +44,7 @@ class CustomAttributeModel(Model):
         write_capacity_units = 1
 
     id = UnicodeAttribute(hash_key=True)
-    obj = PickleAttribute()
+    obj = PickleAttribute(legacy_encoding=False)
 
 
 # Create the example table

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -168,13 +168,21 @@ class Attribute(Generic[_T]):
 
     def serialize(self, value: Any) -> Any:
         """
-        This method should return a dynamodb compatible value
+        Serializes a value for botocore's DynamoDB client.
+
+        For a list of DynamoDB attribute types and their matching botocore Python types,
+        see `DynamoDB.Client.get_item API reference
+        <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.get_item>`_.
         """
         return value
 
     def deserialize(self, value: Any) -> Any:
         """
-        Performs any needed deserialization on the value
+        Deserializes a value from botocore's DynamoDB client.
+
+        For a list of DynamoDB attribute types and their matching botocore Python types,
+        see `DynamoDB.Client.get_item API reference
+        <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.get_item>`_.
         """
         return value
 
@@ -523,7 +531,7 @@ class DiscriminatorAttribute(Attribute[type]):
 
 class BinaryAttribute(Attribute[bytes]):
     """
-    A binary attribute
+    An attribute containing a binary data object (:code:`bytes`).
 
     :param legacy_encoding: If :code:`True`, inefficient legacy encoding will be used to maintain compatibility
       with PynamoDB 5 and lower. Set to :code:`False` for new tables and models, and always set to :code:`False`
@@ -550,7 +558,7 @@ class BinaryAttribute(Attribute[bytes]):
 
 class BinarySetAttribute(Attribute[Set[bytes]]):
     """
-    A binary set
+    An attribute containing a set of binary data objects (:code:`bytes`).
 
     :param legacy_encoding: If :code:`True`, inefficient legacy encoding will be used to maintain compatibility
       with PynamoDB 5 and lower. Set to :code:`False` for new tables and models, and always set to :code:`False`

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -1,6 +1,7 @@
 """
 PynamoDB attributes
 """
+import base64
 import calendar
 import collections.abc
 import json
@@ -20,7 +21,6 @@ from pynamodb.constants import BINARY
 from pynamodb.constants import BINARY_SET
 from pynamodb.constants import BOOLEAN
 from pynamodb.constants import DATETIME_FORMAT
-from pynamodb.constants import DEFAULT_ENCODING
 from pynamodb.constants import LIST
 from pynamodb.constants import MAP
 from pynamodb.constants import NULL
@@ -270,6 +270,7 @@ class Attribute(Generic[_T]):
 
 
 class AttributeContainerMeta(type):
+    _attributes: Dict[str, Attribute]
 
     def __new__(cls, name, bases, namespace, discriminator=None):
         # Defined so that the discriminator can be set in the class definition.
@@ -329,10 +330,8 @@ class AttributeContainer(metaclass=AttributeContainerMeta):
     def get_attributes(cls) -> Dict[str, Attribute]:
         """
         Returns the attributes of this class as a mapping from `python_attr_name` => `attribute`.
-
-        :rtype: dict[str, Attribute]
         """
-        return cls._attributes  # type: ignore
+        return cls._attributes
 
     @classmethod
     def _dynamo_to_python_attr(cls, dynamo_key: str) -> str:
@@ -443,8 +442,10 @@ class AttributeContainer(metaclass=AttributeContainerMeta):
     def _coerce_attribute_type(attr_type: str, attribute_value: Dict[str, Any]):
         # coerce attribute types to disambiguate json string and array types
         if attr_type == BINARY and STRING in attribute_value:
-            attribute_value[BINARY] = attribute_value.pop(STRING)
-        if attr_type in {BINARY_SET, NUMBER_SET, STRING_SET} and LIST in attribute_value:
+            attribute_value[BINARY] = base64.b64decode(attribute_value.pop(STRING))
+        elif attr_type == BINARY_SET and LIST in attribute_value:
+            attribute_value[BINARY_SET] = [base64.b64decode(v[STRING]) for v in attribute_value.pop(LIST)]
+        elif attr_type in {NUMBER_SET, STRING_SET} and LIST in attribute_value:
             json_type = NUMBER if attr_type == NUMBER_SET else STRING
             if all(next(iter(v)) == json_type for v in attribute_value[LIST]):
                 attribute_value[attr_type] = [value[json_type] for value in attribute_value.pop(LIST)]
@@ -523,40 +524,62 @@ class DiscriminatorAttribute(Attribute[type]):
 class BinaryAttribute(Attribute[bytes]):
     """
     A binary attribute
+
+    :param legacy_encoding: If :code:`True`, inefficient legacy encoding will be used to maintain compatibility
+      with PynamoDB 5 and lower. Set to :code:`False` for new tables and models, and always set to :code:`False`
+      within :class:`pynamodb.attributes.MapAttribute`.
+
+      For more details, see :doc:`upgrading_binary`.
     """
     attr_type = BINARY
 
+    def __init__(self, *args: Any, legacy_encoding: bool, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.legacy_encoding = legacy_encoding
+
     def serialize(self, value):
-        """
-        Returns a base64 encoded binary string
-        """
-        return b64encode(value).decode(DEFAULT_ENCODING)
+        if self.legacy_encoding:
+            return b64encode(value)
+        return value
 
     def deserialize(self, value):
-        """
-        Returns a decoded byte string from a base64 encoded value
-        """
-        return b64decode(value)
+        if self.legacy_encoding:
+            return b64decode(value)
+        return value
 
 
 class BinarySetAttribute(Attribute[Set[bytes]]):
     """
     A binary set
+
+    :param legacy_encoding: If :code:`True`, inefficient legacy encoding will be used to maintain compatibility
+      with PynamoDB 5 and lower. Set to :code:`False` for new tables and models, and always set to :code:`False`
+      within :class:`pynamodb.attributes.MapAttribute`.
+
+      For more details, see :doc:`upgrading_binary`.
     """
     attr_type = BINARY_SET
     null = True
+
+    def __init__(self, *args: Any, legacy_encoding: bool, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.legacy_encoding = legacy_encoding
 
     def serialize(self, value):
         """
         Returns a list of base64 encoded binary strings. Encodes empty sets as "None".
         """
-        return [b64encode(v).decode(DEFAULT_ENCODING) for v in value] or None
+        if self.legacy_encoding:
+            return [b64encode(v) for v in value] or None
+        return list(value) or None
 
     def deserialize(self, value):
         """
         Returns a set of decoded byte strings from base64 encoded values.
         """
-        return {b64decode(v) for v in value}
+        if self.legacy_encoding:
+            return {b64decode(v) for v in value}
+        return set(value)
 
 
 class UnicodeAttribute(Attribute[str]):
@@ -800,7 +823,18 @@ class NullAttribute(Attribute[None]):
         return None
 
 
-class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
+class MetaMapAttribute(AttributeContainerMeta):
+    def __init__(self, name, bases, namespace, discriminator=None):
+        super().__init__(name, bases, namespace, discriminator=discriminator)
+        for attr_name, attr in self._attributes.items():
+            if isinstance(attr, (BinaryAttribute, BinarySetAttribute)) and attr.legacy_encoding:
+                raise ValueError(
+                    "Legacy encoding is only ever needed for top-level (model) attributes. "
+                    f"Please remove the legacy_encoding flag from the definition of '{attr_name}'."
+                )
+
+
+class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer, metaclass=MetaMapAttribute):
     """
     A Map Attribute
 
@@ -1152,15 +1186,28 @@ class DynamicMapAttribute(MapAttribute):
         return True
 
 
-def _get_class_for_serialize(value):
+def _get_class_for_serialize(value: Any) -> Attribute:
     if value is None:
         return NullAttribute()
     if isinstance(value, MapAttribute):
         return value
+    if isinstance(value, set):
+        set_types = {type(v) for v in value}
+        if not set_types:
+            raise ValueError("Cannot serialize empty set")
+        if set_types == {str}:
+            return UnicodeSetAttribute()
+        if set_types <= {int, float}:
+            return NumberSetAttribute()
+        if set_types == {bytes}:
+            return BinarySetAttribute(legacy_encoding=False)
+        raise ValueError(f"Cannot serialize set consisting of types: {', '.join(sorted(map(repr, set_types)))}")
+
     value_type = type(value)
-    if value_type not in SERIALIZE_CLASS_MAP:
-        raise ValueError('Unknown value: {}'.format(value_type))
-    return SERIALIZE_CLASS_MAP[value_type]
+    attr = SERIALIZE_CLASS_MAP.get(value_type)
+    if attr is None:
+        raise ValueError(f"Unsupported value type '{value_type}'")
+    return attr
 
 
 class ListAttribute(Generic[_T], Attribute[List[_T]]):
@@ -1215,15 +1262,19 @@ class ListAttribute(Generic[_T], Attribute[List[_T]]):
         Decode from list of AttributeValue types.
         """
         if self.element_type:
-            element_attr = self.element_type()
-            if isinstance(element_attr, MapAttribute):
-                element_attr._make_attribute()  # ensure attr_name exists
+            element_attr: Attribute
+            if issubclass(self.element_type, (BinaryAttribute, BinarySetAttribute)):
+                element_attr = self.element_type(legacy_encoding=False)
+            else:
+                element_attr = self.element_type()
+                if isinstance(element_attr, MapAttribute):
+                    element_attr._make_attribute()  # ensure attr_name exists
             deserialized_lst = []
             for idx, attribute_value in enumerate(values):
                 value = None
                 if NULL not in attribute_value:
                     # set attr_name in case `get_value` raises an exception
-                    element_attr.attr_name = '{}[{}]'.format(self.attr_name, idx)
+                    element_attr.attr_name = f'{self.attr_name}[{idx}]' if self.attr_name else f'[{idx}]'
                     value = element_attr.deserialize(element_attr.get_value(attribute_value))
                 deserialized_lst.append(value)
             return deserialized_lst
@@ -1257,13 +1308,15 @@ class ListAttribute(Generic[_T], Attribute[List[_T]]):
         if isinstance(value, Attribute):
             return value
         if self.element_type:
+            if issubclass(self.element_type, (BinaryAttribute, BinarySetAttribute)):
+                return self.element_type(legacy_encoding=False)
             return self.element_type()
-        return SERIALIZE_CLASS_MAP[type(value)]
+        return _get_class_for_serialize(value)
 
 
 DESERIALIZE_CLASS_MAP: Dict[str, Attribute] = {
-    BINARY: BinaryAttribute(),
-    BINARY_SET: BinarySetAttribute(),
+    BINARY: BinaryAttribute(legacy_encoding=False),
+    BINARY_SET: BinarySetAttribute(legacy_encoding=False),
     BOOLEAN: BooleanAttribute(),
     LIST: ListAttribute(),
     MAP: MapAttribute(),
@@ -1274,13 +1327,12 @@ DESERIALIZE_CLASS_MAP: Dict[str, Attribute] = {
     STRING_SET: UnicodeSetAttribute()
 }
 
-SERIALIZE_CLASS_MAP = {
+SERIALIZE_CLASS_MAP: Mapping[type, Attribute] = {
     dict: MapAttribute(),
     list: ListAttribute(),
-    set: ListAttribute(),
     bool: BooleanAttribute(),
     float: NumberAttribute(),
     int: NumberAttribute(),
     str: UnicodeAttribute(),
-    bytes: BinaryAttribute(),
+    bytes: BinaryAttribute(legacy_encoding=False),
 }

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -527,7 +527,7 @@ class BinaryAttribute(Attribute[bytes]):
 
     :param legacy_encoding: If :code:`True`, inefficient legacy encoding will be used to maintain compatibility
       with PynamoDB 5 and lower. Set to :code:`False` for new tables and models, and always set to :code:`False`
-      within :class:`pynamodb.attributes.MapAttribute`.
+      within :class:`~pynamodb.attributes.MapAttribute`.
 
       For more details, see :doc:`upgrading_binary`.
     """
@@ -554,7 +554,7 @@ class BinarySetAttribute(Attribute[Set[bytes]]):
 
     :param legacy_encoding: If :code:`True`, inefficient legacy encoding will be used to maintain compatibility
       with PynamoDB 5 and lower. Set to :code:`False` for new tables and models, and always set to :code:`False`
-      within :class:`pynamodb.attributes.MapAttribute`.
+      within :class:`~pynamodb.attributes.MapAttribute`.
 
       For more details, see :doc:`upgrading_binary`.
     """

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1118,6 +1118,11 @@ class Model(AttributeContainer, metaclass=MetaModel):
         """
         Serializes a model for botocore's DynamoDB client.
 
+        .. warning::
+            BINARY and BINARY_SET attributes (whether top-level or nested) serialization would contain
+            :code:`bytes` objects which are not JSON-serializable by the :code:`json` module.
+            You may use a custom JSON encoder to serialize such models.
+
         See :func:`~pynamodb.models.Model.to_dict` for a simple JSON-serializable dict.
         """
         return self._container_serialize(null_check=null_check)

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1124,14 +1124,16 @@ class Model(AttributeContainer, metaclass=MetaModel):
 
     def serialize(self, null_check: bool = True) -> Dict[str, Dict[str, Any]]:
         """
-        Serialize attribute values for DynamoDB API.
+        Serializes a model for botocore's DynamoDB client.
+
         See :func:`~pynamodb.models.Model.to_dict` for a simple JSON-serializable dict.
         """
         return self._container_serialize(null_check=null_check)
 
     def deserialize(self, attribute_values: Dict[str, Dict[str, Any]]) -> None:
         """
-        Sets attributes sent back from DynamoDB on this object.
+        Deserializes a model from botocore's DynamoDB client.
+
         Use :func:`~pynamodb.models.Model.from_dict` to set attributes from a dict
         previously produced by :func:`~pynamodb.models.Model.to_dict`.
         """

--- a/pynamodb/util.py
+++ b/pynamodb/util.py
@@ -1,6 +1,7 @@
 """
 Utils
 """
+import base64
 import json
 from typing import Any
 from typing import Dict
@@ -25,7 +26,11 @@ def attribute_value_to_json(attribute_value: Dict[str, Any]) -> Any:
         return {k: attribute_value_to_json(v) for k, v in attr_value.items()}
     if attr_type == NULL:
         return None
-    if attr_type in {BINARY, BINARY_SET, BOOLEAN, STRING, STRING_SET}:
+    if attr_type == BINARY:
+        return base64.b64encode(attr_value).decode()
+    if attr_type == BINARY_SET:
+        return [base64.b64encode(v).decode() for v in attr_value]
+    if attr_type in {BOOLEAN, STRING, STRING_SET}:
         return attr_value
     if attr_type == NUMBER:
         return json.loads(attr_value)

--- a/tests/integration/binary_update_test.py
+++ b/tests/integration/binary_update_test.py
@@ -5,13 +5,14 @@ from pynamodb.models import Model
 
 
 @pytest.mark.ddblocal
-def test_binary_attribute_update(ddb_url):
+@pytest.mark.parametrize('legacy_encoding', [False, True])
+def test_binary_set_attribute_update(legacy_encoding: bool, ddb_url: str) -> None:
     class DataModel(Model):
         class Meta:
-            table_name = 'binary_attr_update'
+            table_name = f'binary_attr_update__legacy_{legacy_encoding}'
             host = ddb_url
         pkey = UnicodeAttribute(hash_key=True)
-        data = BinaryAttribute()
+        data = BinaryAttribute(legacy_encoding=legacy_encoding)
 
     DataModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
     data = b'\x00hey\xfb'
@@ -24,14 +25,16 @@ def test_binary_attribute_update(ddb_url):
     m.update(actions=[DataModel.data.set(new_data)])
     assert new_data == m.data
 
+
 @pytest.mark.ddblocal
-def test_binary_set_attribute_update(ddb_url):
+@pytest.mark.parametrize('legacy_encoding', [False, True])
+def test_binary_set_attribute_update(legacy_encoding: bool, ddb_url: str) -> None:
     class DataModel(Model):
         class Meta:
-            table_name = 'binary_set_attr_update'
+            table_name = f'binary_set_attr_update__legacy_{legacy_encoding}'
             host = ddb_url
         pkey = UnicodeAttribute(hash_key=True)
-        data = BinarySetAttribute()
+        data = BinarySetAttribute(legacy_encoding=legacy_encoding)
 
     DataModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
     data = {b'\x00hey\xfb', b'\x00beautiful\xfb'}

--- a/tests/integration/model_integration_test.py
+++ b/tests/integration/model_integration_test.py
@@ -51,7 +51,7 @@ def test_model_integration(ddb_url):
         view_index = LSIndex()
         epoch_index = GSIndex()
         epoch = UTCDateTimeAttribute(default=datetime.now)
-        content = BinaryAttribute(null=True)
+        content = BinaryAttribute(null=True, legacy_encoding=False)
         scores = NumberSetAttribute()
         version = VersionAttribute()
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -8,6 +8,8 @@ from base64 import b64encode
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from typing import List
+from typing import Set
 
 from unittest.mock import patch, call
 import pytest
@@ -17,10 +19,15 @@ from pynamodb.attributes import (
     UnicodeAttribute, UnicodeSetAttribute, UTCDateTimeAttribute, BooleanAttribute, MapAttribute, NullAttribute,
     ListAttribute, JSONAttribute, TTLAttribute, VersionAttribute, Attribute)
 from pynamodb.constants import (
-    DATETIME_FORMAT, DEFAULT_ENCODING, NUMBER, STRING, STRING_SET, NUMBER_SET, BINARY_SET,
+    NUMBER, STRING, STRING_SET, NUMBER_SET, BINARY_SET,
     BINARY, BOOLEAN,
 )
 from pynamodb.models import Model
+
+
+class AttributeTestMapAttribute(MapAttribute):
+    string = UnicodeAttribute()
+    binary = BinaryAttribute(legacy_encoding=False)
 
 
 class AttributeTestModel(Model):
@@ -29,8 +36,8 @@ class AttributeTestModel(Model):
         host = 'http://localhost:8000'
         table_name = 'test'
 
-    binary_attr = BinaryAttribute(hash_key=True)
-    binary_set_attr = BinarySetAttribute()
+    binary_attr = BinaryAttribute(hash_key=True, legacy_encoding=False)
+    binary_set_attr = BinarySetAttribute(legacy_encoding=False)
     number_attr = NumberAttribute()
     number_set_attr = NumberSetAttribute()
     unicode_attr = UnicodeAttribute()
@@ -38,7 +45,8 @@ class AttributeTestModel(Model):
     datetime_attr = UTCDateTimeAttribute()
     bool_attr = BooleanAttribute()
     json_attr = JSONAttribute()
-    map_attr = MapAttribute()
+    map_attr = AttributeTestMapAttribute()
+    raw_map_attr = MapAttribute()
     ttl_attr = TTLAttribute()
     null_attr = NullAttribute(null=True)
 
@@ -204,79 +212,95 @@ class TestBinaryAttribute:
     """
     Tests binary attributes
     """
-    def test_binary_attribute(self):
-        """
-        BinaryAttribute.default
-        """
-        attr = BinaryAttribute()
-        assert attr is not None
+    @pytest.mark.parametrize('legacy_encoding', [False, True])
+    def test_binary_attribute(self, legacy_encoding: bool) -> None:
+        attr = BinaryAttribute(legacy_encoding=legacy_encoding)
         assert attr.attr_type == BINARY
+        assert attr.legacy_encoding == legacy_encoding
 
-        attr = BinaryAttribute(default=b'foo')
+        attr = BinaryAttribute(default=b'foo', legacy_encoding=legacy_encoding)
         assert attr.default == b'foo'
 
-    def test_binary_round_trip(self):
+    @pytest.mark.parametrize('legacy_encoding', [False, True])
+    def test_binary_round_trip(self, legacy_encoding: bool) -> None:
         """
         BinaryAttribute round trip
         """
-        attr = BinaryAttribute()
+        attr = BinaryAttribute(legacy_encoding=legacy_encoding)
         value = b'foo'
         serial = attr.serialize(value)
         assert attr.deserialize(serial) == value
 
-    def test_binary_serialize(self):
+    @pytest.mark.parametrize(['legacy_encoding', 'expected'], [
+        (False, b'foo'),
+        (True, b'Zm9v'),
+    ])
+    def test_binary_serialize(self, legacy_encoding: bool, expected: bytes) -> None:
         """
         BinaryAttribute.serialize
         """
-        attr = BinaryAttribute()
-        serial = b64encode(b'foo').decode(DEFAULT_ENCODING)
-        assert attr.serialize(b'foo') == serial
+        attr = BinaryAttribute(legacy_encoding=legacy_encoding)
+        assert attr.serialize(b'foo') == expected
 
-    def test_binary_deserialize(self):
+    @pytest.mark.parametrize(['legacy_encoding', 'serialized'], [
+        pytest.param(False, b'foo',id='encoded from API, decoded in _covert_binary'),
+        pytest.param(True, b'Zm9v', id='double-encoded from API, once decoded in _convert_binary'),
+    ])
+    def test_binary_deserialize(self, legacy_encoding: bool, serialized: bytes) -> None:
         """
         BinaryAttribute.deserialize
         """
-        attr = BinaryAttribute()
-        serial = b64encode(b'foo').decode(DEFAULT_ENCODING)
-        assert attr.deserialize(serial) == b'foo'
+        attr = BinaryAttribute(legacy_encoding=legacy_encoding)
+        assert attr.deserialize(serialized) == b'foo'
 
-    def test_binary_set_serialize(self):
+
+class TestBinarySetAttribute:
+    @pytest.mark.parametrize(['legacy_encoding', 'expected'], [
+        pytest.param(False, {b'foo', b'bar'},id='encoded from API, decoded in _covert_binary'),
+        pytest.param(True, [b'Zm9v', b'YmFy'], id='double-encoded from API, once decoded in _convert_binary'),
+    ])
+    def test_binary_set_attribute(self, legacy_encoding: bool, expected: Set[bytes]) -> None:
+        attr = BinarySetAttribute(legacy_encoding=legacy_encoding)
+        assert attr.attr_type == BINARY_SET
+        assert attr.legacy_encoding == legacy_encoding
+
+    @pytest.mark.parametrize(['legacy_encoding', 'expected'], [
+        (False, [b'foo', b'bar']),
+        (True, [b'Zm9v', b'YmFy']),
+    ])
+    def test_binary_set_serialize(self, legacy_encoding: bool, expected: List[bytes]) -> None:
         """
         BinarySetAttribute.serialize
         """
-        attr = BinarySetAttribute()
+        attr = BinarySetAttribute(legacy_encoding=legacy_encoding)
         assert attr.attr_type == BINARY_SET
-        assert sorted(attr.serialize({b'foo', b'bar'})) == ['YmFy', 'Zm9v']
+
+        actual = attr.serialize({b'foo', b'bar'})
+        assert isinstance(actual, list)
+        assert sorted(actual) == sorted(expected)
+
         assert attr.serialize({}) is None
 
-    def test_binary_set_round_trip(self):
+    @pytest.mark.parametrize('legacy_encoding', [False, True])
+    def test_binary_set_round_trip(self, legacy_encoding: bool) -> None:
         """
         BinarySetAttribute round trip
         """
-        attr = BinarySetAttribute()
+        attr = BinarySetAttribute(legacy_encoding=legacy_encoding)
         value = {b'foo', b'bar'}
         serial = attr.serialize(value)
         assert attr.deserialize(serial) == value
 
-    def test_binary_set_deserialize(self):
+    @pytest.mark.parametrize(['legacy_encoding', 'serialized'], [
+        pytest.param(False, [b'foo', b'bar'],id='encoded from API, decoded in _covert_binary'),
+        pytest.param(True, [b'Zm9v', b'YmFy'], id='double-encoded from API, once decoded in _convert_binary'),
+    ])
+    def test_binary_set_deserialize(self, legacy_encoding: bool, serialized: List[bytes]) -> None:
         """
         BinarySetAttribute.deserialize
         """
-        attr = BinarySetAttribute()
-        value = {b'foo', b'bar'}
-        assert attr.deserialize(
-            [b64encode(val).decode(DEFAULT_ENCODING) for val in sorted(value)]
-        ) == value
-
-    def test_binary_set_attribute(self):
-        """
-        BinarySetAttribute.serialize
-        """
-        attr = BinarySetAttribute()
-        assert attr is not None
-
-        attr = BinarySetAttribute(default=lambda: {b'foo', b'bar'})
-        assert attr.default() == {b'foo', b'bar'}
+        attr = BinarySetAttribute(legacy_encoding=legacy_encoding)
+        assert attr.deserialize(serialized) == {b'foo', b'bar'}
 
 
 class TestNumberAttribute:
@@ -288,7 +312,6 @@ class TestNumberAttribute:
         NumberAttribute.default
         """
         attr = NumberAttribute()
-        assert attr is not None
         assert attr.attr_type == NUMBER
 
         attr = NumberAttribute(default=1)
@@ -332,9 +355,6 @@ class TestNumberAttribute:
         """
         NumberSetAttribute.default
         """
-        attr = NumberSetAttribute()
-        assert attr is not None
-
         attr = NumberSetAttribute(default=lambda: {1, 2})
         assert attr.default() == {1, 2}
 
@@ -348,7 +368,6 @@ class TestUnicodeAttribute:
         UnicodeAttribute.default
         """
         attr = UnicodeAttribute()
-        assert attr is not None
         assert attr.attr_type == STRING
 
         attr = UnicodeAttribute(default='foo')
@@ -429,7 +448,6 @@ class TestUnicodeAttribute:
         UnicodeSetAttribute.default
         """
         attr = UnicodeSetAttribute()
-        assert attr is not None
         assert attr.attr_type == STRING_SET
         attr = UnicodeSetAttribute(default=lambda: {'foo', 'bar'})
         assert attr.default() == {'foo', 'bar'}
@@ -443,11 +461,8 @@ class TestBooleanAttribute:
         """
         BooleanAttribute.default
         """
-        attr = BooleanAttribute()
-        assert attr is not None
-
-        assert attr.attr_type == BOOLEAN
         attr = BooleanAttribute(default=True)
+        assert attr.attr_type == BOOLEAN
         assert attr.default is True
 
     def test_boolean_serialize(self):
@@ -537,11 +552,8 @@ class TestJSONAttribute:
         """
         JSONAttribute.default
         """
-        attr = JSONAttribute()
-        assert attr is not None
-
-        assert attr.attr_type == STRING
         attr = JSONAttribute(default=lambda: {})
+        assert attr.attr_type == STRING
         assert attr.default() == {}
 
     def test_json_serialize(self):
@@ -581,11 +593,25 @@ class TestMapAttribute:
         person_attribute = {
             'name': 'Justin',
             'age': 12345678909876543211234234324234,
-            'height': 187.96
+            'height': 187.96,
+            'lucky_numbers': {42, 1337},
+            'picture': b'\xde\xad\xbe\xef',
+            'lunch': {b'\xca\xfe', b'\xf0\x0d'},
         }
         attr = MapAttribute()
         serialized = attr.serialize(person_attribute)
         assert attr.deserialize(serialized) == person_attribute
+
+    def test_serialize_invalid_set(self):
+        attr = MapAttribute()
+
+        with pytest.raises(ValueError, match="Cannot serialize empty set"):
+            attr.serialize({'test': set()})
+        with pytest.raises(ValueError, match="Cannot serialize set consisting of types: <class 'int'>, <class 'str'>"):
+            attr.serialize({'test': {42, "foo"}})
+        with pytest.raises(ValueError, match="Cannot serialize set consisting of types: "
+                                             "<class 'bytes'>, <class 'int'>"):
+            attr.serialize({'test': {42, b"foo"}})
 
     # Special case for raw map attributes
     def test_null_attribute_raw_map(self):
@@ -671,29 +697,29 @@ class TestMapAttribute:
 
     def test_raw_set_attr(self):
         item = AttributeTestModel()
-        item.map_attr = {}
-        item.map_attr.foo = 'bar'
-        item.map_attr.num = 3
-        item.map_attr.nested = {'nestedfoo': 'nestedbar'}
+        item.raw_map_attr = {}
+        item.raw_map_attr.foo = 'bar'
+        item.raw_map_attr.num = 3
+        item.raw_map_attr.nested = {'nestedfoo': 'nestedbar'}
 
-        assert item.map_attr['foo'] == 'bar'
-        assert item.map_attr['num'] == 3
-        assert item.map_attr['nested']['nestedfoo'] == 'nestedbar'
+        assert item.raw_map_attr['foo'] == 'bar'
+        assert item.raw_map_attr['num'] == 3
+        assert item.raw_map_attr['nested']['nestedfoo'] == 'nestedbar'
 
     def test_raw_set_item(self):
         item = AttributeTestModel()
-        item.map_attr = {}
-        item.map_attr['foo'] = 'bar'
-        item.map_attr['num'] = 3
-        item.map_attr['nested'] = {'nestedfoo': 'nestedbar'}
+        item.raw_map_attr = {}
+        item.raw_map_attr['foo'] = 'bar'
+        item.raw_map_attr['num'] = 3
+        item.raw_map_attr['nested'] = {'nestedfoo': 'nestedbar'}
 
-        assert item.map_attr['foo'] == 'bar'
-        assert item.map_attr['num'] == 3
-        assert item.map_attr['nested']['nestedfoo'] == 'nestedbar'
+        assert item.raw_map_attr['foo'] == 'bar'
+        assert item.raw_map_attr['num'] == 3
+        assert item.raw_map_attr['nested']['nestedfoo'] == 'nestedbar'
 
     def test_raw_map_from_dict(self):
         item = AttributeTestModel(
-            map_attr={
+            raw_map_attr={
                 "foo": "bar",
                 "num": 3,
                 "nested": {
@@ -702,8 +728,8 @@ class TestMapAttribute:
             }
         )
 
-        assert item.map_attr['foo'] == 'bar'
-        assert item.map_attr['num'] == 3
+        assert item.raw_map_attr['foo'] == 'bar'
+        assert item.raw_map_attr['num'] == 3
 
     def test_raw_map_access(self):
         raw = {
@@ -741,10 +767,10 @@ class TestMapAttribute:
 
         serialized_raw = json.dumps(raw, sort_keys=True)
         serialized_attr_from_raw = json.dumps(
-            AttributeTestModel(map_attr=raw).map_attr.as_dict(),
+            AttributeTestModel(raw_map_attr=raw).raw_map_attr.as_dict(),
             sort_keys=True)
         serialized_attr_from_map = json.dumps(
-            AttributeTestModel(map_attr=MapAttribute(**raw)).map_attr.as_dict(),
+            AttributeTestModel(raw_map_attr=MapAttribute(**raw)).raw_map_attr.as_dict(),
             sort_keys=True)
 
         assert serialized_attr_from_raw == serialized_raw
@@ -932,26 +958,49 @@ class TestDynamicMapAttribute:
 
 class TestListAttribute:
 
-    def test_untyped_list(self):
-        untyped_list = [{'Hello': 'World'}, ['!'], {'foo', 'bar'}, None, "", 0, False]
-        serialized = ListAttribute().serialize(untyped_list)
-        # set attributes are serialized as lists
-        untyped_list[2] = list(untyped_list[2])
-        assert ListAttribute().deserialize(serialized) == untyped_list
+    def test_roundtrip_untyped(self) -> None:
+        string_list_attribute = ListAttribute()
+        values = [
+            None,  # NULL
+            'foo',  # S
+            '',  # S
+            42,  # NUMBER
+            True,  # BOOL
+            b'foo',  # B
+            {42, 43},  # NS of ints
+            {42.5, 43.5},  # NS of floats
+            {42, 43.5},  # NS of ints and floats
+            {'foo', 'bar'},  # SS
+            {b'foo', b'bar'},  # BS
+            {'foo': 'bar'},  # M with one S
+            ['foo', 'bar'],  # L of S
+        ]
+        serialized = string_list_attribute.serialize(values)
+        assert string_list_attribute.deserialize(serialized) == values
 
-    def test_list_of_strings(self):
-        string_list_attribute = ListAttribute(of=UnicodeAttribute)
-        string_list = ['foo', 'bar', 'baz']
-        serialized = string_list_attribute.serialize(string_list)
-        assert string_list_attribute.deserialize(serialized) == string_list
+    def test_serialize_invalid_set(self) -> None:
+        string_list_attribute = ListAttribute()
+        with pytest.raises(ValueError, match="Cannot serialize empty set"):
+            string_list_attribute.serialize([set()])
+        with pytest.raises(ValueError, match="Cannot serialize set consisting of types: <class 'int'>, <class 'str'>"):
+            string_list_attribute.serialize([{42, "foo"}])
+        with pytest.raises(ValueError, match="Cannot serialize set consisting of types: "
+                                             "<class 'bytes'>, <class 'int'>"):
+            string_list_attribute.serialize([{42, b"foo"}])
+
+    def test_list_of_binary_set(self) -> None:
+        string_list_attribute = ListAttribute(of=BinarySetAttribute)
+        values = [{b'bar', b'baz'}]
+        serialized = string_list_attribute.serialize(values)
+        assert string_list_attribute.deserialize(serialized) == values
 
     def test_list_type_error(self):
         string_list_attribute = ListAttribute(of=UnicodeAttribute)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='List elements must be of type: UnicodeAttribute'):
             string_list_attribute.serialize([MapAttribute(foo='bar')])
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match=r"Cannot deserialize '\[0\]' attribute from type: S"):
             string_list_attribute.deserialize([{'M': {'foo': {'S': 'bar'}}}])
 
     def test_serialize_null(self):
@@ -1083,9 +1132,7 @@ class TestVersionAttribute:
 
 class TestAttributeContainer:
     def test_to_json(self):
-        now = datetime.now(tz=timezone.utc)
-        now_formatted = now.strftime(DATETIME_FORMAT)
-        now_unix_ts = calendar.timegm(now.utctimetuple())
+        dt = datetime(2022, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
         test_model = AttributeTestModel()
         test_model.binary_attr = b'foo'
         test_model.binary_set_attr = {b'bar'}
@@ -1093,44 +1140,51 @@ class TestAttributeContainer:
         test_model.number_set_attr = {0, 0.5, 1}
         test_model.unicode_attr = 'foo'
         test_model.unicode_set_attr = {'baz'}
-        test_model.datetime_attr = now
+        test_model.datetime_attr = dt
         test_model.bool_attr = True
         test_model.json_attr = {'foo': 'bar'}
-        test_model.map_attr = {'foo': 'bar'}
-        test_model.ttl_attr = now
+        test_model.raw_map_attr = {
+            'string': 'bar',
+            'binary': b'bar',  # this won't roundtrip :(
+        }
+        test_model.map_attr = AttributeTestMapAttribute(
+            string='bar',
+            binary=b'bar',
+        )
+        test_model.ttl_attr = dt
         test_model.null_attr = True
         assert test_model.to_json() == (
             '{'
             '"binary_attr": "Zm9v", '
             '"binary_set_attr": ["YmFy"], '
             '"bool_attr": true, '
-            '"datetime_attr": "' + now_formatted + '", '
+            '"datetime_attr": "2022-12-31T23:59:59.000000+0000", '
             '"json_attr": "{\\"foo\\": \\"bar\\"}", '
-            '"map_attr": {"foo": "bar"}, '
+            '"map_attr": {"binary": "YmFy", "string": "bar"}, '
             '"null_attr": null, '
             '"number_attr": 1, '
             '"number_set_attr": [0, 0.5, 1], '
-            '"ttl_attr": ' + str(now_unix_ts) + ', '
+            '"raw_map_attr": {"string": "bar", "binary": "YmFy"}, '
+            '"ttl_attr": 1672531199, '
             '"unicode_attr": "foo", '
             '"unicode_set_attr": ["baz"]'
             '}')
 
     def test_from_json(self):
-        now = datetime.now(tz=timezone.utc)
-        now_formatted = now.strftime(DATETIME_FORMAT)
-        now_unix_ts = calendar.timegm(now.utctimetuple())
+        dt = datetime(2022, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
         json_string = (
             '{'
             '"binary_attr": "Zm9v", '
             '"binary_set_attr": ["YmFy"], '
             '"bool_attr": true, '
-            '"datetime_attr": "' + now_formatted + '", '
+            '"datetime_attr": "2022-12-31T23:59:59.000000+0000", '
             '"json_attr": "{\\"foo\\": \\"bar\\"}", '
-            '"map_attr": {"foo": "bar"}, '
+            '"map_attr": {"string": "bar", "binary": "YmFy"}, '
+            '"raw_map_attr": {"string": "bar", "binary": "YmFy"}, '
             '"null_attr": null, '
             '"number_attr": 1, '
             '"number_set_attr": [0, 0.5, 1], '
-            '"ttl_attr": ' + str(now_unix_ts) + ', '
+            '"ttl_attr": 1672531199, '
             '"unicode_attr": "foo", '
             '"unicode_set_attr": ["baz"]'
             '}')
@@ -1142,11 +1196,14 @@ class TestAttributeContainer:
         assert test_model.number_set_attr == {0, 0.5, 1}
         assert test_model.unicode_attr == 'foo'
         assert test_model.unicode_set_attr == {'baz'}
-        assert test_model.datetime_attr == now
+        assert test_model.datetime_attr == dt
         assert test_model.bool_attr is True
         assert test_model.json_attr == {'foo': 'bar'}
-        assert test_model.map_attr.foo == 'bar'
-        assert test_model.ttl_attr == now.replace(microsecond=0)
+        assert test_model.map_attr.string == 'bar'
+        assert test_model.map_attr.binary == b'bar'
+        assert test_model.raw_map_attr.string == 'bar'
+        assert test_model.raw_map_attr.binary == 'YmFy'  # this can't roundtrip :(
+        assert test_model.ttl_attr == dt
         assert test_model.null_attr is None
 
     def test_to_json_complex(self):

--- a/tests/test_binary_legacy_encoding.py
+++ b/tests/test_binary_legacy_encoding.py
@@ -1,0 +1,16 @@
+import pytest
+
+from pynamodb.attributes import BinaryAttribute
+from pynamodb.attributes import MapAttribute
+from pynamodb.models import Model
+
+
+def test_legacy_encoding__model() -> None:
+    class _(Model):
+        binary = BinaryAttribute(legacy_encoding=True)
+
+
+def test_legacy_encoding__map_attribute() -> None:
+    with pytest.raises(ValueError, match='legacy_encoding'):
+        class _(MapAttribute):
+            binary = BinaryAttribute(legacy_encoding=True)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -149,7 +149,7 @@ class IndexedModel(Model):
     include_index = NonKeyAttrIndex()
     numbers = NumberSetAttribute()
     aliases = UnicodeSetAttribute()
-    icons = BinarySetAttribute()
+    icons = BinarySetAttribute(legacy_encoding=False)
 
 
 class LocalIndexedModel(Model):
@@ -165,7 +165,7 @@ class LocalIndexedModel(Model):
     email_index = LocalEmailIndex()
     numbers = NumberSetAttribute()
     aliases = UnicodeSetAttribute()
-    icons = BinarySetAttribute()
+    icons = BinarySetAttribute(legacy_encoding=False)
 
 
 class SimpleUserModel(Model):
@@ -180,7 +180,7 @@ class SimpleUserModel(Model):
     email = UnicodeAttribute()
     numbers = NumberSetAttribute()
     custom_aliases = UnicodeSetAttribute(attr_name='aliases')
-    icons = BinarySetAttribute()
+    icons = BinarySetAttribute(legacy_encoding=False)
     views = NumberAttribute(null=True)
     is_active = BooleanAttribute(null=True)
     signature = UnicodeAttribute(null=True)
@@ -222,12 +222,11 @@ class UserModel(Model):
 
     custom_user_name = UnicodeAttribute(hash_key=True, attr_name='user_name')
     user_id = UnicodeAttribute(range_key=True)
-    picture = BinaryAttribute(null=True)
+    picture = BinaryAttribute(null=True, legacy_encoding=False)
     zip_code = NumberAttribute(null=True)
     email = UnicodeAttribute(default='needs_email')
     callable_field = NumberAttribute(default=lambda: 42)
     ttl = TTLAttribute(null=True)
-
 
 
 class BatchModel(Model):


### PR DESCRIPTION
For many versions (verified in versions 3-5) we had a known issue where
1. top-level Binary(Set)Attributes were double-base64-encoded in the underlying DynamoDB table item
2. nested Binary(Set)Attributes were unusable: every serialization would add another round of Base64 encoding(!), so nested binary attributes could not have been used in practice

Clearly (1) is inefficient and (2) is unusable, and we wanted PynamoDB to be efficient (and not broken) by default, but similarly didn't want to risk breaking systems during an upgrade to PynamoDB 6. With that in mind, we're introducing a `legacy_encoding` required parameter to `BinaryAttribute` and `BinarySetAttribute`, the rationale being a new required parameter will prompt an informed decision. The parameter will exist throughout the lifetime of PynamoDB 6.x and perhaps removed in a future version (in favor of `legacy_encoding=False` becoming the default behavior).

Since nested binary attributes were previously unusable, we're safely defaulting to `legacy_encoding=False` for nested attributes (and forcing it to be `False` when binary attributes are declared in non-raw maps).

Along with this, a slight breaking change in introduced: A **set** in a "raw" list or map have previously serialized as a list (**L**) but will now result in a string/number/binary set:
- for all strings, string set (**SS**)
- for all numbers, number set (**NS**)
- for all bytes, binary set (**BS**)
- else, raises an error on serialization

Additions to docs:
- [Upgrading Binary(Set)Attribute](https://pynamodb--1112.org.readthedocs.build/en/1112/upgrading_binary.html)
- [BinaryAttribute (initializer)](https://pynamodb--1112.org.readthedocs.build/en/1112/api.html#pynamodb.attributes.BinaryAttribute)
- [BinarySetAttribute (initializer)](https://pynamodb--1112.org.readthedocs.build/en/1112/api.html#pynamodb.attributes.BinarySetAttribute)