### PR TITLE
feat: attr_type argument to Attribute.is_type

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -233,9 +233,8 @@ class Attribute(Generic[_T]):
     def does_not_exist(self) -> 'NotExists':
         return Path(self).does_not_exist()
 
-    def is_type(self):
-        # What makes sense here? Are we using this to check if deserialization will be successful?
-        return Path(self).is_type(self.attr_type)
+    def is_type(self, attr_type: str = None):
+        return Path(self).is_type(attr_type or self.attr_type)
 
     def startswith(self, prefix: str) -> 'BeginsWith':
         return Path(self).startswith(prefix)

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -228,6 +228,13 @@ class ConditionExpressionTestCase(TestCase):
         assert self.placeholder_names == {'foo': '#0'}
         assert self.expression_attribute_values == {':0': {'S': 'S'}}
 
+    def test_is_type_with_null(self):
+        condition = self.attribute.is_type('NULL')
+        expression = condition.serialize(self.placeholder_names, self.expression_attribute_values)
+        assert expression == "attribute_type (#0, :0)"
+        assert self.placeholder_names == {'foo': '#0'}
+        assert self.expression_attribute_values == {':0': {'S': 'NULL'}}
+
     def test_begins_with(self):
         condition = self.attribute.startswith('bar')
         expression = condition.serialize(self.placeholder_names, self.expression_attribute_values)


### PR DESCRIPTION
This PR adds `attr_type` to make it possible to check the type of an `Attribute` in DynamoDB within a [Conditional Expression](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html#:~:text=Checking%20for%20attribute%20type).

It defaults to `None` to not break the existing behavior.