### PR TITLE
fix: allow Enum values as attribute defaults

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,6 +3,13 @@
 Release Notes
 =============
 
+v6.1.1
+------
+
+Fixes:
+
+* Allow :py:class:`~enum.Enum` instances as attribute defaults (:pr:`1302`)
+
 v6.1.0
 ------
 

--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -7,6 +7,7 @@ import collections.abc
 import json
 import time
 import warnings
+from enum import Enum
 from base64 import b64encode, b64decode
 from copy import deepcopy
 from datetime import datetime
@@ -57,7 +58,7 @@ _ACT = TypeVar('_ACT', bound = 'AttributeContainer')
 
 _A = TypeVar('_A', bound='Attribute')
 
-_IMMUTABLE_TYPES = (str, int, float, datetime, timedelta, bytes, bool, tuple, frozenset, type(None))
+_IMMUTABLE_TYPES = (str, int, float, datetime, timedelta, bytes, bool, tuple, frozenset, type(None), Enum)
 _IMMUTABLE_TYPE_NAMES = ', '.join(map(lambda x: x.__name__, _IMMUTABLE_TYPES))
 
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -153,6 +153,16 @@ class TestDefault:
         with pytest.raises(ValueError, match="An attribute cannot have both default and default_for_new parameters"):
             Attribute(default=False, default_for_new='test')
 
+    def test_default_enum(self):
+        from enum import Enum, unique
+
+        @unique
+        class Color(Enum):
+            RED = 'red'
+            BLUE = 'blue'
+
+        Attribute(default=Color.RED)
+        Attribute(default_for_new=Color.BLUE)
 
 
 class TestUTCDateTimeAttribute:


### PR DESCRIPTION
Problem
In PynamoDB 6.0, using an Enum value as an attribute default raises a ValueError:

```python
class ApplicationType(Enum):
AWS = 'aws'
AZURE = 'azure'

Raises: ValueError: An attribute's 'default' must be immutable (str, int, ...) or a callable
type = StringEnumAttribute(default=ApplicationType.AWS)
```

The only workaround was to wrap it in a lambda:

```python
type = StringEnumAttribute(default=lambda: ApplicationType.AWS)
```

Fix
Enum instances are immutable by design — this is a Python guarantee. Added Enum to _IMMUTABLE_TYPES so all Enum subclass instances are accepted as defaults.

Changes
pynamodb/attributes.py: import Enum and add it to _IMMUTABLE_TYPES
tests/test_attributes.py: add test_default_enum to cover this case
Closes #1301