### PR TITLE
AWS account credentials in the Model Meta class is not used in threaded code

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,6 +3,19 @@
 Release Notes
 =============
 
+v5.4.1
+----------
+* Use model's AWS credentials in threads (#1160)
+
+  A model can specify custom AWS credentials in the ``Meta`` class (in lieu of "global"
+  AWS credentials from the environment). Previously those model-specific credentials
+  were not used from within new threads.
+
+Contributors to this release:
+
+* @atsuoishimoto
+
+
 v5.4.0
 ----------
 * Expose transaction cancellation reasons in

--- a/pynamodb/connection/table.py
+++ b/pynamodb/connection/table.py
@@ -41,14 +41,13 @@ class TableConnection:
                                      max_retry_attempts=max_retry_attempts,
                                      base_backoff_ms=base_backoff_ms,
                                      max_pool_connections=max_pool_connections,
-                                     extra_headers=extra_headers)
+                                     extra_headers=extra_headers,
+                                     aws_access_key_id=aws_access_key_id,
+                                     aws_secret_access_key=aws_secret_access_key,
+                                     aws_session_token=aws_session_token)
+
         if meta_table is not None:
             self.connection.add_meta_table(meta_table)
-
-        if aws_access_key_id and aws_secret_access_key:
-            self.connection.session.set_credentials(aws_access_key_id,
-                                                    aws_secret_access_key,
-                                                    aws_session_token)
 
     def get_meta_table(self) -> MetaTable:
         """

--- a/tests/test_table_connection.py
+++ b/tests/test_table_connection.py
@@ -2,6 +2,7 @@
 Test suite for the table class
 """
 from unittest import TestCase
+from concurrent.futures import ThreadPoolExecutor
 
 from pynamodb.connection import TableConnection
 from pynamodb.constants import DEFAULT_REGION
@@ -39,7 +40,16 @@ class ConnectionTestCase(TestCase):
             aws_access_key_id='access_key_id',
             aws_secret_access_key='secret_access_key')
 
-        credentials = conn.connection.session.get_credentials()
+        def get_credentials():
+            return conn.connection.session.get_credentials()
+
+        credentials = get_credentials()
+        self.assertEqual(credentials.access_key, 'access_key_id')
+        self.assertEqual(credentials.secret_key, 'secret_access_key')
+
+        with ThreadPoolExecutor() as executor:
+            fut = executor.submit(get_credentials)
+            credentials = fut.result()
 
         self.assertEqual(credentials.access_key, 'access_key_id')
         self.assertEqual(credentials.secret_key, 'secret_access_key')


### PR DESCRIPTION
Backporting #1160 to 5.x branch.