### PR TITLE
fix indentation of sidebar on documentation 

### DIFF
--- a/docs/updates.rst
+++ b/docs/updates.rst
@@ -56,7 +56,7 @@ The following expressions and functions can only be used in the context of the a
     "if_not_exists( `attr`, `value` )", `attr` | `value`, Any, :code:`Thread.forum_name | 'Default Forum Name'`
 
 ``set`` action
-""""""""""""""
+^^^^^^^^^^^^^^
 
 The ``set`` action is the simplest action as it overwrites any previously stored value:
 


### PR DESCRIPTION
This pull request will change unintended indentation on Read The Docs documentation

**As-Is : "set action" has the different indentation from others** 
![image](https://github.com/user-attachments/assets/7d85621b-dcbe-4b0c-aae1-b3f38cc6ac71)

**To-Be :**
![image](https://github.com/user-attachments/assets/ca01c342-4bb2-4c33-83a6-c30a4fabc9da)

