### PR TITLE
Remove empty attribute_values from DynamicMapAttribute (#999 )

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -424,7 +424,6 @@ class AttributeContainer(metaclass=AttributeContainerMeta):
         """
         Sets attributes sent back from DynamoDB on this object
         """
-        self.attribute_values = {}
         self._set_discriminator()
         self._set_defaults(_user_instantiated=False)
         for name, attr in self.get_attributes().items():


### PR DESCRIPTION
Not sure why it is set there at all
Was added 4 yrs ago

Tests seem fine as well as all my local usuage of pynamodb