### PR TITLE
Connection: call describe_table as needed

### DIFF
--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '5.3.0'
+__version__ = '5.3.1'

--- a/pynamodb/connection/base.py
+++ b/pynamodb/connection/base.py
@@ -578,10 +578,9 @@ class Connection(object):
         """
         Returns information about the table's schema.
         """
-        try:
-            return self._tables[table_name]
-        except KeyError:
-            raise TableError(f"Meta-table for '{table_name}' not initialized") from None
+        if table_name not in self._tables:
+            self.describe_table(table_name)
+        return self._tables[table_name]
 
     def create_table(
         self,


### PR DESCRIPTION
In #1095 we stopped calling DescribeTable for models since they can provide their own "meta-table". However, some users are using Connection directly and this was a breaking change for them, so we'll return to calling DescribeTable as needed in those cases.