### PR TITLE
Fix updating set to empty

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -268,7 +268,7 @@ class Attribute(Generic[_T]):
     def set(
         self,
         value: Union[_T, 'Attribute[_T]', '_Increment', '_Decrement', '_IfNotExists', '_ListAppend']
-    ) -> 'SetAction':
+    ) -> Union['SetAction', 'RemoveAction']:
         return Path(self).set(value)
 
     def remove(self) -> 'RemoveAction':

--- a/pynamodb/expressions/operand.py
+++ b/pynamodb/expressions/operand.py
@@ -299,7 +299,9 @@ class Path(_NumericOperand, _ListAppendOperand, _ConditionOperand):
         return _IfNotExists(self, self._to_operand(other))
 
     def set(self, value: Any) -> Union[SetAction, RemoveAction]:
-        # Returns an update action that sets this attribute to the given value
+        # Returns an update action that sets this attribute to the given value.
+        # For attributes that may not be empty (e.g. sets), this may result
+        # in a remove action.
         operand = self._to_operand(value)
         if isinstance(operand, Value) and next(iter(operand.value.values())) is None:
             return RemoveAction(self)

--- a/pynamodb/expressions/operand.py
+++ b/pynamodb/expressions/operand.py
@@ -298,9 +298,12 @@ class Path(_NumericOperand, _ListAppendOperand, _ConditionOperand):
     def __or__(self, other):
         return _IfNotExists(self, self._to_operand(other))
 
-    def set(self, value: Any) -> SetAction:
+    def set(self, value: Any) -> Union[SetAction, RemoveAction]:
         # Returns an update action that sets this attribute to the given value
-        return SetAction(self, self._to_operand(value))
+        operand = self._to_operand(value)
+        if isinstance(operand, Value) and next(iter(operand.value.values())) is None:
+            return RemoveAction(self)
+        return SetAction(self, operand)
 
     def remove(self) -> RemoveAction:
         # Returns an update action that removes this attribute from the item

--- a/tests/integration/model_integration_test.py
+++ b/tests/integration/model_integration_test.py
@@ -102,6 +102,10 @@ def test_model_integration(ddb_url):
     for item in TestModel.view_index.query('foo', TestModel.view > 0):
         print("Item queried from index: {}".format(item.view))
 
+    query_obj.update([TestModel.scores.set([])])
+    query_obj.refresh()
+    assert query_obj.scores is None
+
     print(query_obj.update([TestModel.view.add(1)], condition=TestModel.forum.exists()))
     TestModel.delete_table()
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -479,6 +479,13 @@ class UpdateExpressionTestCase(TestCase):
         assert self.placeholder_names == {'foo': '#0'}
         assert self.expression_attribute_values == {':0': {'S': 'bar'}}
 
+    def test_set_action_as_remove(self):
+        action = self.set_attribute.set([])
+        expression = action.serialize(self.placeholder_names, self.expression_attribute_values)
+        assert expression == "#0"
+        assert self.placeholder_names == {'foo_set': '#0'}
+        assert self.expression_attribute_values == {}
+
     def test_set_action_attribute_container(self):
         # Simulate initialization from inside an AttributeContainer
         my_map_attribute = MapAttribute[str, str](attr_name='foo')
@@ -619,6 +626,15 @@ class UpdateExpressionTestCase(TestCase):
             ':1': {'NS': ['0']},
             ':2': {'NS': ['1']}
         }
+
+    def test_update_set_to_empty(self):
+        update = Update(
+            self.set_attribute.set([]),
+        )
+        expression = update.serialize(self.placeholder_names, self.expression_attribute_values)
+        assert expression == "REMOVE #0"
+        assert self.placeholder_names == {'foo_set': '#0'}
+        assert self.expression_attribute_values == {}
 
     def test_update_skips_empty_clauses(self):
         update = Update(self.attribute.remove())


### PR DESCRIPTION
Fixes #962.

Empty sets are not supported by DynamoDB. Currently we're representing empty sets by unsetting the attribute (hence it's indistinguishable from unsetting), i.e.
```python
m1.my_set = set()
m1.save()
m2.my_set = None
m2.save()
```
then
```python
m1.refresh()
m2.refresh()
assert m1.my_set == m2.my_set == None
```

Another way to empty the set should be through an update expression:
```python
m1.update([MyModel.my_set.set([]))
```

We're not changing this semantic here, but we're making it so that `m1.update([MyModel.my_set.set([]))` doesn't crash in botocore.

When preparing an update expression, we've been sending update expressions like `{':0': {'NS': None}}` which crashed botocore with "TypeError: 'NoneType' object is not iterable". The PR addresses it by using a `REMOVE` action when assigning an empty value to a set.