### PR TITLE
Expose transaction cancellation reasons

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,4 +38,9 @@ Exceptions
 .. autoexception:: pynamodb.exceptions.TableError
 .. autoexception:: pynamodb.exceptions.TableDoesNotExist
 .. autoexception:: pynamodb.exceptions.DoesNotExist
-
+.. autoexception:: pynamodb.exceptions.TransactWriteError
+.. autoexception:: pynamodb.exceptions.TransactGetError
+.. autoexception:: pynamodb.exceptions.InvalidStateError
+.. autoexception:: pynamodb.exceptions.AttributeDeserializationError
+.. autoexception:: pynamodb.exceptions.AttributeNullError
+.. autoclass:: pynamodb.exceptions.CancellationReason

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,6 +3,13 @@
 Release Notes
 =============
 
+v5.4.0
+----------
+* Expose transaction cancellation reasons in
+  :meth:`~pynamodb.exceptions.TransactWriteError.cancellation_reasons` and
+  :meth:`~pynamodb.exceptions.TransactGetError.cancellation_reasons` (#1144).
+
+
 v5.3.4
 ----------
 * Make serialization :code:`null_check=False` propagate to maps inside lists (#1128).

--- a/docs/transaction.rst
+++ b/docs/transaction.rst
@@ -105,6 +105,10 @@ Now, say you make another attempt to debit one of the accounts when they don't h
         # Because the condition check on the account balance failed,
         # the entire transaction should be cancelled
         assert e.cause_response_code == 'TransactionCanceledException'
+        # the first 'update' was a reason for the cancellation
+        assert e.cancellation_reasons[0].code == 'ConditionalCheckFailed'
+        # the second 'update' wasn't a reason, but was cancelled too
+        assert e.cancellation_reasons[1] is None
 
         user1_statement.refresh()
         user2_statement.refresh()

--- a/pynamodb/__init__.py
+++ b/pynamodb/__init__.py
@@ -7,4 +7,4 @@ A simple abstraction over DynamoDB
 """
 __author__ = 'Jharrod LaFon'
 __license__ = 'MIT'
-__version__ = '5.3.4'
+__version__ = '5.4.0'

--- a/pynamodb/exceptions.py
+++ b/pynamodb/exceptions.py
@@ -1,13 +1,11 @@
 """
 PynamoDB exceptions
 """
-from dataclasses import dataclass
 from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
-from typing_extensions import Literal
 
 import botocore.exceptions
 


### PR DESCRIPTION
This will allow the caller to know e.g. which of the transaction items ran into a conflict, which can sometimes allow app logic to better handle the error without needing to make more requests.

This is a backport of #1144 to 5.x branch (adjusted to Python 3.6 compatibility, hence no dataclass).

Fixes #891.