### PR TITLE
Mark ddblocal on integration tests that need it.

### DIFF
--- a/tests/integration/test_discriminator_index.py
+++ b/tests/integration/test_discriminator_index.py
@@ -14,6 +14,7 @@ from pynamodb.indexes import GlobalSecondaryIndex
 
 class TestDiscriminatorIndex:
 
+    @pytest.mark.ddblocal
     def test_create_table(self, ddb_url):
         class ParentModel(Model, discriminator='Parent'):
             class Meta:
@@ -65,6 +66,7 @@ class TestDiscriminatorIndex:
         model = next(ChildModel2.child_index.query('baz'))
         assert isinstance(model, ChildModel2)
 
+    @pytest.mark.ddblocal
     def test_create_table__incompatible_indexes(self, ddb_url):
         class ParentModel(Model, discriminator='Parent'):
             class Meta:


### PR DESCRIPTION
Uses `pytest.mark.ddblocal` on integration tests that use DynamoDB local.  As I forked the repo to try my first contribution to the project, unit tests immediately failed on these tests cases.