### PR TITLE
Remove __repr__s from docs and examples

### DIFF
--- a/docs/optimistic_locking.rst
+++ b/docs/optimistic_locking.rst
@@ -29,9 +29,6 @@ To enable optimistic locking for a table simply add a ``VersionAttribute`` to yo
       def __eq__(self, other):
           return isinstance(other, OfficeEmployeeMap) and self.person == other.person
 
-      def __repr__(self):
-          return str(vars(self))
-
 
   class Office(Model):
       class Meta:

--- a/examples/attributes.py
+++ b/examples/attributes.py
@@ -17,9 +17,6 @@ class Color(object):
     def __init__(self, name: str) -> None:
         self.name = name
 
-    def __repr__(self) -> str:
-        return "<Color: {}>".format(self.name)
-
 
 class PickleAttribute(Attribute[object]):
     """

--- a/examples/optimistic_locking.py
+++ b/examples/optimistic_locking.py
@@ -16,9 +16,6 @@ class OfficeEmployeeMap(MapAttribute):
     def __eq__(self, other):
         return isinstance(other, OfficeEmployeeMap) and self.person == other.person
 
-    def __repr__(self):
-        return str(vars(self))
-
 
 class Office(Model):
     class Meta:


### PR DESCRIPTION
Since #1100, we don't need to override `__repr__` anymore to get a useful repr.