### PR TITLE
In setup.cfg, avoid deprecated license_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal = False
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE


### PR DESCRIPTION
Use `license_files` instead.

https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

Fixes warnings like:

```
!!

        ********************************************************************************
        The license_file parameter is deprecated, use license_files instead.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!
```