### PR TITLE
Improve first iteration logic

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,6 +3,28 @@
 Release Notes
 =============
 
+v5.3.3
+----------
+* Fix :py:class:`~pynamodb.pagination.PageIterator` and :py:class:`~pynamodb.pagination.ResultIterator`
+  to allow recovery from an exception when retrieving the first item (#1101).
+
+  .. code-block:: python
+
+    results = MyModel.query('hash_key')
+    while True:
+        try:
+            item = next(results)
+        except StopIteration:
+            break
+        except pynamodb.exceptions.QueryError as ex:
+            if ex.cause_response_code == 'ThrottlingException':
+                time.sleep(1)  # for illustration purposes only
+            else:
+                raise
+        else:
+            handle_item(item)
+
+
 v5.3.2
 ----------
 * Prevent ``typing_tests`` from being installed into site-packages (#1118)

--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '5.3.2'
+__version__ = '5.3.3'

--- a/pynamodb/pagination.py
+++ b/pynamodb/pagination.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Callable, Dict, Iterable, Iterator, TypeVar, Optional
+from typing import Any, Callable, Dict, Iterable, Iterator, Optional, TypeVar
 
 from pynamodb.constants import (CAMEL_COUNT, ITEMS, LAST_EVALUATED_KEY, SCANNED_COUNT,
                                 CONSUMED_CAPACITY, TOTAL, CAPACITY_UNITS)
@@ -90,8 +90,8 @@ class PageIterator(Iterator[_T]):
         self._operation = operation
         self._args = args
         self._kwargs = kwargs
-        self._first_iteration = True
         self._last_evaluated_key = kwargs.get('exclusive_start_key')
+        self._is_last_page = False
         self._total_scanned_count = 0
         self._rate_limiter = None
         if rate_limit:
@@ -102,10 +102,8 @@ class PageIterator(Iterator[_T]):
         return self
 
     def __next__(self) -> _T:
-        if self._last_evaluated_key is None and not self._first_iteration:
+        if self._is_last_page:
             raise StopIteration()
-
-        self._first_iteration = False
 
         self._kwargs['exclusive_start_key'] = self._last_evaluated_key
 
@@ -114,6 +112,7 @@ class PageIterator(Iterator[_T]):
             self._kwargs['return_consumed_capacity'] = TOTAL
         page = self._operation(*self._args, settings=self._settings, **self._kwargs)
         self._last_evaluated_key = page.get(LAST_EVALUATED_KEY)
+        self._is_last_page = self._last_evaluated_key is None
         self._total_scanned_count += page[SCANNED_COUNT]
 
         if self._rate_limiter:
@@ -170,10 +169,11 @@ class ResultIterator(Iterator[_T]):
         settings: OperationSettings = OperationSettings.default,
     ) -> None:
         self.page_iter: PageIterator = PageIterator(operation, args, kwargs, rate_limit, settings)
-        self._first_iteration = True
         self._map_fn = map_fn
         self._limit = limit
         self._total_count = 0
+        self._index = 0
+        self._count = 0
 
     def _get_next_page(self) -> None:
         page = next(self.page_iter)
@@ -188,10 +188,6 @@ class ResultIterator(Iterator[_T]):
     def __next__(self) -> _T:
         if self._limit == 0:
             raise StopIteration
-
-        if self._first_iteration:
-            self._first_iteration = False
-            self._get_next_page()
 
         while self._index == self._count:
             self._get_next_page()
@@ -209,7 +205,7 @@ class ResultIterator(Iterator[_T]):
 
     @property
     def last_evaluated_key(self) -> Optional[Dict[str, Dict[str, Any]]]:
-        if self._first_iteration or self._index == self._count:
+        if self._index == self._count:
             # Not started iterating yet: return `exclusive_start_key` if set, otherwise expect None; or,
             # Entire page has been consumed: last_evaluated_key is whatever DynamoDB returned
             # It may correspond to the current item, or it may correspond to an item evaluated but not returned.


### PR DESCRIPTION
Backport of #1101 to 5.x branch. The motivation of backporting is to allow I/O exception handling for a [manual retry done by a user](https://github.com/pynamodb/PynamoDB/commit/47a52f69f3ca78400242403fed9454baec2ce603#commitcomment-90975363) (our retry mechanism apparently doesn't kick in).