### PR TITLE
4.x: workaround for _convert_to_request_dict change (#1083)

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+v4.4.0
+----------
+* Update for botocore 1.28 private API change (#1130) which caused the following exception::
+
+    TypeError: _convert_to_request_dict() missing 1 required positional argument: 'endpoint_url'
+
 v4.3.3
 ----------
 

--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '4.3.3'
+__version__ = '4.4.0'

--- a/pynamodb/connection/_botocore_private.py
+++ b/pynamodb/connection/_botocore_private.py
@@ -1,0 +1,46 @@
+"""
+Type-annotates the private botocore APIs that we're currently relying on.
+"""
+from typing import Any, Dict, Optional
+
+import botocore.client
+import botocore.credentials
+import botocore.endpoint
+import botocore.hooks
+import botocore.model
+import botocore.signers
+
+
+class BotocoreEndpointPrivate(botocore.endpoint.Endpoint):
+    _event_emitter: botocore.hooks.HierarchicalEmitter
+
+
+class BotocoreRequestSignerPrivate(botocore.signers.RequestSigner):
+    _credentials: botocore.credentials.Credentials
+
+
+class BotocoreBaseClientPrivate(botocore.client.BaseClient):
+    _endpoint: BotocoreEndpointPrivate
+    _request_signer: BotocoreRequestSignerPrivate
+    _service_model: botocore.model.ServiceModel
+
+    def _resolve_endpoint_ruleset(
+        self,
+        operation_model: botocore.model.OperationModel,
+        params: Dict[str, Any],
+        request_context: Dict[str, Any],
+        ignore_signing_region: bool = ...,
+    ):
+        ...
+
+    def _convert_to_request_dict(
+        self,
+        api_params: Dict[str, Any],
+        operation_model: botocore.model.OperationModel,
+        *,
+        endpoint_url: str = ...,  # added in botocore 1.28
+        context: Optional[Dict[str, Any]] = ...,
+        headers: Optional[Dict[str, Any]] = ...,
+        set_user_agent_header: bool = ...,
+    ) -> Dict[str, Any]:
+        ...

--- a/tests/test_base_connection.py
+++ b/tests/test_base_connection.py
@@ -2,11 +2,14 @@
 Tests for the base connection class
 """
 import base64
+import io
 import json
 import six
 from unittest import TestCase
 
 import botocore.exceptions
+import botocore.httpsession
+import urllib3
 from botocore.awsrequest import AWSPreparedRequest, AWSRequest, AWSResponse
 from botocore.client import ClientError
 from botocore.exceptions import BotoCoreError
@@ -1448,6 +1451,22 @@ class ConnectionTestCase(TestCase):
                 ScanError,
                 conn.scan,
                 table_name)
+
+    def test_make_api_call__happy_path(self):
+        response = AWSResponse(
+            url='https://www.example.com',
+            status_code=200,
+            raw=urllib3.HTTPResponse(
+                body=io.BytesIO(json.dumps({}).encode('utf-8')),
+                preload_content=False,
+            ),
+            headers={'x-amzn-RequestId': 'abcdef'},
+        )
+
+        c = Connection()
+
+        with patch.object(botocore.httpsession.URLLib3Session, 'send', return_value=response):
+            c._make_api_call('CreateTable', {'TableName': 'MyTable'})
 
     @mock.patch('pynamodb.connection.Connection.client')
     def test_make_api_call_throws_verbose_error_after_backoff(self, client_mock):


### PR DESCRIPTION
botocore 1.28 [changed](https://github.com/boto/botocore/pull/2785) the signature of private method `botocore.client.BaseClient._convert_to_request_dict` adding an `endpoint_url` parameter. We are updating pynamodb to inspect the signature and add this parameter as needed.

Backport to 4.x of #1083 and #1087.