### PR TITLE
Fixed filter_condition examples in the docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Examples of ways to query your table with filter conditions:
 
 .. code-block:: python
 
-    for user in UserModel.query("Denver", UserModel.email=="djohn@company.org"):
+    for user in UserModel.query("Denver", filter_condition=UserModel.email=="djohn@company.org"):
         print(user.first_name)
 
 Retrieve an existing user:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -136,11 +136,18 @@ Now, suppose that you want to search the table for users with a last name
     for user in UserModel.query('Smith', UserModel.first_name.startswith('J')):
         print(user.first_name)
 
-You can combine query terms:
+You can combine query terms in filter conditions using OR:
 
 ::
 
-    for user in UserModel.query('Smith', UserModel.first_name.startswith('J') | UserModel.email.contains('domain.com')):
+    for user in UserModel.query('Smith', filter_condition=UserModel.email.contains('domain_a.com') | UserModel.email.contains('domain_b.com')):
+        print(user)
+
+or using AND:
+
+::
+
+    for user in UserModel.query('Smith', filter_condition=UserModel.email.startswith('smith') & UserModel.email.contains('domain.com')):
         print(user)
 
 


### PR DESCRIPTION
The current examples don't work with DynamoDB because they are using `email` in the range key condition.
It also doesn't seem like we can combine query terms for range conditions so I changed the wording to specify this is about filter conditions.

No code changes made.