### PR TITLE
Fix exception messages

### DIFF
--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -8,6 +8,8 @@ import botocore.exceptions
 
 
 class PynamoDBException(Exception):
+    msg: str
+
     """
     A common exception class
     """

--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -12,7 +12,7 @@ class PynamoDBException(Exception):
     A common exception class
     """
     def __init__(self, msg: Optional[str] = None, cause: Optional[Exception] = None) -> None:
-        self.msg = msg
+        self.msg = msg if msg is not None else self.msg
         self.cause = cause
         super(PynamoDBException, self).__init__(self.msg)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,6 @@
 from botocore.exceptions import ClientError
 
-from pynamodb.exceptions import PutError
+from pynamodb.exceptions import PynamoDBException, PutError
 
 
 def test_get_cause_response_code():
@@ -40,3 +40,10 @@ def test_get_cause_response_message__no_message():
     error = PutError()
     assert error.cause_response_message is None
 
+
+class PynamoDBTestError(PynamoDBException):
+    msg = "Test message"
+
+
+def test_subclass_message_is_not_overwritten_with_none():
+    assert PynamoDBTestError().msg == "Test message"


### PR DESCRIPTION
Pull request #786 broke messages for all errors that extend `PynamoDBException`, because it would overwrite the default message with `None`. This change returns the previous behaviour.