### PR TITLE
Fix get method in models.py to not throw an exception when returning an empty item.

### DIFF
--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -549,9 +549,8 @@ class Model(AttributeContainer, metaclass=MetaModel):
             attributes_to_get=attributes_to_get,
         )
         if data:
-            item_data = data.get(ITEM)
-            if item_data:
-                return cls.from_raw_data(item_data)
+            if ITEM in data:
+                return cls.from_raw_data(data.get(ITEM))
         raise cls.DoesNotExist()
 
     @classmethod

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -548,9 +548,8 @@ class Model(AttributeContainer, metaclass=MetaModel):
             consistent_read=consistent_read,
             attributes_to_get=attributes_to_get,
         )
-        if data:
-            if ITEM in data:
-                return cls.from_raw_data(data.get(ITEM))
+        if data and ITEM in data:
+            return cls.from_raw_data(data.get(ITEM))
         raise cls.DoesNotExist()
 
     @classmethod

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1766,7 +1766,7 @@ class ModelTestCase(TestCase):
                 # This simulates DynamoDB returning an empty Item when the requested
                 # attributes don't exist or are empty, but the item itself exists
                 return {
-                    'Item': {}  # Empty item dictionary
+                    'Item': {}
                 }
             return MODEL_TABLE_DATA
 
@@ -1774,45 +1774,15 @@ class ModelTestCase(TestCase):
         fake_db.side_effect = fake_dynamodb
 
         with patch(PATCH_METHOD, new=fake_db) as req:
-            # This should not raise DoesNotExist even though the Item is empty
-            # because the item exists in DynamoDB, just the requested attributes are empty
-            try:
-                item = UserModel.get(
-                    'foo',
-                    'bar',
-                    attributes_to_get=['nonexistent_attribute']
-                )
-                # The item should be returned with empty attributes
-                self.assertIsNotNone(item)
-                # Verify that the get method was called with the right parameters
-                self.assertTrue(req.called)
-                call_args = req.call_args[0][1]
-                self.assertIn('Key', call_args)
-                self.assertIn('ProjectionExpression', call_args)
-            except DoesNotExist:
-                self.fail("get method should not raise DoesNotExist when DynamoDB returns empty Item but item exists")
-    
-    def test_get_with_no_item_still_raises_does_not_exist(self):
-        """
-        Test that get method still raises DoesNotExist when no item is returned from DynamoDB
-        """
-        
-        def fake_dynamodb(*args):
-            kwargs = args[1]
-            if kwargs == {'TableName': UserModel.Meta.table_name}:
-                return MODEL_TABLE_DATA
-            elif 'Key' in kwargs:
-                # This simulates DynamoDB returning no item at all
-                return {}  # No Item key in response
-            return MODEL_TABLE_DATA
-
-        fake_db = MagicMock()
-        fake_db.side_effect = fake_dynamodb
-
-        with patch(PATCH_METHOD, new=fake_db):
-            # This should still raise DoesNotExist when no item is found
-            with self.assertRaises(DoesNotExist):
-                UserModel.get('foo', 'bar')
+            item = UserModel.get(
+                'foo',
+                'bar',
+                attributes_to_get=['nonexistent_attribute']
+            )
+            # The item should be returned with empty attributes
+            self.assertIsNotNone(item)
+            self.assertTrue(isinstance(item, UserModel))
+            self.assertIsNone(item.get_attributes().get('nonexistent_attribute'))
 
     def test_batch_get(self):
         """

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1752,6 +1752,68 @@ class ModelTestCase(TestCase):
             self.assertEqual(item.overidden_user_name, CUSTOM_ATTR_NAME_ITEM_DATA['Item']['user_name']['S'])
             self.assertEqual(item.overidden_user_id, CUSTOM_ATTR_NAME_ITEM_DATA['Item']['user_id']['S'])
 
+    def test_get_with_empty_item_from_attributes_to_get(self):
+        """
+        Test that get method doesn't raise DoesNotExist when attributes_to_get 
+        returns an empty Item dictionary but the item exists in DynamoDB.
+        """
+        
+        def fake_dynamodb(*args):
+            kwargs = args[1]
+            if kwargs == {'TableName': UserModel.Meta.table_name}:
+                return MODEL_TABLE_DATA
+            elif 'Key' in kwargs and 'ProjectionExpression' in kwargs:
+                # This simulates DynamoDB returning an empty Item when the requested
+                # attributes don't exist or are empty, but the item itself exists
+                return {
+                    'Item': {}  # Empty item dictionary
+                }
+            return MODEL_TABLE_DATA
+
+        fake_db = MagicMock()
+        fake_db.side_effect = fake_dynamodb
+
+        with patch(PATCH_METHOD, new=fake_db) as req:
+            # This should not raise DoesNotExist even though the Item is empty
+            # because the item exists in DynamoDB, just the requested attributes are empty
+            try:
+                item = UserModel.get(
+                    'foo',
+                    'bar',
+                    attributes_to_get=['nonexistent_attribute']
+                )
+                # The item should be returned with empty attributes
+                self.assertIsNotNone(item)
+                # Verify that the get method was called with the right parameters
+                self.assertTrue(req.called)
+                call_args = req.call_args[0][1]
+                self.assertIn('Key', call_args)
+                self.assertIn('ProjectionExpression', call_args)
+            except DoesNotExist:
+                self.fail("get method should not raise DoesNotExist when DynamoDB returns empty Item but item exists")
+    
+    def test_get_with_no_item_still_raises_does_not_exist(self):
+        """
+        Test that get method still raises DoesNotExist when no item is returned from DynamoDB
+        """
+        
+        def fake_dynamodb(*args):
+            kwargs = args[1]
+            if kwargs == {'TableName': UserModel.Meta.table_name}:
+                return MODEL_TABLE_DATA
+            elif 'Key' in kwargs:
+                # This simulates DynamoDB returning no item at all
+                return {}  # No Item key in response
+            return MODEL_TABLE_DATA
+
+        fake_db = MagicMock()
+        fake_db.side_effect = fake_dynamodb
+
+        with patch(PATCH_METHOD, new=fake_db):
+            # This should still raise DoesNotExist when no item is found
+            with self.assertRaises(DoesNotExist):
+                UserModel.get('foo', 'bar')
+
     def test_batch_get(self):
         """
         Model.batch_get


### PR DESCRIPTION
Fix for issue https://github.com/pynamodb/PynamoDB/issues/1287#issuecomment-3281642349 When getting a model value with `attributes_to_get` parameter, set in a way where it could return an empty object, the get method is erronously throwing an exception even though the object exists. This fixes the issue.