### PR TITLE
feat: add wait argument to `Model.delete_table`

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,6 +3,13 @@
 Release Notes
 =============
 
+v6.1.0
+------
+
+Features:
+
+* Add a `wait` argument to `Model.delete_table` (:pr:`1270`)
+
 v6.0.2
 ------
 

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -760,11 +760,18 @@ class Model(AttributeContainer, metaclass=MetaModel):
             return False
 
     @classmethod
-    def delete_table(cls) -> Any:
+    def delete_table(cls, *, wait: bool = False) -> Any:
         """
         Delete the table for this model
+
+        :param wait: If set, then this call will block until the table is deleted
         """
-        return cls._get_connection().delete_table()
+        result = cls._get_connection().delete_table()
+
+        while wait and cls.exists():
+            time.sleep(2)
+
+        return result
 
     @classmethod
     def describe_table(cls) -> Any:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3438,3 +3438,21 @@ def test_delete(add_version_condition: bool) -> None:
         }
         args = req.call_args[0][1]
         assert args == expected
+
+def test_delete_with_wait(mocker):
+    """Test that the wait argument works as expected on the delete."""
+    mock_exists = mocker.patch.object(target=Model, attribute="exists", autospec=True)
+    mock__get_connection = mocker.patch.object(
+        target=Model, attribute="_get_connection", autospec=True
+    )
+
+    # Make the first two exists calls show the table as still existing, then have the
+    # last call show it has been deleted.
+    mock_exists.side_effect = (True, True, False)
+
+    result = Model.delete_table(wait=True)
+
+    # Should have returned the delete value.
+    assert result == mock__get_connection.return_value.delete_table.return_value
+    # Should have called exists 3 times.
+    assert mock_exists.call_count == 3


### PR DESCRIPTION
This adds a `wait` argument that will make the `delete_table` call block until the DynamoDB table is fully deleted if set to `True`. It defaults to `False` to not break the existing behavior.