### PR TITLE
Add long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author_email='jlafon@eyesopen.com',
     description='A Pythonic Interface to DynamoDB',
     long_description=open('README.rst').read(),
+    long_description_content_type='text/x-rst',
     zip_safe=False,
     license='MIT',
     keywords='python dynamodb amazon',


### PR DESCRIPTION
twine says:
```
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
```