### PR TITLE
Fix DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. 

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -825,7 +825,7 @@ class TTLAttribute(Attribute[datetime]):
             value = calendar.timegm(value.utctimetuple())
         else:
             raise ValueError("TTLAttribute value must be a timedelta or datetime")
-        return datetime.utcfromtimestamp(value).replace(tzinfo=timezone.utc)
+        return datetime.fromtimestamp(value, tz=timezone.utc)
 
     def __set__(self, instance, value):
         """
@@ -846,7 +846,7 @@ class TTLAttribute(Attribute[datetime]):
         Deserializes a timestamp (Unix time) as a UTC datetime.
         """
         timestamp = json.loads(value)
-        return datetime.utcfromtimestamp(timestamp).replace(tzinfo=timezone.utc)
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
 
 
 class UTCDateTimeAttribute(Attribute[datetime]):


### PR DESCRIPTION
This pull request includes changes to the `pynamodb/attributes.py` file to standardize the method used for converting timestamps to datetime objects. The most important changes are:

* [`pynamodb/attributes.py`](diffhunk://#diff-036d5fdbbcdad0183d26970d7632121a91726f121c4a1cfc05232826a36d32e5L828-R828): Modified the `_normalize` method to use `datetime.fromtimestamp` with `tz=timezone.utc` instead of `datetime.utcfromtimestamp` to ensure timezone consistency.
* [`pynamodb/attributes.py`](diffhunk://#diff-036d5fdbbcdad0183d26970d7632121a91726f121c4a1cfc05232826a36d32e5L849-R849): Updated the `deserialize` method to use `datetime.fromtimestamp` with `tz=timezone.utc` instead of `datetime.utcfromtimestamp` for deserializing timestamps.