### PR TITLE
Upload to Test PyPi only on manual trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,10 +3,10 @@ name: Release
 on:
   release:
     types: [published]
-  # For non-release, we want to exercise (a) building, (b) uploading to test.pypi.org
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -35,9 +35,7 @@ jobs:
 
     - name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: ${{ github.event_name != 'release' }}
+      if: ${{ github.event_name == 'workflow_dispatch' }}
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
-        # Since we run this often, it's OK if that version already exists
-        skip_existing: true


### PR DESCRIPTION
Looking at #1158, I've realized that contributors don't have access to the Test PyPi secret. :(

In #1123 I've made it so that pull requests exercise building, which is still a good idea, but uploading to Test PyPi is futile since it mostly fails due to the version already existing, and it also fails for contributors.

So I'd like to move it to a [manual workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).